### PR TITLE
feat: add Droploud, GateRush, and DownloadGater support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,16 @@
 HYPEDDIT_NAME=
 HYPEDDIT_EMAIL=
-SC_COMMENT=
+# Name/email are optional — only needed when a Hypeddit, GateRush, or Droploud gate asks for them.
+# Droploud requires at least 2 characters when a SoundCloud comment step is present.
+SC_COMMENT=Fire track!
 SC_CLIENT_ID=
 SC_OAUTH_TOKEN=
+MANAGED_SC_CLIENT_ID=
+MANAGED_SC_OAUTH_TOKEN=
+# Optional residential proxy when SoundCloud DataDome hard-blocks engagement PUTs
+# (repost/like/comment). DELETE cleanup is not DataDome-protected and works without this.
+# SC_API_PROXY=http://user:pass@host:port
+# CLOAKBROWSER_PROXY=http://user:pass@host:port
+# PROXY_URL=http://user:pass@host:port
+# WebUI browser jobs default to headed CloakBrowser (needed for OAuth). Set true to force headless.
+# BROWSER_HEADLESS=true

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ HYPEDDIT_EMAIL=
 SC_COMMENT=Fire track!
 SC_CLIENT_ID=
 SC_OAUTH_TOKEN=
+# Optional — only used by `bun manage-acc` to export a *separate* SoundCloud account
+# (follows/likes/reposts/playlists → ./exports). Not used by the downloader; leave blank otherwise.
 MANAGED_SC_CLIENT_ID=
 MANAGED_SC_OAUTH_TOKEN=
 # Optional residential proxy when SoundCloud DataDome hard-blocks engagement PUTs

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # browser data (cookies, login sessions)
 browser-data
+browser-data-captcha
 downloads
 # soundcloud cookies
 soundcloud-cookies.json
@@ -42,3 +43,5 @@ soundcloud-cookies.json
 spotify-cookies.json
 # config file
 config.json
+# exports
+exports

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Hypeddit SoundCloud Downloader
+# sc-gate-dl
 
-A simple tool that automates downloading audio from Hypeddit posts and enriches them with metadata from SoundCloud.
+Download and tag SoundCloud tracks unlocked via Hypeddit, Droploud, or GateRush gates.
 
 ## Features
 
-- 🎵 Automatically download audio from Hypeddit posts
+- 🎵 Automatically download audio from Hypeddit, Droploud, and GateRush gates
 - ⚡ Browserless fast path that skips the browser for gates that don't need real verification (see [How It Works](#how-it-works))
 - 🔄 Handles multiple gate types (see [How It Works](#how-it-works))
 - 📝 Fetches metadata from the provided SoundCloud link
@@ -17,7 +17,7 @@ A simple tool that automates downloading audio from Hypeddit posts and enriches 
 
 - [**Bun**](https://bun.sh) - JavaScript runtime and package manager
 - [**ffmpeg**](https://ffmpeg.org) - Must be installed and available in your `PATH`
-- **SoundCloud account** - It is recommended to create a throwaway account for this. Even though there were no reports of accounts getting banned I can't guarantee it. Also most Hypeddit downloads require reposts/likes/follows which you might not want to do with your main account
+- **SoundCloud account** - It is recommended to create a throwaway account for this. Even though there were no reports of accounts getting banned I can't guarantee it. Also most gate downloads require reposts/likes/follows which you might not want to do with your main account
 - **Spotify account** (optional) - Required when a Hypeddit post has an unskippable Spotify gate. I also recommend creating a throwaway account as most Hypeddit downloads require saving playlists/songs to your library or following artists which you might not want on your main account.
 
 ## Installation
@@ -61,6 +61,8 @@ For `HYPEDDIT_EMAIL` you can enter any valid email address (For example grab one
 5. Go to the **Payload** tab
 6. You should see your client id in the **Query String Parameters** section, and your oauth token (`access_token`) in the **Request Payload** section
 7. Copy these values to your `.env` file as `SC_CLIENT_ID` and `SC_OAUTH_TOKEN`
+
+If you want to export data from a separate SoundCloud account, add that account's credentials as `MANAGED_SC_CLIENT_ID` and `MANAGED_SC_OAUTH_TOKEN`.
 
 ### Cookies
 
@@ -114,6 +116,16 @@ bun start https://soundcloud.com/artist/track
 
 The final MP3 file will be saved in the `./downloads` directory with proper metadata and artwork embedded.
 
+### Managed account export
+
+To export the followed users, liked tracks, reposted tracks, and playlists from the separate managed SoundCloud account in your `.env`, run:
+
+```bash
+bun manage-acc
+```
+
+The export will be written to a timestamped directory inside `./exports` and includes `playlists.json` with playlist track data. `reposted-playlists.json` is also included as an extra export.
+
 ### Web UI
 
 There is now also an experimental (vibe-coded) web UI for the tool. You can start it by running
@@ -140,6 +152,8 @@ If it's the first time you're running it you will need to initialize the logins 
 - YouTube gate: Handles YouTube subscribe requirements (This gets bypassed as it does not actually require subscribing)
 - Spotify gate: Authorizes Spotify access
 - Download gate: Triggers the audio download
+
+Droploud and GateRush gates are handled via their own downloaders with similar email / social unlock flows.
 
 **File Processing**:
 

--- a/bun.lock
+++ b/bun.lock
@@ -3,10 +3,11 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "hypeddit-soundcloud-downloader",
+      "name": "sc-gate-dl",
       "dependencies": {
         "@inquirer/prompts": "^8.5.2",
         "cli-progress": "^3.12.0",
+        "cloakbrowser": "^0.5.2",
         "execa": "^9.6.1",
         "find-bin": "^1.1.0",
         "puppeteer": "^25.3.0",
@@ -76,6 +77,8 @@
 
     "@inquirer/type": ["@inquirer/type@4.0.7", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g=="],
 
+    "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
+
     "@puppeteer/browsers": ["@puppeteer/browsers@3.0.6", "", { "dependencies": { "modern-tar": "^0.7.6", "yargs": "^18.0.0" }, "peerDependencies": { "proxy-agent": ">=8.0.1", "yauzl": "^2.10.0 || ^3.4.0" }, "optionalPeers": ["proxy-agent", "yauzl"], "bin": { "browsers": "lib/main-cli.js" } }, "sha512-B/gKoqlFkzhvzsI6jo9K1cZz9o5ypviVv/xu8CwA4grZzyVwN+XfkT+tu8T1zrauuEXv6VhS2oGX+6NL95WcKA=="],
 
     "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
@@ -98,6 +101,8 @@
 
     "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
 
+    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
+
     "chromium-bidi": ["chromium-bidi@16.0.1", "", { "dependencies": { "mitt": "^3.0.1", "zod": "^3.24.1" }, "peerDependencies": { "devtools-protocol": "*" } }, "sha512-J63PGu/9PpeCwLIcKYyzWP6yaVL5pxuBc0shlYCYM8BaAkmlwiQboXO1iNbOgSDbVklEyYFfNEcHD8oOAWacUA=="],
 
     "cli-progress": ["cli-progress@3.12.0", "", { "dependencies": { "string-width": "^4.2.3" } }, "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A=="],
@@ -105,6 +110,8 @@
     "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
 
     "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
+
+    "cloakbrowser": ["cloakbrowser@0.5.2", "", { "dependencies": { "tar": "^7.0.0" }, "peerDependencies": { "mmdb-lib": ">=2.0.0", "playwright-core": ">=1.53.0", "puppeteer-core": ">=21.0.0", "socks-proxy-agent": ">=10.0.0" }, "optionalPeers": ["mmdb-lib", "playwright-core", "puppeteer-core", "socks-proxy-agent"], "bin": { "cloakbrowser": "dist/cli.js" } }, "sha512-vXMWM1HzI87CGUrOobMpTu/GqPn2eZbNcImhMMjF/48/M12iZEWVolrquY3ot0YI++ddYjoVb71hkodpRsRlIg=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -148,6 +155,10 @@
 
     "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
 
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
+
     "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
 
     "modern-tar": ["modern-tar@0.7.6", "", {}, "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg=="],
@@ -182,6 +193,8 @@
 
     "strip-final-newline": ["strip-final-newline@4.0.0", "", {}, "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="],
 
+    "tar": ["tar@7.5.22", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA=="],
+
     "typed-query-selector": ["typed-query-selector@2.12.2", "", {}, "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
@@ -199,6 +212,8 @@
     "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
 

--- a/manage-acc.ts
+++ b/manage-acc.ts
@@ -1,0 +1,90 @@
+import { mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { SoundcloudClient } from './src/soundcloud.ts';
+
+const clientId = process.env.MANAGED_SC_CLIENT_ID;
+const oauthToken = process.env.MANAGED_SC_OAUTH_TOKEN;
+
+if (!clientId || !oauthToken) {
+	throw new Error(
+		'MANAGED_SC_CLIENT_ID and MANAGED_SC_OAUTH_TOKEN are required. Please set them in your .env file.',
+	);
+}
+
+const client = new SoundcloudClient({
+	credentials: {
+		clientId,
+		oauthToken,
+	},
+});
+
+const exportData = await client.exportManagedAccountData();
+const me = exportData.me;
+console.log(
+	`Using managed SoundCloud account: ${getString(me.username) ?? getString(me.id) ?? 'unknown'}`,
+);
+const accountSlug = sanitizePathSegment(
+	getString(me.permalink) ??
+		getString(me.username) ??
+		getString(me.id) ??
+		'managed-account',
+);
+const timestamp = new Date().toISOString().replaceAll(':', '-');
+const exportDir = join('exports', `${accountSlug}-${timestamp}`);
+
+await mkdir(exportDir, { recursive: true });
+
+await Promise.all([
+	writeJson(join(exportDir, 'account.json'), exportData.me),
+	writeJson(join(exportDir, 'followed-users.json'), exportData.followedUsers),
+	writeJson(join(exportDir, 'liked-tracks.json'), exportData.likedTracks),
+	writeJson(join(exportDir, 'reposted-tracks.json'), exportData.repostedTracks),
+	writeJson(join(exportDir, 'playlists.json'), exportData.ownedPlaylists),
+	writeJson(
+		join(exportDir, 'reposted-playlists.json'),
+		exportData.repostedPlaylists,
+	),
+	writeJson(join(exportDir, 'summary.json'), {
+		exportedAt: new Date().toISOString(),
+		credentialsSource: 'MANAGED_SC_CLIENT_ID / MANAGED_SC_OAUTH_TOKEN',
+		account: {
+			id: getString(me.id),
+			username: getString(me.username),
+			permalink: getString(me.permalink),
+			permalinkUrl: getString(me.permalink_url),
+		},
+		counts: {
+			followedUsers: exportData.followedUsers.length,
+			likedTracks: exportData.likedTracks.length,
+			repostedTracks: exportData.repostedTracks.length,
+			playlists: exportData.ownedPlaylists.length,
+			repostedPlaylists: exportData.repostedPlaylists.length,
+		},
+	}),
+]);
+
+console.log(`Managed account export written to ${exportDir}`);
+console.log(`- followed users: ${exportData.followedUsers.length}`);
+console.log(`- liked tracks: ${exportData.likedTracks.length}`);
+console.log(`- reposted tracks: ${exportData.repostedTracks.length}`);
+console.log(`- playlists: ${exportData.ownedPlaylists.length}`);
+console.log(`- reposted playlists: ${exportData.repostedPlaylists.length}`);
+
+async function writeJson(path: string, data: unknown) {
+	await Bun.write(path, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+function getString(value: unknown): string | undefined {
+	if (typeof value === 'string' || typeof value === 'number') {
+		return String(value);
+	}
+	return undefined;
+}
+
+function sanitizePathSegment(value: string): string {
+	return value
+		.trim()
+		.replace(/[^a-zA-Z0-9._-]+/g, '-')
+		.replace(/-+/g, '-')
+		.replace(/^-|-$/g, '');
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "hypeddit-soundcloud-downloader",
+	"name": "sc-gate-dl",
 	"module": "src/index.ts",
 	"type": "module",
 	"private": true,
@@ -33,6 +33,7 @@
 	"dependencies": {
 		"@inquirer/prompts": "^8.5.2",
 		"cli-progress": "^3.12.0",
+		"cloakbrowser": "^0.5.2",
 		"execa": "^9.6.1",
 		"find-bin": "^1.1.0",
 		"puppeteer": "^25.3.0",

--- a/patches/soundcloud.ts@0.7.4.patch
+++ b/patches/soundcloud.ts@0.7.4.patch
@@ -2,10 +2,13 @@ diff --git a/dist/API.d.ts b/dist/API.d.ts
 index 3fad2ed9f4412d5421b212abdc756a64eff7ce13..c5528171d38dd84a949e14f0d903eece2bba2c2e 100644
 --- a/dist/API.d.ts
 +++ b/dist/API.d.ts
-@@ -15,6 +15,9 @@ export declare class API {
+@@ -15,6 +15,12 @@ export declare class API {
      getV2: (endpoint: string, params?: {
          [key: string]: any;
      }) => Promise<any>;
++    putV2: (endpoint: string, params?: {
++        [key: string]: any;
++    }) => Promise<any>;
 +    deleteV2: (endpoint: string, params?: {
 +        [key: string]: any;
 +    }) => Promise<any>;
@@ -16,10 +19,11 @@ diff --git a/dist/API.js b/dist/API.js
 index d92a54c425a37ce5269a129570b6d515dede7240..2625c9486eeb9f028bf0aea415898e7d4c4295bd 100644
 --- a/dist/API.js
 +++ b/dist/API.js
-@@ -59,6 +59,7 @@ var API = /** @class */ (function () {
+@@ -59,6 +59,8 @@ var API = /** @class */ (function () {
          this.getWebsite = function (endpoint, params) { return _this.getRequest(webURL, endpoint, params); };
          this.getURL = function (URI, params) { return _this.fetchRequest(URI, "GET", params); };
          this.post = function (endpoint, params) { return _this.fetchRequest("".concat(apiURL, "/").concat(endpoint), "POST", params); };
++        this.putV2 = function (endpoint, params) { return _this.fetchRequest("".concat(apiV2URL, "/").concat(endpoint), "PUT", params); };
 +        this.deleteV2 = function (endpoint, params) { return _this.fetchRequest("".concat(apiV2URL, "/").concat(endpoint), "DELETE", params); };
          this.options = function (method, params) {
              var options = {

--- a/src/browserLaunch.ts
+++ b/src/browserLaunch.ts
@@ -1,0 +1,62 @@
+import { launch, launchPersistentContext } from 'cloakbrowser/puppeteer';
+import type { Browser } from 'puppeteer';
+
+export type AppBrowserLaunchOptions = {
+	headless?: boolean;
+	userDataDir?: string;
+	args?: string[];
+	/** Passed through to Puppeteer via cloakbrowser `launchOptions`. */
+	defaultViewport?: { width: number; height: number } | null;
+	humanize?: boolean;
+};
+
+const DEFAULT_ARGS = [
+	'--no-sandbox',
+	'--disable-setuid-sandbox',
+	'--mute-audio',
+	'--hide-crash-restore-bubble',
+	'--no-first-run',
+	'--no-default-browser-check',
+	'--disable-restore-session-state',
+	'--window-size=1920,1080',
+];
+
+/**
+ * Launch CloakBrowser (stealth Chromium) for all automation.
+ * Optional `CLOAKBROWSER_PROXY` / `PROXY_URL` for residential egress when an IP is hard-blocked.
+ * Set `CLOAKBROWSER_GEOIP=true` (requires `bun add mmdb-lib`) to match timezone to the proxy.
+ */
+export async function launchAppBrowser(
+	options: AppBrowserLaunchOptions = {},
+): Promise<Browser> {
+	process.env.CLOAKBROWSER_SUPPRESS_FONT_WARNING ??= '1';
+
+	const proxy =
+		process.env.CLOAKBROWSER_PROXY?.trim() ||
+		process.env.PROXY_URL?.trim() ||
+		undefined;
+
+	const geoip = Boolean(proxy) && process.env.CLOAKBROWSER_GEOIP === 'true';
+
+	const launchOpts = {
+		headless: options.headless ?? true,
+		humanize: options.humanize ?? true,
+		stealthArgs: true,
+		...(proxy ? { proxy, ...(geoip ? { geoip: true } : {}) } : {}),
+		args: options.args ?? DEFAULT_ARGS,
+		launchOptions: {
+			...(options.defaultViewport !== undefined
+				? { defaultViewport: options.defaultViewport }
+				: {}),
+		},
+	};
+
+	const browser = options.userDataDir
+		? await launchPersistentContext({
+				...launchOpts,
+				userDataDir: options.userDataDir,
+			})
+		: await launch(launchOpts);
+
+	return browser as Browser;
+}

--- a/src/downloadgater.ts
+++ b/src/downloadgater.ts
@@ -1,0 +1,700 @@
+import { Presets, SingleBar } from 'cli-progress';
+import type { Browser, Page } from 'puppeteer';
+import { launchAppBrowser } from './browserLaunch';
+import type { ProgressCallback } from './hypeddit';
+import Selectors from './selectors';
+import type { HypedditConfig } from './types';
+import { loadCookies, timeout } from './utils';
+
+export class DownloadgaterDownloader {
+	private browser!: Browser;
+	private downloadFilename: string | null = null;
+	private config: HypedditConfig;
+	private progressCallback: ProgressCallback | null = null;
+
+	constructor(config: HypedditConfig) {
+		this.config = config;
+	}
+
+	setProgressCallback(callback: ProgressCallback): void {
+		this.progressCallback = callback;
+	}
+
+	private emitProgress(
+		stage: Parameters<ProgressCallback>[0],
+		message: string,
+		percent: number,
+		extra?: Parameters<ProgressCallback>[3],
+	): void {
+		this.progressCallback?.(stage, message, percent, extra);
+	}
+
+	async initialize() {
+		this.browser = await launchAppBrowser({
+			headless: this.config.headless,
+			userDataDir: './browser-data',
+		});
+
+		const browserContext = this.browser.defaultBrowserContext();
+		const soundCloudCookies = await loadCookies('soundcloud-cookies.json');
+		await browserContext.setCookie(...soundCloudCookies);
+	}
+
+	async prepareLogins() {
+		const soundCloudPage = await this.browser.newPage();
+		soundCloudPage.setViewport({ width: 1920, height: 1080 });
+		await soundCloudPage.goto('https://soundcloud.com/messages');
+
+		try {
+			await soundCloudPage.waitForSelector(
+				Selectors.SOUNDCLOUD_CAPTCHA_CONTAINER,
+				{ timeout: 5_000 },
+			);
+			console.log(
+				'DownloadGater: SoundCloud captcha present during login warm-up; solve it in the browser window if needed.',
+			);
+			await soundCloudPage.waitForSelector(
+				Selectors.SOUNDCLOUD_CAPTCHA_CONTAINER,
+				{ hidden: true, timeout: 120_000 },
+			);
+		} catch {
+			// no captcha
+		}
+
+		await soundCloudPage.waitForSelector(Selectors.SOUNDCLOUD_LIBRARY_LINK, {
+			timeout: 30_000,
+		});
+		await Promise.all([
+			soundCloudPage.click(Selectors.SOUNDCLOUD_LIBRARY_LINK),
+			soundCloudPage.waitForNavigation({ waitUntil: 'domcontentloaded' }),
+		]);
+		await soundCloudPage.waitForFunction(() =>
+			window.location.href.includes('/you/library'),
+		);
+		await soundCloudPage.close();
+	}
+
+	async downloadAudio(url: string): Promise<string | null> {
+		console.log('Navigating to DownloadGater gate...');
+		this.emitProgress(
+			'handling_gates',
+			'Navigating to DownloadGater gate...',
+			25,
+		);
+
+		const page = await this.browser.newPage();
+		await page.setViewport({ width: 1920, height: 1080 });
+		await page.goto(url, { waitUntil: 'domcontentloaded' });
+		try {
+			await page.waitForNetworkIdle({ timeout: 15_000, idleTime: 10 });
+		} catch {
+			// continue
+		}
+
+		await this.clickFreeDownload(page);
+
+		let soundcloudAttempted = false;
+		const deadline = Date.now() + 180_000;
+		while (Date.now() < deadline) {
+			if (await this.hasDownloadButton(page)) break;
+
+			// Post-OAuth UI can show "Verified unlock" / Finish before Download file.
+			await this.clickUnlockFinishIfPresent(page);
+			if (await this.hasDownloadButton(page)) break;
+
+			const pane = await this.detectPane(page);
+			console.log('DownloadGater pane:', pane);
+
+			if (pane === 'instagram') {
+				this.emitProgress(
+					'handling_gates',
+					'Handling DownloadGater Instagram follows...',
+					40,
+					{ currentGate: 'ig' },
+				);
+				await this.handleInstagramStep(page);
+				continue;
+			}
+
+			if (pane === 'soundcloud') {
+				if (soundcloudAttempted) {
+					const urlError = await this.readSoundcloudUrlError(page);
+					if (urlError) {
+						throw new Error(
+							`DownloadGater SoundCloud unlock failed: ${urlError}`,
+						);
+					}
+					// Still hydrating unlock → Download file; do not re-click Connect.
+					await timeout(500);
+					continue;
+				}
+				soundcloudAttempted = true;
+				this.emitProgress(
+					'handling_gates',
+					'Connecting SoundCloud on DownloadGater...',
+					55,
+					{ currentGate: 'sc' },
+				);
+				await this.handleSoundcloudConnect(page);
+				continue;
+			}
+
+			if (pane === 'spotify') {
+				throw new Error(
+					'This DownloadGater gate requires Spotify OAuth, which is not supported yet.',
+				);
+			}
+
+			await timeout(500);
+		}
+
+		if (!(await this.hasDownloadButton(page))) {
+			throw new Error(
+				'DownloadGater download button never appeared after completing gates.',
+			);
+		}
+
+		await this.handleDownload(page);
+		await page.close();
+		return this.downloadFilename;
+	}
+
+	async close() {
+		await this.browser?.close();
+	}
+
+	private async clickFreeDownload(page: Page) {
+		// GatePage is a lazy SPA chunk — wait for hydration before looking for CTA.
+		await page.waitForFunction(
+			() => {
+				const byClass = document.querySelector<HTMLButtonElement>(
+					'button.download-button',
+				);
+				if (byClass && !byClass.disabled) return true;
+				return Array.from(document.querySelectorAll('button')).some((btn) =>
+					/free\s*download/i.test((btn.textContent || '').trim()),
+				);
+			},
+			{ timeout: 30_000 },
+		);
+
+		const clicked = await page.evaluate(() => {
+			const byClass = document.querySelector<HTMLButtonElement>(
+				'button.download-button',
+			);
+			if (byClass && !byClass.disabled) {
+				byClass.click();
+				return 'class';
+			}
+			const free = Array.from(document.querySelectorAll('button')).find(
+				(btn) =>
+					/free\s*download/i.test((btn.textContent || '').trim()) &&
+					!(btn as HTMLButtonElement).disabled,
+			) as HTMLButtonElement | undefined;
+			if (free) {
+				free.click();
+				return 'text';
+			}
+			return null;
+		});
+		if (!clicked) {
+			throw new Error('DownloadGater FREE DOWNLOAD button not found.');
+		}
+		await timeout(800);
+	}
+
+	private async detectPane(
+		page: Page,
+	): Promise<'instagram' | 'soundcloud' | 'spotify' | 'download' | 'unknown'> {
+		return page.evaluate(() => {
+			const buttons = Array.from(document.querySelectorAll('button'));
+			const buttonText = (btn: Element) => (btn.textContent || '').trim();
+
+			if (
+				buttons.some((btn) =>
+					/^(download file|download zip)$/i.test(buttonText(btn)),
+				)
+			) {
+				return 'download';
+			}
+
+			// Unlocked / finishing UI still mentions SoundCloud — not a Connect step.
+			const body = document.body?.innerText || '';
+			if (
+				/verified unlock/i.test(body) ||
+				buttons.some((btn) => /^finish$/i.test(buttonText(btn)))
+			) {
+				return 'download';
+			}
+
+			const title =
+				document.querySelector('#gate-flow-title')?.textContent?.trim() || '';
+
+			if (
+				buttons.some((btn) =>
+					/connect.*soundcloud|connect & (follow|repost)/i.test(
+						buttonText(btn),
+					),
+				) ||
+				(/^complete soundcloud$/i.test(title) &&
+					!!document.querySelector('textarea'))
+			) {
+				return 'soundcloud';
+			}
+			if (
+				/instagram/i.test(title) ||
+				buttons.some((btn) => /follow on instagram/i.test(buttonText(btn)))
+			) {
+				return 'instagram';
+			}
+			if (/spotify/i.test(title)) return 'spotify';
+			return 'unknown';
+		});
+	}
+
+	private async hasDownloadButton(page: Page): Promise<boolean> {
+		return page.evaluate(() =>
+			Array.from(document.querySelectorAll('button')).some((btn) =>
+				/^(download file|download zip)$/i.test((btn.textContent || '').trim()),
+			),
+		);
+	}
+
+	private async clickUnlockFinishIfPresent(page: Page): Promise<boolean> {
+		return page.evaluate(() => {
+			const btn = Array.from(document.querySelectorAll('button')).find(
+				(el) =>
+					/^finish$/i.test((el.textContent || '').trim()) &&
+					!(el as HTMLButtonElement).disabled,
+			) as HTMLButtonElement | undefined;
+			btn?.click();
+			return !!btn;
+		});
+	}
+
+	private async readSoundcloudUrlError(page: Page): Promise<string | null> {
+		try {
+			return new URL(page.url()).searchParams.get('soundcloud_error');
+		} catch {
+			return null;
+		}
+	}
+
+	/**
+	 * Honor-system Instagram: open each target (popup), wait for the 5s unlock
+	 * timer, then confirm. Multiple IG targets are served one at a time.
+	 */
+	private async handleInstagramStep(page: Page) {
+		for (let attempt = 0; attempt < 8; attempt++) {
+			if ((await this.detectPane(page)) !== 'instagram') return;
+			if (await this.hasDownloadButton(page)) return;
+
+			const pagesBefore = new Set(await this.browser.pages(true));
+
+			const followClicked = await page.evaluate(() => {
+				const btn = Array.from(document.querySelectorAll('button')).find(
+					(el) =>
+						/follow on instagram/i.test(el.textContent || '') &&
+						!(el as HTMLButtonElement).disabled,
+				) as HTMLButtonElement | undefined;
+				btn?.click();
+				return !!btn;
+			});
+
+			if (followClicked) {
+				let popup: Page | undefined;
+				const started = Date.now();
+				while (!popup && Date.now() - started < 8_000) {
+					const pages = await this.browser.pages(true);
+					popup = pages.find(
+						(candidate) =>
+							candidate !== page &&
+							!pagesBefore.has(candidate) &&
+							candidate.url() !== 'about:blank',
+					);
+					if (!popup) {
+						popup = pages.find(
+							(candidate) =>
+								candidate !== page && /instagram\.com/i.test(candidate.url()),
+						);
+					}
+					if (!popup) await timeout(200);
+				}
+
+				// Site unlocks after ~5s with the popup open.
+				await timeout(5_500);
+
+				if (popup && !popup.isClosed()) {
+					try {
+						await popup.close();
+					} catch {
+						// ignore
+					}
+				}
+			}
+
+			const confirmed = await page.evaluate(() => {
+				const btn = Array.from(document.querySelectorAll('button')).find(
+					(el) =>
+						/^(i followed|i opened it)$/i.test((el.textContent || '').trim()) &&
+						!(el as HTMLButtonElement).disabled,
+				) as HTMLButtonElement | undefined;
+				btn?.click();
+				return !!btn;
+			});
+
+			if (confirmed) {
+				await timeout(800);
+			} else {
+				await timeout(500);
+			}
+
+			if ((await this.detectPane(page)) !== 'instagram') return;
+		}
+
+		throw new Error(
+			'DownloadGater Instagram step did not advance. Allow popups and retry.',
+		);
+	}
+
+	private async handleSoundcloudConnect(page: Page) {
+		const comment = this.config.comment.trim();
+		const needsComment = await page.evaluate(() =>
+			Boolean(document.querySelector('textarea')),
+		);
+		if (needsComment) {
+			if (comment.length < 1) {
+				throw new Error(
+					'This DownloadGater gate requires SC_COMMENT before connecting SoundCloud.',
+				);
+			}
+			await page.focus('textarea');
+			await page.evaluate((value) => {
+				const el = document.querySelector('textarea');
+				if (!el) return;
+				const setter = Object.getOwnPropertyDescriptor(
+					window.HTMLTextAreaElement.prototype,
+					'value',
+				)?.set;
+				setter?.call(el, value);
+				el.dispatchEvent(new Event('input', { bubbles: true }));
+				el.dispatchEvent(new Event('change', { bubbles: true }));
+			}, comment);
+			await timeout(300);
+		}
+
+		const pagesBefore = new Set(await this.browser.pages(true));
+
+		const clicked = await page.evaluate(() => {
+			const btn = Array.from(document.querySelectorAll('button')).find((el) =>
+				/connect.*soundcloud|connect & (follow|repost)/i.test(
+					el.textContent || '',
+				),
+			) as HTMLButtonElement | undefined;
+			if (!btn || btn.disabled) return false;
+			btn.click();
+			return true;
+		});
+		if (!clicked) {
+			throw new Error('DownloadGater SoundCloud connect button not found.');
+		}
+
+		// Same-tab OAuth (window.location.assign) — keep one loop like the working
+		// Nico Chromium flow: wait for authorize → click Allow → wait for unlock.
+		// Never treat "still on downloadgater Connecting…" as done, and never click
+		// email "Continue".
+		const deadline = Date.now() + 120_000;
+		while (Date.now() < deadline) {
+			const oauthPage = await this.findSoundcloudOauthPage(page, pagesBefore);
+			const active =
+				oauthPage ??
+				(!page.isClosed() ? page : null) ??
+				(await this.findPageWithApprovalButton());
+
+			if (!active || active.isClosed()) {
+				await timeout(300);
+				continue;
+			}
+
+			const url = active.url();
+
+			if (
+				/soundcloud\.com|secure\.soundcloud\.com/i.test(url) &&
+				!url.includes('downloadgater.com')
+			) {
+				const allowed = await this.clickSoundcloudOauthAllow(active);
+				if (!allowed) {
+					// Authorize shell can render before #submit_approval is attached.
+					await timeout(400);
+				} else {
+					await timeout(1_000);
+				}
+				continue;
+			}
+
+			// Gate tab may still be downloadgater while authorize is another target.
+			const approvalTab = await this.findPageWithApprovalButton();
+			if (approvalTab) {
+				await this.clickSoundcloudOauthAllow(approvalTab);
+				await timeout(1_000);
+				continue;
+			}
+
+			if (!url.includes('downloadgater.com')) {
+				await timeout(300);
+				continue;
+			}
+
+			// Still on the OAuth callback endpoint — wait for the gate redirect.
+			// Do not navigate away; that drops the unlock token.
+			if (/\/api\/soundcloud\/callback/i.test(url)) {
+				await timeout(300);
+				continue;
+			}
+
+			const soundcloudError = await this.readSoundcloudUrlError(active);
+			if (soundcloudError) {
+				throw new Error(
+					`DownloadGater SoundCloud unlock failed: ${soundcloudError}`,
+				);
+			}
+
+			await this.clickUnlockFinishIfPresent(active);
+
+			if (await this.hasDownloadButton(active)) {
+				await timeout(500);
+				return;
+			}
+
+			// Unlock query is present briefly, then stripped into localStorage by the SPA.
+			if (/[?&]unlock=/i.test(url)) {
+				await timeout(1_500);
+				return;
+			}
+
+			if (!page.isClosed()) {
+				const pane = await this.detectPane(page);
+				if (pane === 'download' || pane === 'instagram') {
+					await timeout(500);
+					return;
+				}
+			}
+
+			await timeout(400);
+		}
+
+		throw new Error(
+			'DownloadGater did not unlock after SoundCloud OAuth. Check Allow was clicked / Initialize Logins.',
+		);
+	}
+
+	private async findSoundcloudOauthPage(
+		gatePage: Page,
+		pagesBefore: Set<Page>,
+	): Promise<Page | null> {
+		const pages = await this.browser.pages(true);
+
+		const byAuthorizeUrl = pages.find((candidate) => {
+			if (candidate.isClosed()) return false;
+			return /secure\.soundcloud\.com\/authorize|soundcloud\.com\/.*\/?authorize/i.test(
+				candidate.url(),
+			);
+		});
+		if (byAuthorizeUrl) return byAuthorizeUrl;
+
+		if (!gatePage.isClosed()) {
+			const gateUrl = gatePage.url();
+			if (/soundcloud\.com|secure\.soundcloud\.com/i.test(gateUrl)) {
+				return gatePage;
+			}
+		}
+
+		return (
+			pages.find((candidate) => {
+				if (candidate === gatePage || candidate.isClosed()) return false;
+				const candidateUrl = candidate.url();
+				return (
+					/soundcloud\.com|secure\.soundcloud\.com/i.test(candidateUrl) ||
+					(!pagesBefore.has(candidate) &&
+						candidateUrl !== 'about:blank' &&
+						/soundcloud/i.test(candidateUrl))
+				);
+			}) ?? null
+		);
+	}
+
+	private async findPageWithApprovalButton(): Promise<Page | null> {
+		for (const candidate of await this.browser.pages(true)) {
+			if (candidate.isClosed()) continue;
+			try {
+				for (const frame of candidate.frames()) {
+					const handle = await frame.$(Selectors.SC_SUBMIT_APPROVAL_BUTTON);
+					if (handle) {
+						await handle.dispose();
+						return candidate;
+					}
+				}
+			} catch {
+				// page/frame navigated
+			}
+		}
+		return null;
+	}
+
+	/** Approve OAuth only — never the sign-in email "Continue". */
+	private async clickSoundcloudOauthAllow(oauthPage: Page): Promise<boolean> {
+		try {
+			await oauthPage.bringToFront();
+		} catch {
+			// tab may be navigating
+		}
+
+		const needsLogin = await oauthPage
+			.evaluate(() =>
+				/sign in or create an account/i.test(document.body?.innerText || ''),
+			)
+			.catch(() => false);
+
+		// Trusted pointer click — authorize ignores plain DOM click() under CloakBrowser.
+		for (const frame of oauthPage.frames()) {
+			try {
+				const submit = await frame.$(Selectors.SC_SUBMIT_APPROVAL_BUTTON);
+				if (submit) {
+					await submit.click({ delay: 40 });
+					console.log(
+						'DownloadGater: clicked SoundCloud OAuth submit_approval',
+					);
+					return true;
+				}
+			} catch {
+				// frame detached / navigated
+			}
+		}
+
+		for (const frame of oauthPage.frames()) {
+			try {
+				const clicked = await frame.evaluate(() => {
+					const approve = Array.from(document.querySelectorAll('button')).find(
+						(btn) =>
+							/^(connect|allow|authorize|accept)$/i.test(
+								(btn.textContent || '').trim(),
+							) && !(btn as HTMLButtonElement).disabled,
+					) as HTMLButtonElement | undefined;
+					if (!approve) return null;
+					approve.click();
+					return (approve.textContent || '').trim();
+				});
+				if (clicked) {
+					console.log(`DownloadGater: clicked SoundCloud OAuth ${clicked}`);
+					return true;
+				}
+			} catch {
+				// frame detached / navigated
+			}
+		}
+
+		if (needsLogin) {
+			throw new Error(
+				'SoundCloud is not logged in. Run Initialize Logins (or CLI initializeLogins) first.',
+			);
+		}
+
+		return false;
+	}
+
+	private async handleDownload(page: Page) {
+		this.emitProgress('downloading', 'Preparing DownloadGater download...', 75);
+
+		const client = await page.createCDPSession();
+		await client.send('Browser.setDownloadBehavior', {
+			behavior: 'allow',
+			downloadPath: './downloads',
+			eventsEnabled: true,
+		});
+
+		let downloadGuid: string | null = null;
+		let downloadCompleteResolve: (value: string) => void;
+		const downloadCompletePromise = new Promise<string>((resolve) => {
+			downloadCompleteResolve = resolve;
+		});
+
+		const pBar = new SingleBar(
+			{
+				format:
+					'{prefix} {bar} {percentage}% | {current_mb}/{total_mb} MB | ETA: {eta_formatted}',
+				hideCursor: true,
+			},
+			{
+				barCompleteChar: '█',
+				barIncompleteChar: '░',
+				format: Presets.shades_classic.format,
+			},
+		);
+
+		client.on('Browser.downloadWillBegin', (event) => {
+			downloadGuid = event.guid;
+			this.downloadFilename = event.suggestedFilename;
+			console.log('Download started:', this.downloadFilename);
+			this.emitProgress(
+				'downloading',
+				`Downloading ${this.downloadFilename}...`,
+				76,
+			);
+		});
+
+		client.on('Browser.downloadProgress', (event) => {
+			if (event.guid !== downloadGuid || !this.downloadFilename) return;
+			if (event.state === 'completed') {
+				pBar.stop();
+				console.log('Download completed');
+				this.emitProgress('downloading', 'Download complete', 85);
+				downloadCompleteResolve(this.downloadFilename);
+			} else if (event.state === 'inProgress') {
+				const { receivedBytes, totalBytes } = event;
+				if (pBar.isActive) {
+					pBar.update(receivedBytes, {
+						total_mb: Number((totalBytes / 1024 / 1024).toFixed(2)),
+						current_mb: Number((receivedBytes / 1024 / 1024).toFixed(2)),
+					});
+				} else {
+					pBar.start(totalBytes, receivedBytes, { prefix: 'Downloading' });
+				}
+				const downloadPercent = totalBytes > 0 ? receivedBytes / totalBytes : 0;
+				this.emitProgress(
+					'downloading',
+					`Downloading... ${(receivedBytes / 1024 / 1024).toFixed(1)} / ${(totalBytes / 1024 / 1024).toFixed(1)} MB`,
+					76 + downloadPercent * 8,
+					{ downloadBytes: receivedBytes, totalBytes },
+				);
+			} else if (event.state === 'canceled') {
+				pBar.stop();
+				throw new Error('Download was canceled');
+			}
+		});
+
+		const clickDownload = async () => {
+			await page.evaluate(() => {
+				const btn = Array.from(document.querySelectorAll('button')).find((el) =>
+					/^(download file|download zip)$/i.test((el.textContent || '').trim()),
+				) as HTMLButtonElement | undefined;
+				btn?.click();
+			});
+		};
+
+		setTimeout(async () => {
+			if (!downloadGuid) {
+				console.log(
+					'Download not started after 10 seconds, clicking button again...',
+				);
+				try {
+					await clickDownload();
+				} catch {
+					// ignore
+				}
+			}
+		}, 10_000);
+
+		await clickDownload();
+		await downloadCompletePromise;
+	}
+}

--- a/src/downloadgater.ts
+++ b/src/downloadgater.ts
@@ -32,7 +32,7 @@ export class DownloadgaterDownloader {
 	async initialize() {
 		this.browser = await launchAppBrowser({
 			headless: this.config.headless,
-			userDataDir: './browser-data',
+			userDataDir: this.config.userDataDir ?? './browser-data',
 		});
 
 		const browserContext = this.browser.defaultBrowserContext();
@@ -690,7 +690,7 @@ export class DownloadgaterDownloader {
 			});
 		};
 
-		setTimeout(async () => {
+		const retryTimer = setTimeout(async () => {
 			if (!downloadGuid) {
 				console.log(
 					'Download not started after 10 seconds, clicking button again...',
@@ -708,6 +708,7 @@ export class DownloadgaterDownloader {
 			await downloadCompletePromise;
 		} finally {
 			clearTimeout(downloadTimer);
+			clearTimeout(retryTimer);
 			pBar.stop();
 			await client.detach().catch(() => {});
 		}

--- a/src/downloadgater.ts
+++ b/src/downloadgater.ts
@@ -614,9 +614,18 @@ export class DownloadgaterDownloader {
 
 		let downloadGuid: string | null = null;
 		let downloadCompleteResolve: (value: string) => void;
-		const downloadCompletePromise = new Promise<string>((resolve) => {
+		let downloadCompleteReject: (reason: Error) => void;
+		const downloadCompletePromise = new Promise<string>((resolve, reject) => {
 			downloadCompleteResolve = resolve;
+			downloadCompleteReject = reject;
 		});
+		const downloadTimer = setTimeout(
+			() =>
+				downloadCompleteReject(
+					new Error('DownloadGater download did not complete in time'),
+				),
+			5 * 60_000,
+		);
 
 		const pBar = new SingleBar(
 			{
@@ -668,7 +677,7 @@ export class DownloadgaterDownloader {
 				);
 			} else if (event.state === 'canceled') {
 				pBar.stop();
-				throw new Error('Download was canceled');
+				downloadCompleteReject(new Error('Download was canceled'));
 			}
 		});
 
@@ -694,7 +703,13 @@ export class DownloadgaterDownloader {
 			}
 		}, 10_000);
 
-		await clickDownload();
-		await downloadCompletePromise;
+		try {
+			await clickDownload();
+			await downloadCompletePromise;
+		} finally {
+			clearTimeout(downloadTimer);
+			pBar.stop();
+			await client.detach().catch(() => {});
+		}
 	}
 }

--- a/src/droploud.ts
+++ b/src/droploud.ts
@@ -1067,9 +1067,18 @@ export class DroploudDownloader {
 
 		let downloadGuid: string | null = null;
 		let downloadCompleteResolve: (value: string) => void;
-		const downloadCompletePromise = new Promise<string>((resolve) => {
+		let downloadCompleteReject: (reason: Error) => void;
+		const downloadCompletePromise = new Promise<string>((resolve, reject) => {
 			downloadCompleteResolve = resolve;
+			downloadCompleteReject = reject;
 		});
+		const downloadTimer = setTimeout(
+			() =>
+				downloadCompleteReject(
+					new Error('Droploud download did not complete in time'),
+				),
+			10 * 60_000,
+		);
 
 		const pBar = new SingleBar(
 			{
@@ -1121,7 +1130,7 @@ export class DroploudDownloader {
 				);
 			} else if (event.state === 'canceled') {
 				pBar.stop();
-				throw new Error('Download was canceled');
+				downloadCompleteReject(new Error('Download was canceled'));
 			}
 		});
 
@@ -1155,7 +1164,12 @@ export class DroploudDownloader {
 			}
 		}, 10_000);
 
-		await Promise.all([clickDownload(), downloadCompletePromise]);
-		await client.detach();
+		try {
+			await Promise.all([clickDownload(), downloadCompletePromise]);
+		} finally {
+			clearTimeout(downloadTimer);
+			pBar.stop();
+			await client.detach().catch(() => {});
+		}
 	}
 }

--- a/src/droploud.ts
+++ b/src/droploud.ts
@@ -42,7 +42,7 @@ export class DroploudDownloader {
 	async initialize() {
 		this.browser = await launchAppBrowser({
 			headless: this.config.headless,
-			userDataDir: './browser-data',
+			userDataDir: this.config.userDataDir ?? './browser-data',
 		});
 
 		const browserContext = this.browser.defaultBrowserContext();
@@ -1151,7 +1151,7 @@ export class DroploudDownloader {
 			}
 		};
 
-		setTimeout(async () => {
+		const retryTimer = setTimeout(async () => {
 			if (!downloadGuid) {
 				console.log(
 					'Download not started after 10 seconds, clicking button again...',
@@ -1168,6 +1168,7 @@ export class DroploudDownloader {
 			await Promise.all([clickDownload(), downloadCompletePromise]);
 		} finally {
 			clearTimeout(downloadTimer);
+			clearTimeout(retryTimer);
 			pBar.stop();
 			await client.detach().catch(() => {});
 		}

--- a/src/droploud.ts
+++ b/src/droploud.ts
@@ -1,0 +1,1161 @@
+import { Presets, SingleBar } from 'cli-progress';
+import type { Browser, Page } from 'puppeteer';
+import { launchAppBrowser } from './browserLaunch';
+import type { ProgressCallback } from './hypeddit';
+import Selectors from './selectors';
+import { SoundcloudClient } from './soundcloud';
+import type { HypedditConfig } from './types';
+import { loadCookies, timeout } from './utils';
+
+type PaneKind =
+	| 'social_open'
+	| 'soundcloud_connect'
+	| 'email'
+	| 'droploud_follow'
+	| 'disclaimer'
+	| 'unlocked'
+	| 'unknown';
+
+export class DroploudDownloader {
+	private browser!: Browser;
+	private downloadFilename: string | null = null;
+	private config: HypedditConfig;
+	private progressCallback: ProgressCallback | null = null;
+
+	constructor(config: HypedditConfig) {
+		this.config = config;
+	}
+
+	setProgressCallback(callback: ProgressCallback): void {
+		this.progressCallback = callback;
+	}
+
+	private emitProgress(
+		stage: Parameters<ProgressCallback>[0],
+		message: string,
+		percent: number,
+		extra?: Parameters<ProgressCallback>[3],
+	): void {
+		this.progressCallback?.(stage, message, percent, extra);
+	}
+
+	async initialize() {
+		this.browser = await launchAppBrowser({
+			headless: this.config.headless,
+			userDataDir: './browser-data',
+		});
+
+		const browserContext = this.browser.defaultBrowserContext();
+		const soundCloudCookies = await loadCookies('soundcloud-cookies.json');
+		await browserContext.setCookie(...soundCloudCookies);
+	}
+
+	async prepareLogins() {
+		const soundCloudPage = await this.browser.newPage();
+		soundCloudPage.setViewport({ width: 1920, height: 1080 });
+		await soundCloudPage.goto('https://soundcloud.com/messages');
+
+		try {
+			await soundCloudPage.waitForSelector(
+				Selectors.SOUNDCLOUD_CAPTCHA_CONTAINER,
+				{ timeout: 5_000 },
+			);
+			console.log(
+				'Droploud: SoundCloud captcha present during login warm-up; solve it in the browser window if needed.',
+			);
+			await soundCloudPage.waitForSelector(
+				Selectors.SOUNDCLOUD_CAPTCHA_CONTAINER,
+				{ hidden: true, timeout: 120_000 },
+			);
+		} catch {
+			// no captcha
+		}
+
+		await soundCloudPage.waitForSelector(Selectors.SOUNDCLOUD_LIBRARY_LINK, {
+			timeout: 30_000,
+		});
+		await Promise.all([
+			soundCloudPage.click(Selectors.SOUNDCLOUD_LIBRARY_LINK),
+			soundCloudPage.waitForNavigation({ waitUntil: 'domcontentloaded' }),
+		]);
+		await soundCloudPage.waitForFunction(() =>
+			window.location.href.includes('/you/library'),
+		);
+		await soundCloudPage.close();
+	}
+
+	async downloadAudio(url: string): Promise<string | null> {
+		console.log('Navigating to Droploud gate...');
+		this.emitProgress('handling_gates', 'Navigating to Droploud gate...', 25);
+
+		const page = await this.browser.newPage();
+		await page.setViewport({ width: 1920, height: 1080 });
+		await page.goto(url, { waitUntil: 'domcontentloaded' });
+		try {
+			await page.waitForNetworkIdle({ timeout: 15_000, idleTime: 10 });
+		} catch {
+			// continue with whatever rendered
+		}
+
+		await this.dismissCookieBanner(page);
+		await this.startGateIfNeeded(page);
+
+		const maxSteps = 12;
+		for (let i = 0; i < maxSteps; i++) {
+			const kind = await this.detectPaneKind(page);
+			console.log(`Droploud pane: ${kind}`);
+
+			if (kind === 'unlocked') {
+				break;
+			}
+			if (kind === 'email') {
+				this.emitProgress(
+					'handling_gates',
+					'Submitting Droploud email step...',
+					30 + i * 5,
+					{ currentGate: 'email' },
+				);
+				await this.handleEmailStep(page);
+				continue;
+			}
+			if (kind === 'droploud_follow') {
+				this.emitProgress(
+					'handling_gates',
+					'Skipping Droploud follow step...',
+					32 + i * 5,
+					{ currentGate: 'social' },
+				);
+				await this.handleDroploudFollowStep(page);
+				continue;
+			}
+			if (kind === 'disclaimer') {
+				this.emitProgress(
+					'handling_gates',
+					'Confirming Droploud disclaimer...',
+					33 + i * 5,
+					{ currentGate: 'social' },
+				);
+				await this.handleDisclaimerStep(page);
+				continue;
+			}
+			if (kind === 'soundcloud_connect') {
+				this.emitProgress(
+					'handling_gates',
+					'Connecting SoundCloud on Droploud...',
+					40 + i * 5,
+					{ currentGate: 'sc' },
+				);
+				await this.handleSoundcloudConnect(page);
+				continue;
+			}
+			if (kind === 'social_open') {
+				this.emitProgress(
+					'handling_gates',
+					'Handling Droploud social step...',
+					35 + i * 5,
+					{ currentGate: 'social' },
+				);
+				await this.handleSocialOpenStep(page);
+				continue;
+			}
+
+			const title = await page.evaluate((selector) => {
+				return document.querySelector(selector)?.textContent?.trim() || '';
+			}, Selectors.DROPLOUD_UNLOCKED_TITLE);
+			throw new Error(
+				`Unsupported Droploud gate step${title ? `: ${title}` : ''}. Please create an issue if this keeps happening.`,
+			);
+		}
+
+		const unlocked = await this.detectPaneKind(page);
+		if (unlocked !== 'unlocked') {
+			throw new Error('Droploud gate did not unlock after completing steps');
+		}
+
+		await this.handleDownload(page);
+		await page.close();
+		return this.downloadFilename;
+	}
+
+	async close() {
+		await this.browser?.close();
+	}
+
+	private async dismissCookieBanner(page: Page) {
+		const accepted = await page.evaluate(() => {
+			const buttons = Array.from(document.querySelectorAll('button'));
+			const accept = buttons.find((btn) =>
+				/accept all/i.test(btn.textContent || ''),
+			);
+			if (!accept) return false;
+			accept.click();
+			return true;
+		});
+		if (accepted) {
+			await timeout(500);
+		}
+	}
+
+	private async startGateIfNeeded(page: Page) {
+		const stepPane = await page.$(Selectors.DROPLOUD_STEP_PANE);
+		if (stepPane) return;
+
+		const started = await page.evaluate((selector) => {
+			const buttons = Array.from(
+				document.querySelectorAll<HTMLButtonElement>(selector),
+			);
+			const freeDownload = buttons.find((btn) =>
+				/free download/i.test(btn.textContent || ''),
+			);
+			if (!freeDownload || freeDownload.disabled) return false;
+			freeDownload.click();
+			return true;
+		}, Selectors.DROPLOUD_FREE_DOWNLOAD_BUTTON);
+
+		if (started) {
+			await page.waitForSelector(Selectors.DROPLOUD_STEP_PANE, {
+				timeout: 15_000,
+			});
+		}
+	}
+
+	private async detectPaneKind(page: Page): Promise<PaneKind> {
+		return page.evaluate(
+			(selectors) => {
+				const title =
+					document.querySelector(selectors.title)?.textContent || '';
+				if (/drop unlocked/i.test(title)) {
+					return 'unlocked';
+				}
+
+				const downloadButtons = Array.from(
+					document.querySelectorAll<HTMLButtonElement>(selectors.downloadBtn),
+				);
+				const hasDownload = downloadButtons.some((btn) =>
+					/^(\s*)download(\s*)$/i.test((btn.textContent || '').trim()),
+				);
+				if (hasDownload || /your download is ready/i.test(title)) {
+					return 'unlocked';
+				}
+
+				if (document.querySelector(selectors.emailWrap)) {
+					return 'email';
+				}
+
+				if (document.querySelector(selectors.dlFollowWrap)) {
+					return 'droploud_follow';
+				}
+
+				const connectBtn = Array.from(
+					document.querySelectorAll<HTMLButtonElement>('button'),
+				).find((btn) => /connect soundcloud/i.test(btn.textContent || ''));
+				if (connectBtn || document.querySelector(selectors.commentInput)) {
+					return 'soundcloud_connect';
+				}
+
+				if (document.querySelector(selectors.openLinks)) {
+					return 'social_open';
+				}
+
+				const confirmBtn = Array.from(
+					document.querySelectorAll<HTMLButtonElement>('button'),
+				).find((btn) => /^i confirm/i.test((btn.textContent || '').trim()));
+				if (confirmBtn && document.querySelector(selectors.disclaimerCheck)) {
+					return 'disclaimer';
+				}
+
+				return 'unknown';
+			},
+			{
+				title: Selectors.DROPLOUD_UNLOCKED_TITLE,
+				downloadBtn: Selectors.DROPLOUD_DOWNLOAD_BUTTON,
+				commentInput: Selectors.DROPLOUD_SC_COMMENT_INPUT,
+				openLinks: Selectors.DROPLOUD_OPEN_LINK_BUTTONS,
+				emailWrap: Selectors.DROPLOUD_EMAIL_WRAP,
+				dlFollowWrap: Selectors.DROPLOUD_DLFOLLOW_WRAP,
+				disclaimerCheck: Selectors.DROPLOUD_DISCLAIMER_CHECK,
+			},
+		);
+	}
+
+	private async handleEmailStep(page: Page) {
+		const email = this.config.email?.trim();
+		if (!email) {
+			throw new Error(
+				'This Droploud gate requires an email. Set HYPEDDIT_EMAIL in your .env file.',
+			);
+		}
+
+		await page.waitForSelector(Selectors.DROPLOUD_EMAIL_INPUT, {
+			timeout: 10_000,
+		});
+
+		// Instant fill — React-controlled input needs the native value setter.
+		await page.evaluate(
+			(selector, value) => {
+				const el = document.querySelector<HTMLInputElement>(selector);
+				if (!el) return;
+				const setter = Object.getOwnPropertyDescriptor(
+					window.HTMLInputElement.prototype,
+					'value',
+				)?.set;
+				setter?.call(el, value);
+				el.dispatchEvent(new Event('input', { bubbles: true }));
+				el.dispatchEvent(new Event('change', { bubbles: true }));
+			},
+			Selectors.DROPLOUD_EMAIL_INPUT,
+			email,
+		);
+
+		await page.evaluate((selector) => {
+			const checkbox = document.querySelector<HTMLInputElement>(selector);
+			if (checkbox && !checkbox.checked) {
+				checkbox.click();
+			}
+		}, Selectors.DROPLOUD_EMAIL_CONSENT);
+
+		await page.waitForFunction(
+			() => {
+				const btn = Array.from(document.querySelectorAll('button')).find((el) =>
+					/continue/i.test((el.textContent || '').trim()),
+				) as HTMLButtonElement | undefined;
+				return !!btn && !btn.disabled;
+			},
+			{ timeout: 10_000 },
+		);
+
+		const beforeTitle = await page.evaluate((selector) => {
+			return document.querySelector(selector)?.textContent?.trim() || '';
+		}, Selectors.DROPLOUD_UNLOCKED_TITLE);
+
+		await page.evaluate(() => {
+			const btn = Array.from(document.querySelectorAll('button')).find((el) =>
+				/continue/i.test((el.textContent || '').trim()),
+			) as HTMLButtonElement | undefined;
+			btn?.click();
+		});
+
+		await page.waitForFunction(
+			(selector, previous) => {
+				const title =
+					document.querySelector(selector)?.textContent?.trim() || '';
+				return title !== previous || !document.querySelector('.dtr-email-wrap');
+			},
+			{ timeout: 20_000 },
+			Selectors.DROPLOUD_UNLOCKED_TITLE,
+			beforeTitle,
+		);
+		await timeout(400);
+	}
+
+	private async handleDroploudFollowStep(page: Page) {
+		await page.waitForSelector(Selectors.DROPLOUD_DLFOLLOW_WRAP, {
+			timeout: 10_000,
+		});
+
+		const beforeTitle = await page.evaluate((selector) => {
+			return document.querySelector(selector)?.textContent?.trim() || '';
+		}, Selectors.DROPLOUD_UNLOCKED_TITLE);
+
+		const skipped = await page.evaluate((selector) => {
+			const skip = document.querySelector<HTMLButtonElement>(selector);
+			if (skip && !skip.disabled) {
+				skip.click();
+				return true;
+			}
+			const fallback = Array.from(document.querySelectorAll('button')).find(
+				(btn) =>
+					/skip|i.?m done|continue/i.test((btn.textContent || '').trim()) &&
+					!(btn as HTMLButtonElement).disabled,
+			) as HTMLButtonElement | undefined;
+			fallback?.click();
+			return !!fallback;
+		}, Selectors.DROPLOUD_DLFOLLOW_SKIP);
+
+		if (!skipped) {
+			throw new Error('Droploud follow skip/continue button not found.');
+		}
+
+		await page.waitForFunction(
+			(selector, previous) => {
+				const title =
+					document.querySelector(selector)?.textContent?.trim() || '';
+				return (
+					title !== previous || !document.querySelector('.dtr-dlfollow-wrap')
+				);
+			},
+			{ timeout: 20_000 },
+			Selectors.DROPLOUD_UNLOCKED_TITLE,
+			beforeTitle,
+		);
+		await timeout(400);
+	}
+
+	private async handleDisclaimerStep(page: Page) {
+		await page.evaluate((selector) => {
+			const checkbox = document.querySelector<HTMLInputElement>(selector);
+			if (checkbox && !checkbox.checked) {
+				checkbox.click();
+			}
+		}, Selectors.DROPLOUD_DISCLAIMER_CHECK);
+
+		await page.waitForFunction(
+			() => {
+				const btn = Array.from(document.querySelectorAll('button')).find((el) =>
+					/^i confirm/i.test((el.textContent || '').trim()),
+				) as HTMLButtonElement | undefined;
+				return !!btn && !btn.disabled;
+			},
+			{ timeout: 10_000 },
+		);
+
+		const beforeTitle = await page.evaluate((selector) => {
+			return document.querySelector(selector)?.textContent?.trim() || '';
+		}, Selectors.DROPLOUD_UNLOCKED_TITLE);
+
+		await page.evaluate(() => {
+			const btn = Array.from(document.querySelectorAll('button')).find((el) =>
+				/^i confirm/i.test((el.textContent || '').trim()),
+			) as HTMLButtonElement | undefined;
+			btn?.click();
+		});
+
+		await page.waitForFunction(
+			(selector, previous) => {
+				const title =
+					document.querySelector(selector)?.textContent?.trim() || '';
+				return title !== previous;
+			},
+			{ timeout: 20_000 },
+			Selectors.DROPLOUD_UNLOCKED_TITLE,
+			beforeTitle,
+		);
+		await timeout(400);
+	}
+
+	private async handleSocialOpenStep(page: Page) {
+		await page.waitForSelector(Selectors.DROPLOUD_OPEN_LINK_BUTTONS, {
+			timeout: 15_000,
+		});
+
+		const stepTitle = await page.evaluate((selector) => {
+			return document.querySelector(selector)?.textContent?.trim() || '';
+		}, Selectors.DROPLOUD_UNLOCKED_TITLE);
+		const isManualRepost =
+			/repost/i.test(stepTitle) ||
+			(await page.evaluate((selector) => {
+				const btn = document.querySelector(selector);
+				return /reposted,\s*verify/i.test(btn?.textContent || '');
+			}, Selectors.DROPLOUD_CONFIRM_BUTTON));
+
+		console.log(`Droploud social open: ${stepTitle || 'untitled step'}`);
+
+		for (let attempt = 0; attempt < 10; attempt++) {
+			const nextButtonIndex = await page.evaluate((selector) => {
+				const buttons = Array.from(
+					document.querySelectorAll<HTMLButtonElement>(selector),
+				);
+				return buttons.findIndex(
+					(btn) => !/^\s*✓/.test((btn.textContent || '').trim()),
+				);
+			}, Selectors.DROPLOUD_OPEN_LINK_BUTTONS);
+
+			if (nextButtonIndex < 0) {
+				break;
+			}
+
+			const pagesBefore = new Set(await this.browser.pages(true));
+			const handles = await page.$$(Selectors.DROPLOUD_OPEN_LINK_BUTTONS);
+			const handle = handles[nextButtonIndex];
+			if (!handle) {
+				for (const h of handles) await h.dispose();
+				throw new Error('Droploud open-link button disappeared mid-step.');
+			}
+
+			// Trusted click — needed so React marks the link opened (enables "I did it").
+			await handle.click({ delay: 40 });
+			for (const h of handles) await h.dispose();
+
+			let popup: Page | undefined;
+			const started = Date.now();
+			while (!popup && Date.now() - started < 8_000) {
+				const pages = await this.browser.pages(true);
+				popup = pages.find(
+					(candidate) =>
+						candidate !== page &&
+						!pagesBefore.has(candidate) &&
+						candidate.url() !== 'about:blank',
+				);
+				if (!popup) {
+					popup = pages.find(
+						(candidate) =>
+							candidate !== page &&
+							!candidate.url().includes('droploud.com') &&
+							candidate.url() !== 'about:blank',
+					);
+				}
+				if (!popup) await timeout(200);
+			}
+
+			if (popup && !popup.isClosed()) {
+				try {
+					// Honor-system social (IG/Spotify/etc.): open is enough.
+					// SoundCloud manual repost gates actually verify the repost.
+					if (isManualRepost || /soundcloud\.com/i.test(popup.url())) {
+						await this.performSoundcloudManualActions(popup, {
+							repost: isManualRepost || /repost/i.test(stepTitle),
+						});
+					} else {
+						// Give Spotify/etc. a moment to load before closing.
+						await timeout(1_200);
+					}
+				} finally {
+					if (!popup.isClosed()) {
+						try {
+							await popup.close();
+						} catch {
+							// already closed
+						}
+					}
+				}
+			}
+
+			// Wait until this button shows the ✓ opened marker.
+			try {
+				await page.waitForFunction(
+					(selector, index) => {
+						const buttons = Array.from(
+							document.querySelectorAll<HTMLButtonElement>(selector),
+						);
+						const btn = buttons[index];
+						return !!btn && /^\s*✓/.test((btn.textContent || '').trim());
+					},
+					{ timeout: 8_000 },
+					Selectors.DROPLOUD_OPEN_LINK_BUTTONS,
+					nextButtonIndex,
+				);
+			} catch {
+				console.warn(
+					`Droploud: open-link #${nextButtonIndex + 1} did not show ✓; retrying.`,
+				);
+			}
+
+			await timeout(300);
+		}
+
+		const stillPending = await page.evaluate((selector) => {
+			return Array.from(
+				document.querySelectorAll<HTMLButtonElement>(selector),
+			).some((btn) => !/^\s*✓/.test((btn.textContent || '').trim()));
+		}, Selectors.DROPLOUD_OPEN_LINK_BUTTONS);
+		if (stillPending) {
+			throw new Error(
+				`Droploud social step still has unopened links (${stepTitle || 'unknown'}). Popups may be blocked.`,
+			);
+		}
+
+		const confirm = await page.waitForSelector(
+			Selectors.DROPLOUD_CONFIRM_BUTTON,
+			{ timeout: 10_000 },
+		);
+		if (!confirm) {
+			throw new Error('Droploud confirm button not found');
+		}
+
+		await page.waitForFunction(
+			(selector) => {
+				const btn = document.querySelector<HTMLButtonElement>(selector);
+				return !!btn && !btn.disabled;
+			},
+			{ timeout: 15_000 },
+			Selectors.DROPLOUD_CONFIRM_BUTTON,
+		);
+
+		const titleBeforeConfirm = await page.evaluate((selector) => {
+			return document.querySelector(selector)?.textContent?.trim() || '';
+		}, Selectors.DROPLOUD_UNLOCKED_TITLE);
+
+		let verifyFound: boolean | null = null;
+		const onVerify = async (res: {
+			url: () => string;
+			ok: () => boolean;
+			text: () => Promise<string>;
+		}) => {
+			if (!res.url().includes('/api/soundcloud/verify-repost')) return;
+			try {
+				const body = JSON.parse(await res.text()) as { found?: boolean };
+				verifyFound = body.found === true;
+			} catch {
+				// ignore parse errors
+			}
+		};
+		page.on('response', onVerify);
+
+		await page.click(Selectors.DROPLOUD_CONFIRM_BUTTON);
+
+		// Next gate step can also be social-open (e.g. TikTok → Spotify), so do NOT
+		// wait for `.dtr-open-grid` to vanish — wait for the step title to change.
+		try {
+			await page.waitForFunction(
+				(selectors, previousTitle) => {
+					const title =
+						document.querySelector(selectors.title)?.textContent?.trim() || '';
+					if (/drop unlocked|download is ready/i.test(title)) return true;
+					if (title && title !== previousTitle) return true;
+
+					const confirmBtn = document.querySelector<HTMLButtonElement>(
+						selectors.confirm,
+					);
+					if (
+						confirmBtn &&
+						/confirming|verifying/i.test(confirmBtn.textContent || '')
+					) {
+						return false;
+					}
+					return false;
+				},
+				{ timeout: 45_000 },
+				{
+					title: Selectors.DROPLOUD_UNLOCKED_TITLE,
+					confirm: Selectors.DROPLOUD_CONFIRM_BUTTON,
+				},
+				titleBeforeConfirm,
+			);
+		} catch {
+			page.off('response', onVerify);
+			if (verifyFound === false) {
+				throw new Error(
+					'Droploud could not verify the SoundCloud repost. Make sure the SoundCloud account is logged in (Initialize Logins) and try again.',
+				);
+			}
+			throw new Error(
+				`Droploud social step did not advance after confirm (${titleBeforeConfirm || 'unknown'}). Try again or run non-headless.`,
+			);
+		}
+		page.off('response', onVerify);
+		await timeout(500);
+	}
+
+	/**
+	 * Manual Droploud repost step: open track URL, ensure a repost via API, then
+	 * fall back to clicking Repost in the SoundCloud UI if engagement PUTs fail.
+	 */
+	private async performSoundcloudManualActions(
+		popup: Page,
+		actions: { repost: boolean },
+	) {
+		if (!actions.repost) return;
+
+		const deadline = Date.now() + 25_000;
+		while (Date.now() < deadline) {
+			if (popup.isClosed()) return;
+			const url = popup.url();
+			if (
+				url.includes('soundcloud.com') &&
+				url !== 'about:blank' &&
+				!url.includes('/web-auth')
+			) {
+				break;
+			}
+			await timeout(200);
+		}
+
+		const trackUrl = popup.url();
+		if (!trackUrl.includes('soundcloud.com')) {
+			throw new Error('SoundCloud popup never navigated to a track URL.');
+		}
+
+		try {
+			const soundcloud = new SoundcloudClient();
+			await soundcloud.repostTrack(trackUrl);
+			console.log('Droploud: SoundCloud repost ensured via API.');
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			console.warn(
+				`Droploud: API repost failed (${message.slice(0, 180)}); trying browser UI…`,
+			);
+			await this.repostTrackInBrowser(popup);
+			console.log('Droploud: SoundCloud repost ensured via browser UI.');
+		}
+		await timeout(500);
+	}
+
+	/** Click SoundCloud's track-page Repost control (trusted UI path). */
+	private async repostTrackInBrowser(page: Page) {
+		try {
+			await page.bringToFront();
+		} catch {
+			// ignore
+		}
+
+		const findRepostHandle = async () => {
+			const handles = await page.$$('button');
+			for (const handle of handles) {
+				const meta = await handle.evaluate((btn) => {
+					const text = (btn.textContent || '').trim();
+					const aria = btn.getAttribute('aria-label') || '';
+					const title = btn.title || '';
+					const pressed = btn.getAttribute('aria-pressed');
+					const label = `${aria} ${text} ${title}`;
+					return {
+						text,
+						aria,
+						pressed,
+						isRepost:
+							/^repost$/i.test(text) ||
+							/^repost$/i.test(aria) ||
+							(/^repost/i.test(label) && !/unrepost|reposted/i.test(label)),
+						already:
+							/unrepost|reposted/i.test(label) ||
+							(pressed === 'true' && /repost/i.test(label)),
+					};
+				});
+				if (meta.already) {
+					await handle.dispose();
+					return 'already' as const;
+				}
+				if (meta.isRepost) return handle;
+				await handle.dispose();
+			}
+			return null;
+		};
+
+		const started = Date.now();
+		let target: Awaited<ReturnType<typeof findRepostHandle>> = null;
+		while (Date.now() - started < 20_000) {
+			target = await findRepostHandle();
+			if (target) break;
+			await timeout(300);
+		}
+
+		if (target === 'already') {
+			console.log('Droploud: track already looks reposted in the browser.');
+			return;
+		}
+		if (!target) {
+			throw new Error(
+				'SoundCloud Repost button not found. Is the account logged in (Initialize Logins)?',
+			);
+		}
+
+		await target.click({ delay: 40 });
+		await target.dispose();
+
+		// Some layouts open a menu; confirm "Repost to profile" / plain Repost.
+		await timeout(600);
+		const menuHandles = await page.$$('button, [role="menuitem"], a');
+		for (const handle of menuHandles) {
+			const text = await handle.evaluate((el) => (el.textContent || '').trim());
+			if (
+				/^repost( to (your )?profile)?$/i.test(text) ||
+				/^repost track$/i.test(text)
+			) {
+				await handle.click({ delay: 40 });
+				await handle.dispose();
+				break;
+			}
+			await handle.dispose();
+		}
+
+		await page
+			.waitForFunction(
+				() => {
+					const buttons = Array.from(document.querySelectorAll('button'));
+					return buttons.some((btn) => {
+						const label =
+							`${btn.getAttribute('aria-label') || ''} ${btn.textContent || ''} ${btn.title || ''}`.toLowerCase();
+						return (
+							/unrepost|reposted/i.test(label) ||
+							(btn.getAttribute('aria-pressed') === 'true' &&
+								/repost/i.test(label))
+						);
+					});
+				},
+				{ timeout: 15_000 },
+			)
+			.catch(() => {
+				// Soft-ok: Droploud verify-repost API is the real check.
+				console.warn(
+					'Droploud: browser Repost click did not show a clear Reposted state; continuing for Droploud verify.',
+				);
+			});
+	}
+
+	private async handleSoundcloudConnect(page: Page) {
+		const commentInput = await page.$(Selectors.DROPLOUD_SC_COMMENT_INPUT);
+		if (commentInput) {
+			const comment = this.config.comment.trim();
+			// Droploud keeps Connect disabled while comment.trim().length < 2
+			if (comment.length < 2) {
+				throw new Error(
+					'Droploud requires SC_COMMENT to be at least 2 characters (your .env value is too short).',
+				);
+			}
+
+			// React-controlled textarea: native setter + input event enables Connect.
+			await page.focus(Selectors.DROPLOUD_SC_COMMENT_INPUT);
+			await page.evaluate(
+				(selector, value) => {
+					const el = document.querySelector<HTMLTextAreaElement>(selector);
+					if (!el) return;
+					const setter = Object.getOwnPropertyDescriptor(
+						window.HTMLTextAreaElement.prototype,
+						'value',
+					)?.set;
+					setter?.call(el, value);
+					el.dispatchEvent(new Event('input', { bubbles: true }));
+					el.dispatchEvent(new Event('change', { bubbles: true }));
+				},
+				Selectors.DROPLOUD_SC_COMMENT_INPUT,
+				comment,
+			);
+			await timeout(300);
+		}
+
+		try {
+			await page.waitForFunction(
+				() => {
+					const btn = Array.from(document.querySelectorAll('button')).find(
+						(el) => /connect soundcloud/i.test(el.textContent || ''),
+					) as HTMLButtonElement | undefined;
+					return !!btn && !btn.disabled;
+				},
+				{ timeout: 10_000 },
+			);
+		} catch {
+			throw new Error(
+				'Droploud Connect SoundCloud button stayed disabled. Set SC_COMMENT to at least 2 characters.',
+			);
+		}
+
+		const pagesBefore = await this.browser.pages(true);
+
+		await page.evaluate(() => {
+			const btn = Array.from(document.querySelectorAll('button')).find((el) =>
+				/connect soundcloud/i.test(el.textContent || ''),
+			);
+			(btn as HTMLButtonElement | undefined)?.click();
+		});
+
+		let oauthPage: Page | undefined;
+		const started = Date.now();
+		while (!oauthPage && Date.now() - started < 15_000) {
+			const pages = await this.browser.pages(true);
+			oauthPage = pages.find((candidate) => {
+				if (candidate === page) return false;
+				if (
+					pagesBefore.includes(candidate) &&
+					candidate.url() === 'about:blank'
+				) {
+					return false;
+				}
+				const url = candidate.url();
+				return (
+					url.includes('soundcloud.com') ||
+					url.includes('api.droploud.com/api/soundcloud')
+				);
+			});
+			if (!oauthPage) await timeout(200);
+		}
+
+		if (!oauthPage) {
+			// Popup blocked → Droploud may have navigated this tab
+			if (
+				page.url().includes('soundcloud.com') ||
+				page.url().includes('api.droploud.com/api/soundcloud')
+			) {
+				oauthPage = page;
+			} else {
+				throw new Error(
+					'SoundCloud OAuth window not found. Try initializing logins or disabling headless mode.',
+				);
+			}
+		}
+
+		await this.completeSoundcloudOauth(oauthPage);
+
+		// Wait for Droploud gate page to mark SC steps done / unlock
+		if (oauthPage !== page && !oauthPage.isClosed()) {
+			const closeStarted = Date.now();
+			while (!oauthPage.isClosed() && Date.now() - closeStarted < 20_000) {
+				await timeout(200);
+			}
+			if (!oauthPage.isClosed()) {
+				try {
+					await oauthPage.close();
+				} catch {
+					// ignore
+				}
+			}
+		}
+
+		// If we navigated the main page for OAuth, go back to the gate URL
+		if (oauthPage === page || !page.url().includes('droploud.com')) {
+			throw new Error(
+				'Droploud redirected this tab for SoundCloud OAuth (popup blocked). Re-run with popups allowed or non-headless.',
+			);
+		}
+
+		await page.waitForFunction(
+			() => {
+				const title =
+					document.querySelector('.dtr-card-title')?.textContent || '';
+				if (/drop unlocked/i.test(title)) return true;
+				const downloadButtons = Array.from(
+					document.querySelectorAll<HTMLButtonElement>(
+						'.ds-free-dl.dtr-card-cta',
+					),
+				);
+				if (
+					downloadButtons.some((btn) =>
+						/^(\s*)download(\s*)$/i.test((btn.textContent || '').trim()),
+					)
+				) {
+					return true;
+				}
+				const connect = Array.from(document.querySelectorAll('button')).find(
+					(btn) => /connect soundcloud/i.test(btn.textContent || ''),
+				);
+				const comment = document.querySelector('#dtr-sc-comment-input');
+				// Advanced past the SoundCloud connect pane
+				return !connect && !comment;
+			},
+			{ timeout: 90_000 },
+		);
+		await timeout(1_000);
+	}
+
+	private async completeSoundcloudOauth(oauthPage: Page) {
+		await oauthPage.bringToFront();
+		try {
+			await oauthPage.setViewport({ width: 1920, height: 1080 });
+		} catch {
+			// popup may already be closing
+		}
+
+		const deadline = Date.now() + 90_000;
+		while (Date.now() < deadline) {
+			if (oauthPage.isClosed()) {
+				return;
+			}
+
+			const url = oauthPage.url();
+			if (
+				url.includes('api.droploud.com/api/soundcloud/callback') ||
+				/connected/i.test(await oauthPage.title().catch(() => ''))
+			) {
+				// Connected page auto-closes; give it a moment
+				await timeout(1_500);
+				return;
+			}
+
+			if (url.includes('soundcloud.com')) {
+				const needsLogin = await oauthPage
+					.evaluate(() =>
+						/sign in or create an account/i.test(
+							document.body?.innerText || '',
+						),
+					)
+					.catch(() => false);
+				if (needsLogin) {
+					throw new Error(
+						'SoundCloud is not logged in. Run Initialize Logins (or CLI initializeLogins) first.',
+					);
+				}
+
+				const clicked = await this.clickSoundcloudOauthAllow(oauthPage);
+				if (clicked) {
+					await timeout(1_000);
+					continue;
+				}
+			}
+
+			const approvalTab = await this.findPageWithApprovalButton(oauthPage);
+			if (approvalTab) {
+				const clicked = await this.clickSoundcloudOauthAllow(approvalTab);
+				if (clicked) {
+					await timeout(1_000);
+					continue;
+				}
+			}
+
+			await timeout(300);
+		}
+
+		throw new Error('Timed out waiting for SoundCloud OAuth to complete');
+	}
+
+	private async findPageWithApprovalButton(
+		prefer?: Page,
+	): Promise<Page | null> {
+		const pages = await this.browser.pages(true);
+		const ordered = prefer
+			? [prefer, ...pages.filter((p) => p !== prefer)]
+			: pages;
+		for (const candidate of ordered) {
+			if (candidate.isClosed()) continue;
+			try {
+				for (const frame of candidate.frames()) {
+					const handle = await frame.$(Selectors.SC_SUBMIT_APPROVAL_BUTTON);
+					if (handle) {
+						await handle.dispose();
+						return candidate;
+					}
+				}
+			} catch {
+				// page/frame navigated
+			}
+		}
+		return null;
+	}
+
+	/** Approve OAuth only — never the sign-in email "Continue". */
+	private async clickSoundcloudOauthAllow(oauthPage: Page): Promise<boolean> {
+		try {
+			await oauthPage.bringToFront();
+		} catch {
+			// tab may be navigating
+		}
+
+		for (const frame of oauthPage.frames()) {
+			try {
+				const submit = await frame.$(Selectors.SC_SUBMIT_APPROVAL_BUTTON);
+				if (submit) {
+					await submit.click({ delay: 40 });
+					console.log('Droploud: clicked SoundCloud OAuth submit_approval');
+					return true;
+				}
+			} catch {
+				// frame detached / navigated
+			}
+		}
+
+		for (const frame of oauthPage.frames()) {
+			try {
+				const clicked = await frame.evaluate(() => {
+					const approve = Array.from(document.querySelectorAll('button')).find(
+						(btn) =>
+							/^(connect|allow|authorize|accept)$/i.test(
+								(btn.textContent || '').trim(),
+							) && !(btn as HTMLButtonElement).disabled,
+					) as HTMLButtonElement | undefined;
+					if (!approve) return null;
+					approve.click();
+					return (approve.textContent || '').trim();
+				});
+				if (clicked) {
+					console.log(`Droploud: clicked SoundCloud OAuth ${clicked}`);
+					return true;
+				}
+			} catch {
+				// frame detached / navigated
+			}
+		}
+
+		return false;
+	}
+
+	private async handleDownload(page: Page) {
+		this.emitProgress('downloading', 'Preparing Droploud download...', 75);
+
+		const client = await page.createCDPSession();
+		await client.send('Browser.setDownloadBehavior', {
+			behavior: 'allow',
+			downloadPath: './downloads',
+			eventsEnabled: true,
+		});
+
+		let downloadGuid: string | null = null;
+		let downloadCompleteResolve: (value: string) => void;
+		const downloadCompletePromise = new Promise<string>((resolve) => {
+			downloadCompleteResolve = resolve;
+		});
+
+		const pBar = new SingleBar(
+			{
+				format:
+					'{prefix} {bar} {percentage}% | {current_mb}/{total_mb} MB | ETA: {eta_formatted}',
+				hideCursor: true,
+			},
+			{
+				barCompleteChar: '█',
+				barIncompleteChar: '░',
+				format: Presets.shades_classic.format,
+			},
+		);
+
+		client.on('Browser.downloadWillBegin', (event) => {
+			downloadGuid = event.guid;
+			this.downloadFilename = event.suggestedFilename;
+			console.log('Download started:', this.downloadFilename);
+			this.emitProgress(
+				'downloading',
+				`Downloading ${this.downloadFilename}...`,
+				76,
+			);
+		});
+
+		client.on('Browser.downloadProgress', (event) => {
+			if (event.guid !== downloadGuid || !this.downloadFilename) return;
+			if (event.state === 'completed') {
+				pBar.stop();
+				console.log('Download completed');
+				this.emitProgress('downloading', 'Download complete', 85);
+				downloadCompleteResolve(this.downloadFilename);
+			} else if (event.state === 'inProgress') {
+				const { receivedBytes, totalBytes } = event;
+				if (pBar.isActive) {
+					pBar.update(receivedBytes, {
+						total_mb: Number((totalBytes / 1024 / 1024).toFixed(2)),
+						current_mb: Number((receivedBytes / 1024 / 1024).toFixed(2)),
+					});
+				} else {
+					pBar.start(totalBytes, receivedBytes, { prefix: 'Downloading' });
+				}
+				const downloadPercent = totalBytes > 0 ? receivedBytes / totalBytes : 0;
+				this.emitProgress(
+					'downloading',
+					`Downloading... ${(receivedBytes / 1024 / 1024).toFixed(1)} / ${(totalBytes / 1024 / 1024).toFixed(1)} MB`,
+					76 + downloadPercent * 8,
+					{ downloadBytes: receivedBytes, totalBytes },
+				);
+			} else if (event.state === 'canceled') {
+				pBar.stop();
+				throw new Error('Download was canceled');
+			}
+		});
+
+		const clickDownload = async () => {
+			const clicked = await page.evaluate((selector) => {
+				const buttons = Array.from(
+					document.querySelectorAll<HTMLButtonElement>(selector),
+				);
+				const download = buttons.find((btn) =>
+					/^(\s*)download(\s*)$/i.test((btn.textContent || '').trim()),
+				);
+				if (!download || download.disabled) return false;
+				download.click();
+				return true;
+			}, Selectors.DROPLOUD_DOWNLOAD_BUTTON);
+			if (!clicked) {
+				throw new Error('Droploud DOWNLOAD button not found');
+			}
+		};
+
+		setTimeout(async () => {
+			if (!downloadGuid) {
+				console.log(
+					'Download not started after 10 seconds, clicking button again...',
+				);
+				try {
+					await clickDownload();
+				} catch {
+					// ignore retry errors
+				}
+			}
+		}, 10_000);
+
+		await Promise.all([clickDownload(), downloadCompletePromise]);
+		await client.detach();
+	}
+}

--- a/src/gaterush.ts
+++ b/src/gaterush.ts
@@ -32,7 +32,7 @@ export class GaterushDownloader {
 	async initialize() {
 		this.browser = await launchAppBrowser({
 			headless: this.config.headless,
-			userDataDir: './browser-data',
+			userDataDir: this.config.userDataDir ?? './browser-data',
 		});
 
 		const browserContext = this.browser.defaultBrowserContext();
@@ -589,7 +589,7 @@ export class GaterushDownloader {
 			await page.click(Selectors.GATERUSH_DOWNLOAD_BUTTON);
 		};
 
-		setTimeout(async () => {
+		const retryTimer = setTimeout(async () => {
 			if (!downloadGuid) {
 				console.log(
 					'Download not started after 10 seconds, clicking button again...',
@@ -606,6 +606,7 @@ export class GaterushDownloader {
 			await Promise.all([clickDownload(), downloadCompletePromise]);
 		} finally {
 			clearTimeout(downloadTimer);
+			clearTimeout(retryTimer);
 			pBar.stop();
 			await client.detach().catch(() => {});
 		}

--- a/src/gaterush.ts
+++ b/src/gaterush.ts
@@ -418,7 +418,10 @@ export class GaterushDownloader {
 	}
 
 	private async handleInstagram(page: Page) {
-		while (true) {
+		const deadline = Date.now() + 120_000;
+		let previousIndex = -1;
+		let repeats = 0;
+		while (Date.now() < deadline) {
 			const nextIndex = await page.evaluate((selector) => {
 				const buttons = Array.from(
 					document.querySelectorAll<HTMLButtonElement>(selector),
@@ -430,6 +433,14 @@ export class GaterushDownloader {
 
 			if (nextIndex < 0) {
 				break;
+			}
+
+			repeats = nextIndex === previousIndex ? repeats + 1 : 0;
+			previousIndex = nextIndex;
+			if (repeats >= 3) {
+				throw new Error(
+					`GateRush Instagram step stalled on account button ${nextIndex}`,
+				);
 			}
 
 			const pagesBefore = new Set(await this.browser.pages(true));
@@ -477,6 +488,10 @@ export class GaterushDownloader {
 			await timeout(500);
 		}
 
+		if (Date.now() >= deadline) {
+			throw new Error('GateRush Instagram step timed out');
+		}
+
 		// Wait for IG step completion (server-side gate-step POST)
 		await page.waitForFunction(
 			() => {
@@ -503,9 +518,18 @@ export class GaterushDownloader {
 
 		let downloadGuid: string | null = null;
 		let downloadCompleteResolve: (value: string) => void;
-		const downloadCompletePromise = new Promise<string>((resolve) => {
+		let downloadCompleteReject: (reason: Error) => void;
+		const downloadCompletePromise = new Promise<string>((resolve, reject) => {
 			downloadCompleteResolve = resolve;
+			downloadCompleteReject = reject;
 		});
+		const downloadTimer = setTimeout(
+			() =>
+				downloadCompleteReject(
+					new Error('GateRush download did not complete in time'),
+				),
+			10 * 60_000,
+		);
 
 		const pBar = new SingleBar(
 			{
@@ -557,7 +581,7 @@ export class GaterushDownloader {
 				);
 			} else if (event.state === 'canceled') {
 				pBar.stop();
-				throw new Error('Download was canceled');
+				downloadCompleteReject(new Error('Download was canceled'));
 			}
 		});
 
@@ -578,7 +602,12 @@ export class GaterushDownloader {
 			}
 		}, 10_000);
 
-		await Promise.all([clickDownload(), downloadCompletePromise]);
-		await client.detach();
+		try {
+			await Promise.all([clickDownload(), downloadCompletePromise]);
+		} finally {
+			clearTimeout(downloadTimer);
+			pBar.stop();
+			await client.detach().catch(() => {});
+		}
 	}
 }

--- a/src/gaterush.ts
+++ b/src/gaterush.ts
@@ -1,0 +1,584 @@
+import { Presets, SingleBar } from 'cli-progress';
+import type { Browser, Page } from 'puppeteer';
+import { launchAppBrowser } from './browserLaunch';
+import type { ProgressCallback } from './hypeddit';
+import Selectors from './selectors';
+import type { HypedditConfig } from './types';
+import { loadCookies, timeout } from './utils';
+
+export class GaterushDownloader {
+	private browser!: Browser;
+	private downloadFilename: string | null = null;
+	private config: HypedditConfig;
+	private progressCallback: ProgressCallback | null = null;
+
+	constructor(config: HypedditConfig) {
+		this.config = config;
+	}
+
+	setProgressCallback(callback: ProgressCallback): void {
+		this.progressCallback = callback;
+	}
+
+	private emitProgress(
+		stage: Parameters<ProgressCallback>[0],
+		message: string,
+		percent: number,
+		extra?: Parameters<ProgressCallback>[3],
+	): void {
+		this.progressCallback?.(stage, message, percent, extra);
+	}
+
+	async initialize() {
+		this.browser = await launchAppBrowser({
+			headless: this.config.headless,
+			userDataDir: './browser-data',
+		});
+
+		const browserContext = this.browser.defaultBrowserContext();
+		const soundCloudCookies = await loadCookies('soundcloud-cookies.json');
+		await browserContext.setCookie(...soundCloudCookies);
+	}
+
+	async prepareLogins() {
+		const soundCloudPage = await this.browser.newPage();
+		soundCloudPage.setViewport({ width: 1920, height: 1080 });
+		await soundCloudPage.goto('https://soundcloud.com/messages');
+
+		try {
+			await soundCloudPage.waitForSelector(
+				Selectors.SOUNDCLOUD_CAPTCHA_CONTAINER,
+				{ timeout: 5_000 },
+			);
+			console.log(
+				'GateRush: SoundCloud captcha present during login warm-up; solve it in the browser window if needed.',
+			);
+			await soundCloudPage.waitForSelector(
+				Selectors.SOUNDCLOUD_CAPTCHA_CONTAINER,
+				{ hidden: true, timeout: 120_000 },
+			);
+		} catch {
+			// no captcha
+		}
+
+		await soundCloudPage.waitForSelector(Selectors.SOUNDCLOUD_LIBRARY_LINK, {
+			timeout: 30_000,
+		});
+		await Promise.all([
+			soundCloudPage.click(Selectors.SOUNDCLOUD_LIBRARY_LINK),
+			soundCloudPage.waitForNavigation({ waitUntil: 'domcontentloaded' }),
+		]);
+		await soundCloudPage.waitForFunction(() =>
+			window.location.href.includes('/you/library'),
+		);
+		await soundCloudPage.close();
+	}
+
+	async downloadAudio(url: string): Promise<string | null> {
+		console.log('Navigating to GateRush gate...');
+		this.emitProgress('handling_gates', 'Navigating to GateRush gate...', 25);
+
+		const page = await this.browser.newPage();
+		await page.setViewport({ width: 1920, height: 1080 });
+		await page.goto(url, { waitUntil: 'domcontentloaded' });
+		try {
+			await page.waitForNetworkIdle({ timeout: 15_000, idleTime: 10 });
+		} catch {
+			// continue
+		}
+
+		await this.dismissCookieBanner(page);
+
+		if (await page.$(Selectors.GATERUSH_EMAIL_FORM)) {
+			this.emitProgress('handling_gates', 'Submitting GateRush email...', 30, {
+				currentGate: 'email',
+			});
+			await this.handleEmail(page);
+		}
+
+		if (await page.$(Selectors.GATERUSH_SC_CONNECT)) {
+			this.emitProgress(
+				'handling_gates',
+				'Connecting SoundCloud on GateRush...',
+				45,
+				{ currentGate: 'sc' },
+			);
+			await this.handleSoundcloudConnect(page);
+		}
+
+		if (await page.$(Selectors.GATERUSH_IG_ACCOUNT_BUTTON)) {
+			this.emitProgress(
+				'handling_gates',
+				'Handling GateRush Instagram follows...',
+				60,
+				{ currentGate: 'ig' },
+			);
+			await this.handleInstagram(page);
+		}
+
+		await page.waitForFunction(
+			(selector) => {
+				const btn = document.querySelector<HTMLButtonElement>(selector);
+				return !!btn && !btn.disabled;
+			},
+			{ timeout: 60_000 },
+			Selectors.GATERUSH_DOWNLOAD_BUTTON,
+		);
+
+		await this.handleDownload(page);
+		await page.close();
+		return this.downloadFilename;
+	}
+
+	async close() {
+		await this.browser?.close();
+	}
+
+	private async dismissCookieBanner(page: Page) {
+		const accepted = await page.evaluate((selector) => {
+			const btn = document.querySelector<HTMLButtonElement>(selector);
+			if (!btn) return false;
+			btn.click();
+			return true;
+		}, Selectors.GATERUSH_COOKIE_ACCEPT);
+		if (accepted) {
+			await timeout(500);
+		}
+	}
+
+	private async handleEmail(page: Page) {
+		const fillInput = async (selector: string, value: string) => {
+			await page.evaluate(
+				(sel, val) => {
+					const el = document.querySelector<HTMLInputElement>(sel);
+					if (!el) return;
+					const setter = Object.getOwnPropertyDescriptor(
+						window.HTMLInputElement.prototype,
+						'value',
+					)?.set;
+					setter?.call(el, val);
+					el.dispatchEvent(new Event('input', { bubbles: true }));
+					el.dispatchEvent(new Event('change', { bubbles: true }));
+				},
+				selector,
+				value,
+			);
+		};
+
+		const nameInput = await page.$(Selectors.GATERUSH_NAME_INPUT);
+		if (nameInput) {
+			if (!this.config.name) {
+				throw new Error(
+					'This GateRush gate requires a name. Set HYPEDDIT_NAME in your .env file.',
+				);
+			}
+			await fillInput(Selectors.GATERUSH_NAME_INPUT, this.config.name);
+		}
+
+		const emailInput = await page.$(Selectors.GATERUSH_EMAIL_INPUT);
+		if (emailInput) {
+			if (!this.config.email) {
+				throw new Error(
+					'This GateRush gate requires an email. Set HYPEDDIT_EMAIL in your .env file.',
+				);
+			}
+			await fillInput(Selectors.GATERUSH_EMAIL_INPUT, this.config.email);
+		}
+
+		await page.click(Selectors.GATERUSH_EMAIL_SUBMIT);
+
+		await page.waitForFunction(
+			(selector) => {
+				const step = document.querySelector(
+					`.progress-step[data-action="email"]`,
+				);
+				if (step?.classList.contains('completed')) return true;
+				const btn = document.querySelector<HTMLButtonElement>(selector);
+				return !!btn && btn.textContent === 'SUBMIT' && !btn.disabled;
+			},
+			{ timeout: 30_000 },
+			Selectors.GATERUSH_EMAIL_SUBMIT,
+		);
+
+		const emailDone = await page.evaluate(
+			() =>
+				document
+					.querySelector('.progress-step[data-action="email"]')
+					?.classList.contains('completed') === true,
+		);
+		if (!emailDone) {
+			// SUBMIT returned to idle without completing — likely validation/API error
+			await timeout(1_000);
+			const stillIncomplete = await page.evaluate(
+				() =>
+					document
+						.querySelector('.progress-step[data-action="email"]')
+						?.classList.contains('completed') !== true,
+			);
+			if (stillIncomplete) {
+				throw new Error('GateRush email step did not complete');
+			}
+		}
+	}
+
+	private async handleSoundcloudConnect(page: Page) {
+		const commentForm = await page.$(Selectors.GATERUSH_COMMENT_FORM);
+		const commentInput = await page.$(Selectors.GATERUSH_COMMENT_INPUT);
+		if (commentForm && commentInput) {
+			if (!this.config.comment.trim()) {
+				throw new Error(
+					'SC_COMMENT is required for GateRush SoundCloud connect.',
+				);
+			}
+			await page.evaluate(
+				(selector, value) => {
+					const el = document.querySelector<HTMLInputElement>(selector);
+					if (!el) return;
+					const setter = Object.getOwnPropertyDescriptor(
+						window.HTMLInputElement.prototype,
+						'value',
+					)?.set;
+					setter?.call(el, value);
+					el.dispatchEvent(new Event('input', { bubbles: true }));
+					el.dispatchEvent(new Event('change', { bubbles: true }));
+				},
+				Selectors.GATERUSH_COMMENT_INPUT,
+				this.config.comment,
+			);
+			await timeout(200);
+		}
+
+		await page.waitForFunction(
+			(selector) => {
+				const btn = document.querySelector<HTMLButtonElement>(selector);
+				return !!btn && !btn.disabled;
+			},
+			{},
+			Selectors.GATERUSH_SC_CONNECT,
+		);
+
+		// Single DOM click — page.click() can double-fire under CloakBrowser humanize.
+		await page.evaluate((selector) => {
+			document.querySelector<HTMLButtonElement>(selector)?.click();
+		}, Selectors.GATERUSH_SC_CONNECT);
+
+		await this.completeSoundcloudOauth(page);
+
+		if (!page.url().includes('gaterush.me')) {
+			throw new Error(
+				'GateRush redirected this tab for SoundCloud OAuth (popup blocked). Re-run with popups allowed or non-headless.',
+			);
+		}
+
+		await page.waitForFunction(
+			() => {
+				const step = document.querySelector(
+					'.progress-step[data-action="soundcloud"]',
+				);
+				if (step?.classList.contains('completed')) return true;
+				const download =
+					document.querySelector<HTMLButtonElement>('#btnDownload');
+				return !!download && !download.disabled;
+			},
+			{ timeout: 90_000 },
+		);
+		await timeout(800);
+	}
+
+	/**
+	 * Wait for SoundCloud authorize + #submit_approval, approve it, then wait for
+	 * GateRush to mark the SoundCloud step complete. Never force-closes Allow.
+	 */
+	private async completeSoundcloudOauth(gatePage: Page) {
+		const deadline = Date.now() + 120_000;
+		let lastLog = 0;
+		let lastAllowAt = 0;
+
+		while (Date.now() < deadline) {
+			if (!gatePage.isClosed()) {
+				const gateDone = await gatePage
+					.evaluate(() => {
+						const step = document.querySelector(
+							'.progress-step[data-action="soundcloud"]',
+						);
+						return step?.classList.contains('completed') === true;
+					})
+					.catch(() => false);
+				if (gateDone) {
+					console.log('GateRush: SoundCloud step marked completed.');
+					return;
+				}
+			}
+
+			const authorizePage = await this.findAuthorizePageWithAllow();
+			if (authorizePage) {
+				// Retry Allow if the form is still up after a previous attempt.
+				const canRetry = Date.now() - lastAllowAt > 4_000;
+				if (lastAllowAt === 0 || canRetry) {
+					const method = await this.clickSoundcloudAllow(authorizePage);
+					console.log(
+						`GateRush: Allow → ${method} (${authorizePage.url().slice(0, 100)})`,
+					);
+					if (method !== 'miss') {
+						lastAllowAt = Date.now();
+						await timeout(2_000);
+						continue;
+					}
+				}
+			}
+
+			if (Date.now() - lastLog > 5_000) {
+				const urls = (await this.browser.pages(true)).map((p) =>
+					p.isClosed() ? '(closed)' : p.url(),
+				);
+				console.log('GateRush OAuth waiting…', urls.join(' | '));
+				lastLog = Date.now();
+			}
+
+			await timeout(400);
+		}
+
+		throw new Error(
+			'Timed out waiting for SoundCloud OAuth Allow / GateRush callback.',
+		);
+	}
+
+	/** Fresh handle for authorize tab that has visible #submit_approval. */
+	private async findAuthorizePageWithAllow(): Promise<Page | null> {
+		const pages = (await this.browser.pages(true)).filter((p) => !p.isClosed());
+
+		for (const candidate of [...pages].reverse()) {
+			if (!/secure\.soundcloud\.com\/authorize/i.test(candidate.url())) {
+				continue;
+			}
+			try {
+				for (const frame of candidate.frames()) {
+					const hasAllow = await frame.$(Selectors.SC_SUBMIT_APPROVAL_BUTTON);
+					if (hasAllow) {
+						await hasAllow.dispose().catch(() => {});
+						return candidate;
+					}
+				}
+			} catch {
+				// detached / navigating
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Live authorize HTML:
+	 * <form class="connect-form approve-authorize-form">
+	 *   <button type="submit" id="submit_approval">Allow</button>
+	 * </form>
+	 * CloakBrowser ignores plain DOM click() — prefer Puppeteer pointer click.
+	 */
+	private async clickSoundcloudAllow(oauthPage: Page): Promise<string> {
+		try {
+			await oauthPage.bringToFront();
+		} catch {
+			// ignore
+		}
+
+		for (const frame of oauthPage.frames()) {
+			try {
+				const submit = await frame.$(Selectors.SC_SUBMIT_APPROVAL_BUTTON);
+				if (!submit) continue;
+				await Promise.race([submit.click({ delay: 40 }), timeout(4_000)]);
+				await submit.dispose().catch(() => {});
+				return 'trusted-click';
+			} catch {
+				// frame detached / navigating
+			}
+		}
+
+		for (const frame of oauthPage.frames()) {
+			try {
+				const method = await frame.evaluate((selector) => {
+					const submit = document.querySelector(
+						selector,
+					) as HTMLButtonElement | null;
+					if (!submit) return null;
+					const form = submit.closest('form');
+					if (form && typeof form.requestSubmit === 'function') {
+						form.requestSubmit(submit);
+						return 'requestSubmit';
+					}
+					submit.click();
+					return 'dom-click';
+				}, Selectors.SC_SUBMIT_APPROVAL_BUTTON);
+				if (method) return method;
+			} catch {
+				// frame detached / navigating
+			}
+		}
+
+		return 'miss';
+	}
+
+	private async handleInstagram(page: Page) {
+		while (true) {
+			const nextIndex = await page.evaluate((selector) => {
+				const buttons = Array.from(
+					document.querySelectorAll<HTMLButtonElement>(selector),
+				);
+				return buttons.findIndex(
+					(btn) => !btn.disabled && !/opened|✓/i.test(btn.textContent || ''),
+				);
+			}, Selectors.GATERUSH_IG_ACCOUNT_BUTTON);
+
+			if (nextIndex < 0) {
+				break;
+			}
+
+			const pagesBefore = new Set(await this.browser.pages(true));
+
+			await page.evaluate(
+				(selector, index) => {
+					const buttons = Array.from(
+						document.querySelectorAll<HTMLButtonElement>(selector),
+					);
+					buttons[index]?.click();
+				},
+				Selectors.GATERUSH_IG_ACCOUNT_BUTTON,
+				nextIndex,
+			);
+
+			let popup: Page | undefined;
+			const started = Date.now();
+			while (!popup && Date.now() - started < 5_000) {
+				const pages = await this.browser.pages(true);
+				popup = pages.find(
+					(candidate) =>
+						candidate !== page &&
+						!pagesBefore.has(candidate) &&
+						candidate.url() !== 'about:blank',
+				);
+				if (!popup) {
+					popup = pages.find(
+						(candidate) =>
+							candidate !== page &&
+							!candidate.url().includes('gaterush.me') &&
+							candidate.url() !== 'about:blank',
+					);
+				}
+				if (!popup) await timeout(200);
+			}
+
+			if (popup && !popup.isClosed()) {
+				try {
+					await popup.close();
+				} catch {
+					// already closed
+				}
+			}
+
+			await timeout(500);
+		}
+
+		// Wait for IG step completion (server-side gate-step POST)
+		await page.waitForFunction(
+			() => {
+				const step = document.querySelector(
+					'.progress-step[data-action="instagram"]',
+				);
+				if (!step) return true;
+				return step.classList.contains('completed');
+			},
+			{ timeout: 30_000 },
+		);
+		await timeout(500);
+	}
+
+	private async handleDownload(page: Page) {
+		this.emitProgress('downloading', 'Preparing GateRush download...', 75);
+
+		const client = await page.createCDPSession();
+		await client.send('Browser.setDownloadBehavior', {
+			behavior: 'allow',
+			downloadPath: './downloads',
+			eventsEnabled: true,
+		});
+
+		let downloadGuid: string | null = null;
+		let downloadCompleteResolve: (value: string) => void;
+		const downloadCompletePromise = new Promise<string>((resolve) => {
+			downloadCompleteResolve = resolve;
+		});
+
+		const pBar = new SingleBar(
+			{
+				format:
+					'{prefix} {bar} {percentage}% | {current_mb}/{total_mb} MB | ETA: {eta_formatted}',
+				hideCursor: true,
+			},
+			{
+				barCompleteChar: '█',
+				barIncompleteChar: '░',
+				format: Presets.shades_classic.format,
+			},
+		);
+
+		client.on('Browser.downloadWillBegin', (event) => {
+			downloadGuid = event.guid;
+			this.downloadFilename = event.suggestedFilename;
+			console.log('Download started:', this.downloadFilename);
+			this.emitProgress(
+				'downloading',
+				`Downloading ${this.downloadFilename}...`,
+				76,
+			);
+		});
+
+		client.on('Browser.downloadProgress', (event) => {
+			if (event.guid !== downloadGuid || !this.downloadFilename) return;
+			if (event.state === 'completed') {
+				pBar.stop();
+				console.log('Download completed');
+				this.emitProgress('downloading', 'Download complete', 85);
+				downloadCompleteResolve(this.downloadFilename);
+			} else if (event.state === 'inProgress') {
+				const { receivedBytes, totalBytes } = event;
+				if (pBar.isActive) {
+					pBar.update(receivedBytes, {
+						total_mb: Number((totalBytes / 1024 / 1024).toFixed(2)),
+						current_mb: Number((receivedBytes / 1024 / 1024).toFixed(2)),
+					});
+				} else {
+					pBar.start(totalBytes, receivedBytes, { prefix: 'Downloading' });
+				}
+				const downloadPercent = totalBytes > 0 ? receivedBytes / totalBytes : 0;
+				this.emitProgress(
+					'downloading',
+					`Downloading... ${(receivedBytes / 1024 / 1024).toFixed(1)} / ${(totalBytes / 1024 / 1024).toFixed(1)} MB`,
+					76 + downloadPercent * 8,
+					{ downloadBytes: receivedBytes, totalBytes },
+				);
+			} else if (event.state === 'canceled') {
+				pBar.stop();
+				throw new Error('Download was canceled');
+			}
+		});
+
+		const clickDownload = async () => {
+			await page.click(Selectors.GATERUSH_DOWNLOAD_BUTTON);
+		};
+
+		setTimeout(async () => {
+			if (!downloadGuid) {
+				console.log(
+					'Download not started after 10 seconds, clicking button again...',
+				);
+				try {
+					await clickDownload();
+				} catch {
+					// ignore retry errors
+				}
+			}
+		}, 10_000);
+
+		await Promise.all([clickDownload(), downloadCompletePromise]);
+		await client.detach();
+	}
+}

--- a/src/hypeddit.ts
+++ b/src/hypeddit.ts
@@ -102,7 +102,7 @@ export class HypedditDownloader {
 	async initialize() {
 		this.browser = await launchAppBrowser({
 			headless: this.config.headless,
-			userDataDir: './browser-data',
+			userDataDir: this.config.userDataDir ?? './browser-data',
 		});
 
 		// Load and set cookies at browser context level to make them available to all pages

--- a/src/hypeddit.ts
+++ b/src/hypeddit.ts
@@ -1,5 +1,6 @@
 import { Presets, SingleBar } from 'cli-progress';
-import puppeteer, { type Browser, type Page } from 'puppeteer';
+import type { Browser, Page } from 'puppeteer';
+import { launchAppBrowser } from './browserLaunch';
 import Selectors from './selectors';
 import type { HypedditConfig, JobProgress, JobStage } from './types';
 import { loadCookies, REPO_URL, timeout } from './utils';
@@ -99,19 +100,9 @@ export class HypedditDownloader {
 	}
 
 	async initialize() {
-		this.browser = await puppeteer.launch({
+		this.browser = await launchAppBrowser({
 			headless: this.config.headless,
-			userDataDir: './browser-data', // persistent data directory for cookies/login
-			args: [
-				'--no-sandbox',
-				'--disable-setuid-sandbox',
-				'--mute-audio',
-				'--hide-crash-restore-bubble',
-				'--no-first-run',
-				'--no-default-browser-check',
-				'--disable-restore-session-state',
-				'--window-size=1920,1080',
-			],
+			userDataDir: './browser-data',
 		});
 
 		// Load and set cookies at browser context level to make them available to all pages
@@ -361,7 +352,17 @@ export class HypedditDownloader {
 		// not all email gates require entering a name
 		const emailNameInput = await page.$(Selectors.EMAIL_NAME_INPUT);
 		if (emailNameInput) {
+			if (!this.config.name) {
+				throw new Error(
+					'This Hypeddit gate requires a name. Set HYPEDDIT_NAME in your .env file.',
+				);
+			}
 			await page.type(Selectors.EMAIL_NAME_INPUT, this.config.name);
+		}
+		if (!this.config.email) {
+			throw new Error(
+				'This Hypeddit gate requires an email. Set HYPEDDIT_EMAIL in your .env file.',
+			);
 		}
 		await page.type(Selectors.EMAIL_ADDRESS_INPUT, this.config.email);
 		await nextButton.click();

--- a/src/hypedditHttp.ts
+++ b/src/hypedditHttp.ts
@@ -152,10 +152,16 @@ export class HypedditHttpDownloader {
 			});
 
 			if (gate.steps.includes('email')) {
+				if (!this.config.email) {
+					console.log(
+						'Browserless: email gate needs HYPEDDIT_EMAIL, falling back to browser',
+					);
+					return null;
+				}
 				await this.post('/verifyEmailAddress', finalUrl, {
 					validateEmailAddress: this.config.email,
 					fan_gate_id: gate.fanGateId,
-					email_name: this.config.name,
+					email_name: this.config.name ?? '',
 					adcode: '',
 					hypesource: '',
 				});
@@ -192,7 +198,7 @@ export class HypedditHttpDownloader {
 			page: 'nonsingle',
 			is_skippable: gate.isSkippable,
 			steps: gate.steps.join(','),
-			email: this.config.email,
+			email: this.config.email ?? '',
 			download_action: 'DOWNLOAD',
 			wrndk: gate.wrndk,
 			is_mobile: '',

--- a/src/hypedditHttp.ts
+++ b/src/hypedditHttp.ts
@@ -10,6 +10,14 @@ import type { HypedditConfig } from './types';
 // excluded so the caller falls back to the browser flow.
 const BROWSERLESS_STEPS = new Set(['email', 'sc', 'ig', 'tk', 'yt', 'fb']);
 
+/** Config errors must not fall through as "try the browser" — browser fails the same way. */
+export class BrowserlessConfigError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'BrowserlessConfigError';
+	}
+}
+
 const HYPEDDIT_ORIGIN = 'https://hypeddit.com';
 const USER_AGENT =
 	'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36';
@@ -137,6 +145,12 @@ export class HypedditHttpDownloader {
 				return null;
 			}
 
+			if (gate.steps.includes('email') && !this.config.email) {
+				throw new BrowserlessConfigError(
+					'This Hypeddit gate requires an email. Set HYPEDDIT_EMAIL in your .env file.',
+				);
+			}
+
 			console.log(
 				`Browserless: attempting HTTP download for gates [${gate.steps.join(', ')}]`,
 			);
@@ -152,14 +166,8 @@ export class HypedditHttpDownloader {
 			});
 
 			if (gate.steps.includes('email')) {
-				if (!this.config.email) {
-					console.log(
-						'Browserless: email gate needs HYPEDDIT_EMAIL, falling back to browser',
-					);
-					return null;
-				}
 				await this.post('/verifyEmailAddress', finalUrl, {
-					validateEmailAddress: this.config.email,
+					validateEmailAddress: this.config.email as string,
 					fan_gate_id: gate.fanGateId,
 					email_name: this.config.name ?? '',
 					adcode: '',
@@ -177,6 +185,9 @@ export class HypedditHttpDownloader {
 
 			return await this.saveFile(downloadUrl);
 		} catch (error) {
+			if (error instanceof BrowserlessConfigError) {
+				throw error;
+			}
 			console.log(
 				`Browserless attempt failed (${error instanceof Error ? error.message : 'unknown error'}), falling back to browser`,
 			);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,19 @@
 import { confirm, input } from '@inquirer/prompts';
 import { AudioProcessor } from './audioProcessor';
 import { loadConfig, saveConfig } from './config';
+import { DownloadgaterDownloader } from './downloadgater';
+import { DroploudDownloader } from './droploud';
+import { GaterushDownloader } from './gaterush';
 import { HypedditDownloader } from './hypeddit';
 import { HypedditHttpDownloader } from './hypedditHttp';
 import { SoundcloudClient } from './soundcloud';
-import { getFfmpegBin, getFfprobeBin, validateSoundcloudUrl } from './utils';
+import {
+	getFfmpegBin,
+	getFfprobeBin,
+	getGateProvider,
+	validateGateUrl,
+	validateSoundcloudUrl,
+} from './utils';
 
 try {
 	const ffmpegBin = await getFfmpegBin();
@@ -14,13 +23,14 @@ try {
 	if (!SC_COMMENT) {
 		throw new Error('SC_COMMENT is required. Please set it in your .env file.');
 	}
-	const HYPEDDIT_NAME = process.env.HYPEDDIT_NAME;
-	const HYPEDDIT_EMAIL = process.env.HYPEDDIT_EMAIL;
-	if (!HYPEDDIT_NAME || !HYPEDDIT_EMAIL) {
+	if (SC_COMMENT.trim().length < 2) {
 		throw new Error(
-			'HYPEDDIT_NAME and HYPEDDIT_EMAIL are required. Please set them in your .env file.',
+			'SC_COMMENT must be at least 2 characters (Droploud disables Connect otherwise).',
 		);
 	}
+	// Optional — only required when a gate actually asks for name/email.
+	const HYPEDDIT_NAME = process.env.HYPEDDIT_NAME;
+	const HYPEDDIT_EMAIL = process.env.HYPEDDIT_EMAIL;
 
 	const config = await loadConfig();
 
@@ -43,20 +53,23 @@ try {
 	const soundcloudClient = new SoundcloudClient();
 	const track = await soundcloudClient.getTrack(soundcloudUrl);
 
-	// try to find Hypeddit URL from soundcloud track
-	let hypedditUrl: string | null = await soundcloudClient.getHypedditURL(track);
+	let gate = await soundcloudClient.getGateURL(track);
+	let gateUrl = gate?.url ?? null;
 
-	// if no Hypeddit URL was found, prompt the user for it
-	if (!hypedditUrl) {
-		hypedditUrl = await input({
-			message: 'Enter the URL of the Hypeddit post',
-			validate: (value) => {
-				if (!value?.startsWith('https://hypeddit.com/')) {
-					return 'A valid Hypeddit URL is required';
-				}
-				return true;
-			},
+	if (!gateUrl) {
+		gateUrl = await input({
+			message:
+				'Enter the Hypeddit, Droploud, GateRush, or DownloadGater gate URL',
+			validate: validateGateUrl,
 		});
+		const provider = getGateProvider(gateUrl);
+		gate = provider ? { url: gateUrl, provider, type: 'purchase_url' } : null;
+	}
+
+	if (!gateUrl || !gate) {
+		throw new Error(
+			'A valid Hypeddit, Droploud, GateRush, or DownloadGater URL is required',
+		);
 	}
 
 	const headless = config
@@ -75,35 +88,78 @@ try {
 				default: false,
 			});
 
-	const hypedditConfig = {
+	const gateConfig = {
 		name: HYPEDDIT_NAME,
 		email: HYPEDDIT_EMAIL,
 		comment: SC_COMMENT,
 		headless,
 	};
 
-	// Fast path: gates that are purely client-side (email + social follow/like/
-	// repost buttons) can be satisfied with plain HTTP, skipping the browser.
-	const httpDownloader = new HypedditHttpDownloader(hypedditConfig);
-	let downloadFilename = await httpDownloader.tryDownload(hypedditUrl);
+	let downloadFilename: string | null = null;
 	let usedBrowser = false;
 
-	// Fall back to the browser for gates that need real verification (Spotify, ...).
-	if (!downloadFilename) {
+	if (gate.provider === 'droploud') {
 		usedBrowser = true;
-		const hypedditDownloader = new HypedditDownloader(hypedditConfig);
-		await hypedditDownloader.initialize();
-
+		const droploudDownloader = new DroploudDownloader(gateConfig);
+		await droploudDownloader.initialize();
 		if (initializeLogins) {
-			await hypedditDownloader.prepareLogins();
+			await droploudDownloader.prepareLogins();
 			if (config) {
 				await saveConfig({ ...config, initializeLogins: false });
 				console.log('✓ Updated config.json: initializeLogins set to false');
 			}
 		}
+		downloadFilename = await droploudDownloader.downloadAudio(gateUrl);
+		await droploudDownloader.close();
+	} else if (gate.provider === 'gaterush') {
+		usedBrowser = true;
+		const gaterushDownloader = new GaterushDownloader(gateConfig);
+		await gaterushDownloader.initialize();
+		if (initializeLogins) {
+			await gaterushDownloader.prepareLogins();
+			if (config) {
+				await saveConfig({ ...config, initializeLogins: false });
+				console.log('✓ Updated config.json: initializeLogins set to false');
+			}
+		}
+		downloadFilename = await gaterushDownloader.downloadAudio(gateUrl);
+		await gaterushDownloader.close();
+	} else if (gate.provider === 'downloadgater') {
+		usedBrowser = true;
+		const downloadgaterDownloader = new DownloadgaterDownloader(gateConfig);
+		await downloadgaterDownloader.initialize();
+		if (initializeLogins) {
+			await downloadgaterDownloader.prepareLogins();
+			if (config) {
+				await saveConfig({ ...config, initializeLogins: false });
+				console.log('✓ Updated config.json: initializeLogins set to false');
+			}
+		}
+		downloadFilename = await downloadgaterDownloader.downloadAudio(gateUrl);
+		await downloadgaterDownloader.close();
+	} else {
+		// Fast path: gates that are purely client-side (email + social follow/like/
+		// repost buttons) can be satisfied with plain HTTP, skipping the browser.
+		const httpDownloader = new HypedditHttpDownloader(gateConfig);
+		downloadFilename = await httpDownloader.tryDownload(gateUrl);
 
-		downloadFilename = await hypedditDownloader.downloadAudio(hypedditUrl);
-		await hypedditDownloader.close();
+		// Fall back to the browser for gates that need real verification (Spotify, ...).
+		if (!downloadFilename) {
+			usedBrowser = true;
+			const hypedditDownloader = new HypedditDownloader(gateConfig);
+			await hypedditDownloader.initialize();
+
+			if (initializeLogins) {
+				await hypedditDownloader.prepareLogins();
+				if (config) {
+					await saveConfig({ ...config, initializeLogins: false });
+					console.log('✓ Updated config.json: initializeLogins set to false');
+				}
+			}
+
+			downloadFilename = await hypedditDownloader.downloadAudio(gateUrl);
+			await hypedditDownloader.close();
+		}
 	}
 
 	// The browserless path never touches the SoundCloud account (it only declares

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,42 +101,51 @@ try {
 	if (gate.provider === 'droploud') {
 		usedBrowser = true;
 		const droploudDownloader = new DroploudDownloader(gateConfig);
-		await droploudDownloader.initialize();
-		if (initializeLogins) {
-			await droploudDownloader.prepareLogins();
-			if (config) {
-				await saveConfig({ ...config, initializeLogins: false });
-				console.log('✓ Updated config.json: initializeLogins set to false');
+		try {
+			await droploudDownloader.initialize();
+			if (initializeLogins) {
+				await droploudDownloader.prepareLogins();
+				if (config) {
+					await saveConfig({ ...config, initializeLogins: false });
+					console.log('✓ Updated config.json: initializeLogins set to false');
+				}
 			}
+			downloadFilename = await droploudDownloader.downloadAudio(gateUrl);
+		} finally {
+			await droploudDownloader.close();
 		}
-		downloadFilename = await droploudDownloader.downloadAudio(gateUrl);
-		await droploudDownloader.close();
 	} else if (gate.provider === 'gaterush') {
 		usedBrowser = true;
 		const gaterushDownloader = new GaterushDownloader(gateConfig);
-		await gaterushDownloader.initialize();
-		if (initializeLogins) {
-			await gaterushDownloader.prepareLogins();
-			if (config) {
-				await saveConfig({ ...config, initializeLogins: false });
-				console.log('✓ Updated config.json: initializeLogins set to false');
+		try {
+			await gaterushDownloader.initialize();
+			if (initializeLogins) {
+				await gaterushDownloader.prepareLogins();
+				if (config) {
+					await saveConfig({ ...config, initializeLogins: false });
+					console.log('✓ Updated config.json: initializeLogins set to false');
+				}
 			}
+			downloadFilename = await gaterushDownloader.downloadAudio(gateUrl);
+		} finally {
+			await gaterushDownloader.close();
 		}
-		downloadFilename = await gaterushDownloader.downloadAudio(gateUrl);
-		await gaterushDownloader.close();
 	} else if (gate.provider === 'downloadgater') {
 		usedBrowser = true;
 		const downloadgaterDownloader = new DownloadgaterDownloader(gateConfig);
-		await downloadgaterDownloader.initialize();
-		if (initializeLogins) {
-			await downloadgaterDownloader.prepareLogins();
-			if (config) {
-				await saveConfig({ ...config, initializeLogins: false });
-				console.log('✓ Updated config.json: initializeLogins set to false');
+		try {
+			await downloadgaterDownloader.initialize();
+			if (initializeLogins) {
+				await downloadgaterDownloader.prepareLogins();
+				if (config) {
+					await saveConfig({ ...config, initializeLogins: false });
+					console.log('✓ Updated config.json: initializeLogins set to false');
+				}
 			}
+			downloadFilename = await downloadgaterDownloader.downloadAudio(gateUrl);
+		} finally {
+			await downloadgaterDownloader.close();
 		}
-		downloadFilename = await downloadgaterDownloader.downloadAudio(gateUrl);
-		await downloadgaterDownloader.close();
 	} else {
 		// Fast path: gates that are purely client-side (email + social follow/like/
 		// repost buttons) can be satisfied with plain HTTP, skipping the browser.
@@ -147,18 +156,21 @@ try {
 		if (!downloadFilename) {
 			usedBrowser = true;
 			const hypedditDownloader = new HypedditDownloader(gateConfig);
-			await hypedditDownloader.initialize();
+			try {
+				await hypedditDownloader.initialize();
 
-			if (initializeLogins) {
-				await hypedditDownloader.prepareLogins();
-				if (config) {
-					await saveConfig({ ...config, initializeLogins: false });
-					console.log('✓ Updated config.json: initializeLogins set to false');
+				if (initializeLogins) {
+					await hypedditDownloader.prepareLogins();
+					if (config) {
+						await saveConfig({ ...config, initializeLogins: false });
+						console.log('✓ Updated config.json: initializeLogins set to false');
+					}
 				}
-			}
 
-			downloadFilename = await hypedditDownloader.downloadAudio(gateUrl);
-			await hypedditDownloader.close();
+				downloadFilename = await hypedditDownloader.downloadAudio(gateUrl);
+			} finally {
+				await hypedditDownloader.close();
+			}
 		}
 	}
 

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -63,6 +63,38 @@ const SP_AUTH_ACCEPT_BUTTON = '[data-testid="auth-accept"]';
 // Download gate
 const DW_DOWNLOAD_BUTTON = '#gateDownloadButton';
 
+// Droploud gate
+const DROPLOUD_FREE_DOWNLOAD_BUTTON = '.ds-free-dl.dtr-card-cta';
+const DROPLOUD_STEP_PANE = '.dtr-card-pane-step';
+const DROPLOUD_OPEN_LINK_BUTTONS = '.dtr-open-grid .ds-btn';
+const DROPLOUD_CONFIRM_BUTTON = 'button.dtr-confirm-btn';
+const DROPLOUD_SC_COMMENT_INPUT = '#dtr-sc-comment-input';
+const DROPLOUD_UNLOCKED_TITLE = '.dtr-card-title';
+const DROPLOUD_DOWNLOAD_BUTTON = '.ds-free-dl.dtr-card-cta';
+const DROPLOUD_EMAIL_WRAP = '.dtr-email-wrap';
+const DROPLOUD_EMAIL_INPUT = '.dtr-email-wrap input[type="email"]';
+const DROPLOUD_EMAIL_CONSENT = '.dtr-email-wrap input[type="checkbox"]';
+const DROPLOUD_DLFOLLOW_WRAP = '.dtr-dlfollow-wrap';
+const DROPLOUD_DLFOLLOW_SKIP = 'button.dtr-dlfollow-skip';
+const DROPLOUD_DISCLAIMER_CHECK = '.dtr-social-wrap input[type="checkbox"]';
+
+// GateRush gate
+const GATERUSH_COOKIE_ACCEPT = '#acceptAllBtn';
+const GATERUSH_EMAIL_FORM = '#emailForm';
+const GATERUSH_NAME_INPUT = '#nameInput';
+const GATERUSH_EMAIL_INPUT = '#emailInput';
+const GATERUSH_EMAIL_SUBMIT = '#btnSaveEmail';
+const GATERUSH_COMMENT_FORM = '#commentForm';
+const GATERUSH_COMMENT_INPUT = '#commentInput';
+const GATERUSH_SC_CONNECT = '#btnSoundCloudConnect';
+const GATERUSH_IG_ACCOUNT_BUTTON = '.btnIgAccount';
+const GATERUSH_DOWNLOAD_BUTTON = '#btnDownload';
+const GATERUSH_PROGRESS_STEP = '.progress-step';
+
+// DownloadGater gate
+const DOWNLOADGATER_FREE_DOWNLOAD = 'button.download-button';
+const DOWNLOADGATER_DOWNLOAD_FILE = 'button.download-button';
+
 export default {
 	SOUNDCLOUD_LIBRARY_LINK,
 	SOUNDCLOUD_CAPTCHA_CONTAINER,
@@ -104,4 +136,30 @@ export default {
 	SP_LOGIN_BUTTON,
 	SP_AUTH_ACCEPT_BUTTON,
 	DW_DOWNLOAD_BUTTON,
+	DROPLOUD_FREE_DOWNLOAD_BUTTON,
+	DROPLOUD_STEP_PANE,
+	DROPLOUD_OPEN_LINK_BUTTONS,
+	DROPLOUD_CONFIRM_BUTTON,
+	DROPLOUD_SC_COMMENT_INPUT,
+	DROPLOUD_UNLOCKED_TITLE,
+	DROPLOUD_DOWNLOAD_BUTTON,
+	DROPLOUD_EMAIL_WRAP,
+	DROPLOUD_EMAIL_INPUT,
+	DROPLOUD_EMAIL_CONSENT,
+	DROPLOUD_DLFOLLOW_WRAP,
+	DROPLOUD_DLFOLLOW_SKIP,
+	DROPLOUD_DISCLAIMER_CHECK,
+	GATERUSH_COOKIE_ACCEPT,
+	GATERUSH_EMAIL_FORM,
+	GATERUSH_NAME_INPUT,
+	GATERUSH_EMAIL_INPUT,
+	GATERUSH_EMAIL_SUBMIT,
+	GATERUSH_COMMENT_FORM,
+	GATERUSH_COMMENT_INPUT,
+	GATERUSH_SC_CONNECT,
+	GATERUSH_IG_ACCOUNT_BUTTON,
+	GATERUSH_DOWNLOAD_BUTTON,
+	GATERUSH_PROGRESS_STEP,
+	DOWNLOADGATER_FREE_DOWNLOAD,
+	DOWNLOADGATER_DOWNLOAD_FILE,
 } as const;

--- a/src/server.ts
+++ b/src/server.ts
@@ -55,23 +55,34 @@ type AnyDownloader = {
 const activeDownloaders = new Map<string, AnyDownloader>();
 /** Job-scoped Chromium profiles under ./browser-data/jobs/<jobId>. */
 const jobProfileDirs = new Map<string, string>();
+/** In-flight close+profile cleanup so SIGINT cannot delete a profile mid-close. */
+const closingJobs = new Map<string, Promise<void>>();
 
 async function closeJobDownloader(jobId: string): Promise<void> {
-	const downloader = activeDownloaders.get(jobId);
-	if (downloader) {
-		activeDownloaders.delete(jobId);
-		await downloader.close().catch(() => {});
-	}
+	const existing = closingJobs.get(jobId);
+	if (existing) return existing;
 
+	const downloader = activeDownloaders.get(jobId);
 	const profileDir = jobProfileDirs.get(jobId);
-	if (profileDir) {
-		jobProfileDirs.delete(jobId);
-		await rm(profileDir, { recursive: true, force: true }).catch(() => {});
-	}
+	activeDownloaders.delete(jobId);
+	jobProfileDirs.delete(jobId);
+
+	const closing = (async () => {
+		await downloader?.close().catch(() => {});
+		if (profileDir) {
+			await rm(profileDir, { recursive: true, force: true }).catch(() => {});
+		}
+	})();
+	closingJobs.set(jobId, closing);
+	await closing.finally(() => closingJobs.delete(jobId));
 }
 
 async function closeAllDownloaders(): Promise<void> {
-	const ids = new Set([...activeDownloaders.keys(), ...jobProfileDirs.keys()]);
+	const ids = new Set([
+		...activeDownloaders.keys(),
+		...jobProfileDirs.keys(),
+		...closingJobs.keys(),
+	]);
 	await Promise.all([...ids].map((id) => closeJobDownloader(id)));
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -46,10 +46,24 @@ const HYPEDDIT_EMAIL = getOptionalEnv('HYPEDDIT_EMAIL');
 const soundcloudClient = new SoundcloudClient();
 const audioProcessor = new AudioProcessor(ffmpegBin, ffprobeBin);
 
-let hypedditDownloader: HypedditDownloader | null = null;
-let droploudDownloader: DroploudDownloader | null = null;
-let gaterushDownloader: GaterushDownloader | null = null;
-let downloadgaterDownloader: DownloadgaterDownloader | null = null;
+type AnyDownloader = {
+	close(): Promise<void>;
+};
+
+/** Per-job browser handles so concurrent jobs cannot close each other. */
+const activeDownloaders = new Map<string, AnyDownloader>();
+
+async function closeJobDownloader(jobId: string): Promise<void> {
+	const downloader = activeDownloaders.get(jobId);
+	if (!downloader) return;
+	activeDownloaders.delete(jobId);
+	await downloader.close().catch(() => {});
+}
+
+async function closeAllDownloaders(): Promise<void> {
+	const ids = [...activeDownloaders.keys()];
+	await Promise.all(ids.map((id) => closeJobDownloader(id)));
+}
 
 function serializeTrack(track: SoundcloudTrack): Job['track'] {
 	return {
@@ -109,7 +123,8 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 				'Launching browser for Droploud...',
 				10,
 			);
-			droploudDownloader = new DroploudDownloader(gateConfig);
+			const droploudDownloader = new DroploudDownloader(gateConfig);
+			activeDownloaders.set(jobId, droploudDownloader);
 			droploudDownloader.setProgressCallback(emitProgress);
 			await droploudDownloader.initialize();
 			jobStore.updateProgress(
@@ -119,8 +134,7 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 				25,
 			);
 			downloadFilename = await droploudDownloader.downloadAudio(gateUrl);
-			await droploudDownloader.close();
-			droploudDownloader = null;
+			await closeJobDownloader(jobId);
 		} else if (provider === 'gaterush') {
 			jobStore.updateProgress(
 				jobId,
@@ -128,7 +142,8 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 				'Launching browser for GateRush...',
 				10,
 			);
-			gaterushDownloader = new GaterushDownloader(gateConfig);
+			const gaterushDownloader = new GaterushDownloader(gateConfig);
+			activeDownloaders.set(jobId, gaterushDownloader);
 			gaterushDownloader.setProgressCallback(emitProgress);
 			await gaterushDownloader.initialize();
 			jobStore.updateProgress(
@@ -138,8 +153,7 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 				25,
 			);
 			downloadFilename = await gaterushDownloader.downloadAudio(gateUrl);
-			await gaterushDownloader.close();
-			gaterushDownloader = null;
+			await closeJobDownloader(jobId);
 		} else if (provider === 'downloadgater') {
 			jobStore.updateProgress(
 				jobId,
@@ -147,7 +161,8 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 				'Launching browser for DownloadGater...',
 				10,
 			);
-			downloadgaterDownloader = new DownloadgaterDownloader(gateConfig);
+			const downloadgaterDownloader = new DownloadgaterDownloader(gateConfig);
+			activeDownloaders.set(jobId, downloadgaterDownloader);
 			downloadgaterDownloader.setProgressCallback(emitProgress);
 			await downloadgaterDownloader.initialize();
 			jobStore.updateProgress(
@@ -157,8 +172,7 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 				25,
 			);
 			downloadFilename = await downloadgaterDownloader.downloadAudio(gateUrl);
-			await downloadgaterDownloader.close();
-			downloadgaterDownloader = null;
+			await closeJobDownloader(jobId);
 		} else {
 			// Fast path: gates that are purely client-side (email + social follow/like/
 			// repost buttons) can be satisfied with plain HTTP, skipping the browser.
@@ -183,7 +197,8 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 					10,
 				);
 
-				hypedditDownloader = new HypedditDownloader(gateConfig);
+				const hypedditDownloader = new HypedditDownloader(gateConfig);
+				activeDownloaders.set(jobId, hypedditDownloader);
 				hypedditDownloader.setProgressCallback(emitProgress);
 				await hypedditDownloader.initialize();
 
@@ -195,8 +210,7 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 				);
 
 				downloadFilename = await hypedditDownloader.downloadAudio(gateUrl);
-				await hypedditDownloader.close();
-				hypedditDownloader = null;
+				await closeJobDownloader(jobId);
 			}
 		}
 
@@ -225,22 +239,7 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 
 		jobStore.updateProgress(jobId, 'ready', 'Ready for metadata editing', 100);
 	} catch (error) {
-		if (hypedditDownloader) {
-			await hypedditDownloader.close();
-			hypedditDownloader = null;
-		}
-		if (droploudDownloader) {
-			await droploudDownloader.close();
-			droploudDownloader = null;
-		}
-		if (gaterushDownloader) {
-			await gaterushDownloader.close();
-			gaterushDownloader = null;
-		}
-		if (downloadgaterDownloader) {
-			await downloadgaterDownloader.close();
-			downloadgaterDownloader = null;
-		}
+		await closeJobDownloader(jobId);
 		const message =
 			error instanceof Error ? error.message : 'Unknown error occurred';
 		jobStore.setError(jobId, message);
@@ -747,22 +746,7 @@ const server = Bun.serve({
 	},
 	error: async (err) => {
 		console.error('Server error:', err);
-		if (hypedditDownloader) {
-			await hypedditDownloader.close();
-			hypedditDownloader = null;
-		}
-		if (droploudDownloader) {
-			await droploudDownloader.close();
-			droploudDownloader = null;
-		}
-		if (gaterushDownloader) {
-			await gaterushDownloader.close();
-			gaterushDownloader = null;
-		}
-		if (downloadgaterDownloader) {
-			await downloadgaterDownloader.close();
-			downloadgaterDownloader = null;
-		}
+		await closeAllDownloaders();
 		return jsonResponse({ error: 'Internal Server Error' }, { status: 500 });
 	},
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,4 @@
+import { rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { SoundcloudTrack } from 'soundcloud.ts';
 import { AudioProcessor } from './audioProcessor';
@@ -52,17 +53,26 @@ type AnyDownloader = {
 
 /** Per-job browser handles so concurrent jobs cannot close each other. */
 const activeDownloaders = new Map<string, AnyDownloader>();
+/** Job-scoped Chromium profiles under ./browser-data/jobs/<jobId>. */
+const jobProfileDirs = new Map<string, string>();
 
 async function closeJobDownloader(jobId: string): Promise<void> {
 	const downloader = activeDownloaders.get(jobId);
-	if (!downloader) return;
-	activeDownloaders.delete(jobId);
-	await downloader.close().catch(() => {});
+	if (downloader) {
+		activeDownloaders.delete(jobId);
+		await downloader.close().catch(() => {});
+	}
+
+	const profileDir = jobProfileDirs.get(jobId);
+	if (profileDir) {
+		jobProfileDirs.delete(jobId);
+		await rm(profileDir, { recursive: true, force: true }).catch(() => {});
+	}
 }
 
 async function closeAllDownloaders(): Promise<void> {
-	const ids = [...activeDownloaders.keys()];
-	await Promise.all(ids.map((id) => closeJobDownloader(id)));
+	const ids = new Set([...activeDownloaders.keys(), ...jobProfileDirs.keys()]);
+	await Promise.all([...ids].map((id) => closeJobDownloader(id)));
 }
 
 function serializeTrack(track: SoundcloudTrack): Job['track'] {
@@ -107,11 +117,13 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 
 		// CloakBrowser + DataDome: headed is more reliable (captcha reuses main session).
 		const headless = process.env.BROWSER_HEADLESS === 'true';
+		const userDataDir = join('./browser-data', 'jobs', jobId);
 		const gateConfig = {
 			name: HYPEDDIT_NAME,
 			email: HYPEDDIT_EMAIL,
 			comment: SC_COMMENT,
 			headless,
+			userDataDir,
 		};
 
 		let downloadFilename: string | null = null;
@@ -124,6 +136,7 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 				10,
 			);
 			const droploudDownloader = new DroploudDownloader(gateConfig);
+			jobProfileDirs.set(jobId, userDataDir);
 			activeDownloaders.set(jobId, droploudDownloader);
 			droploudDownloader.setProgressCallback(emitProgress);
 			await droploudDownloader.initialize();
@@ -143,6 +156,7 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 				10,
 			);
 			const gaterushDownloader = new GaterushDownloader(gateConfig);
+			jobProfileDirs.set(jobId, userDataDir);
 			activeDownloaders.set(jobId, gaterushDownloader);
 			gaterushDownloader.setProgressCallback(emitProgress);
 			await gaterushDownloader.initialize();
@@ -162,6 +176,7 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 				10,
 			);
 			const downloadgaterDownloader = new DownloadgaterDownloader(gateConfig);
+			jobProfileDirs.set(jobId, userDataDir);
 			activeDownloaders.set(jobId, downloadgaterDownloader);
 			downloadgaterDownloader.setProgressCallback(emitProgress);
 			await downloadgaterDownloader.initialize();
@@ -198,6 +213,7 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 				);
 
 				const hypedditDownloader = new HypedditDownloader(gateConfig);
+				jobProfileDirs.set(jobId, userDataDir);
 				activeDownloaders.set(jobId, hypedditDownloader);
 				hypedditDownloader.setProgressCallback(emitProgress);
 				await hypedditDownloader.initialize();
@@ -746,9 +762,24 @@ const server = Bun.serve({
 	},
 	error: async (err) => {
 		console.error('Server error:', err);
-		await closeAllDownloaders();
 		return jsonResponse({ error: 'Internal Server Error' }, { status: 500 });
 	},
+});
+
+let shuttingDown = false;
+async function shutdown(signal: string): Promise<void> {
+	if (shuttingDown) return;
+	shuttingDown = true;
+	console.log(`Received ${signal}, closing active browsers...`);
+	await closeAllDownloaders();
+	process.exit(0);
+}
+
+process.on('SIGINT', () => {
+	void shutdown('SIGINT');
+});
+process.on('SIGTERM', () => {
+	void shutdown('SIGTERM');
 });
 
 console.log(`Server is running on ${server.url}`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,17 +1,21 @@
 import { join } from 'node:path';
 import type { SoundcloudTrack } from 'soundcloud.ts';
 import { AudioProcessor } from './audioProcessor';
+import { DownloadgaterDownloader } from './downloadgater';
+import { DroploudDownloader } from './droploud';
+import { GaterushDownloader } from './gaterush';
 import { HypedditDownloader } from './hypeddit';
 import { HypedditHttpDownloader } from './hypedditHttp';
 import { jobStore } from './jobStore';
 import { SoundcloudClient } from './soundcloud';
 import type { Job, Metadata } from './types';
 import {
-	extractHypedditUrl,
+	extractGateUrl,
 	getDefaultMetadata,
 	getFfmpegBin,
 	getFfprobeBin,
-	validateHypedditUrl,
+	getGateProvider,
+	validateGateUrl,
 	validateSoundcloudUrl,
 } from './utils';
 
@@ -26,14 +30,26 @@ function getRequiredEnv(name: string): string {
 	return value;
 }
 
+function getOptionalEnv(name: string): string | undefined {
+	return process.env[name] || undefined;
+}
+
 const SC_COMMENT = getRequiredEnv('SC_COMMENT');
-const HYPEDDIT_NAME = getRequiredEnv('HYPEDDIT_NAME');
-const HYPEDDIT_EMAIL = getRequiredEnv('HYPEDDIT_EMAIL');
+if (SC_COMMENT.trim().length < 2) {
+	throw new Error(
+		'SC_COMMENT must be at least 2 characters (Droploud disables Connect otherwise).',
+	);
+}
+const HYPEDDIT_NAME = getOptionalEnv('HYPEDDIT_NAME');
+const HYPEDDIT_EMAIL = getOptionalEnv('HYPEDDIT_EMAIL');
 
 const soundcloudClient = new SoundcloudClient();
 const audioProcessor = new AudioProcessor(ffmpegBin, ffprobeBin);
 
 let hypedditDownloader: HypedditDownloader | null = null;
+let droploudDownloader: DroploudDownloader | null = null;
+let gaterushDownloader: GaterushDownloader | null = null;
+let downloadgaterDownloader: DownloadgaterDownloader | null = null;
 
 function serializeTrack(track: SoundcloudTrack): Job['track'] {
 	return {
@@ -60,6 +76,13 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 	const job = jobStore.get(jobId);
 	if (!job?.hypedditUrl) return;
 
+	const gateUrl = job.hypedditUrl;
+	const provider = getGateProvider(gateUrl);
+	if (!provider) {
+		jobStore.setError(jobId, 'Unsupported gate URL');
+		return;
+	}
+
 	try {
 		const emitProgress = (
 			stage: Job['progress']['stage'],
@@ -68,57 +91,113 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 			extra?: Partial<Job['progress']>,
 		) => jobStore.updateProgress(jobId, stage, message, percent, extra);
 
-		// Fast path: gates that are purely client-side (email + social follow/like/
-		// repost buttons) can be satisfied with plain HTTP, skipping the browser.
-		jobStore.updateProgress(
-			jobId,
-			'handling_gates',
-			'Trying browserless download...',
-			15,
-		);
-		const httpDownloader = new HypedditHttpDownloader(
-			{
-				name: HYPEDDIT_NAME,
-				email: HYPEDDIT_EMAIL,
-				comment: SC_COMMENT,
-				headless: true,
-			},
-			emitProgress,
-		);
-		let downloadFilename = await httpDownloader.tryDownload(job.hypedditUrl);
+		// CloakBrowser + DataDome: headed is more reliable (captcha reuses main session).
+		const headless = process.env.BROWSER_HEADLESS === 'true';
+		const gateConfig = {
+			name: HYPEDDIT_NAME,
+			email: HYPEDDIT_EMAIL,
+			comment: SC_COMMENT,
+			headless,
+		};
 
-		// Fall back to the browser for gates that need real verification (Spotify, ...).
-		if (!downloadFilename) {
+		let downloadFilename: string | null = null;
+
+		if (provider === 'droploud') {
 			jobStore.updateProgress(
 				jobId,
 				'initializing_browser',
-				'Launching browser...',
+				'Launching browser for Droploud...',
 				10,
 			);
-
-			hypedditDownloader = new HypedditDownloader({
-				name: HYPEDDIT_NAME,
-				email: HYPEDDIT_EMAIL,
-				comment: SC_COMMENT,
-				headless: true,
-			});
-
-			hypedditDownloader.setProgressCallback(emitProgress);
-
-			await hypedditDownloader.initialize();
-
+			droploudDownloader = new DroploudDownloader(gateConfig);
+			droploudDownloader.setProgressCallback(emitProgress);
+			await droploudDownloader.initialize();
 			jobStore.updateProgress(
 				jobId,
 				'handling_gates',
-				'Processing Hypeddit gates...',
+				'Processing Droploud gates...',
 				25,
 			);
-
-			downloadFilename = await hypedditDownloader.downloadAudio(
-				job.hypedditUrl,
+			downloadFilename = await droploudDownloader.downloadAudio(gateUrl);
+			await droploudDownloader.close();
+			droploudDownloader = null;
+		} else if (provider === 'gaterush') {
+			jobStore.updateProgress(
+				jobId,
+				'initializing_browser',
+				'Launching browser for GateRush...',
+				10,
 			);
-			await hypedditDownloader.close();
-			hypedditDownloader = null;
+			gaterushDownloader = new GaterushDownloader(gateConfig);
+			gaterushDownloader.setProgressCallback(emitProgress);
+			await gaterushDownloader.initialize();
+			jobStore.updateProgress(
+				jobId,
+				'handling_gates',
+				'Processing GateRush gates...',
+				25,
+			);
+			downloadFilename = await gaterushDownloader.downloadAudio(gateUrl);
+			await gaterushDownloader.close();
+			gaterushDownloader = null;
+		} else if (provider === 'downloadgater') {
+			jobStore.updateProgress(
+				jobId,
+				'initializing_browser',
+				'Launching browser for DownloadGater...',
+				10,
+			);
+			downloadgaterDownloader = new DownloadgaterDownloader(gateConfig);
+			downloadgaterDownloader.setProgressCallback(emitProgress);
+			await downloadgaterDownloader.initialize();
+			jobStore.updateProgress(
+				jobId,
+				'handling_gates',
+				'Processing DownloadGater gates...',
+				25,
+			);
+			downloadFilename = await downloadgaterDownloader.downloadAudio(gateUrl);
+			await downloadgaterDownloader.close();
+			downloadgaterDownloader = null;
+		} else {
+			// Fast path: gates that are purely client-side (email + social follow/like/
+			// repost buttons) can be satisfied with plain HTTP, skipping the browser.
+			jobStore.updateProgress(
+				jobId,
+				'handling_gates',
+				'Trying browserless download...',
+				15,
+			);
+			const httpDownloader = new HypedditHttpDownloader(
+				gateConfig,
+				emitProgress,
+			);
+			downloadFilename = await httpDownloader.tryDownload(gateUrl);
+
+			// Fall back to the browser for gates that need real verification (Spotify, ...).
+			if (!downloadFilename) {
+				jobStore.updateProgress(
+					jobId,
+					'initializing_browser',
+					'Launching browser...',
+					10,
+				);
+
+				hypedditDownloader = new HypedditDownloader(gateConfig);
+				hypedditDownloader.setProgressCallback(emitProgress);
+				await hypedditDownloader.initialize();
+
+				jobStore.updateProgress(
+					jobId,
+					'handling_gates',
+					'Processing Hypeddit gates...',
+					25,
+				);
+
+				downloadFilename = await hypedditDownloader.downloadAudio(gateUrl);
+				await hypedditDownloader.close();
+				hypedditDownloader = null;
+			}
 		}
 
 		if (!downloadFilename) {
@@ -149,6 +228,18 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 		if (hypedditDownloader) {
 			await hypedditDownloader.close();
 			hypedditDownloader = null;
+		}
+		if (droploudDownloader) {
+			await droploudDownloader.close();
+			droploudDownloader = null;
+		}
+		if (gaterushDownloader) {
+			await gaterushDownloader.close();
+			gaterushDownloader = null;
+		}
+		if (downloadgaterDownloader) {
+			await downloadgaterDownloader.close();
+			downloadgaterDownloader = null;
 		}
 		const message =
 			error instanceof Error ? error.message : 'Unknown error occurred';
@@ -203,7 +294,7 @@ const server = Bun.serve({
 				}),
 		},
 		'/': () =>
-			new Response('Hypeddit SoundCloud Downloader API is running!', {
+			new Response('sc-gate-dl API is running!', {
 				headers: corsHeaders,
 			}),
 
@@ -309,7 +400,7 @@ const server = Bun.serve({
 
 					const hypedditUrl = skipAutomaticHypedditFetch
 						? null
-						: extractHypedditUrl(track);
+						: extractGateUrl(track);
 					const defaultMetadata = getDefaultMetadata(track);
 
 					const updatedJob = jobStore.update(job.id, {
@@ -321,8 +412,8 @@ const server = Bun.serve({
 							message: hypedditUrl
 								? 'Ready to start download'
 								: skipAutomaticHypedditFetch
-									? 'Automatic Hypeddit lookup skipped - manual input required'
-									: 'Hypeddit URL not found - manual input required',
+									? 'Automatic gate lookup skipped - manual input required'
+									: 'Gate URL not found - manual input required',
 							percent: 10,
 						},
 					});
@@ -367,12 +458,12 @@ const server = Bun.serve({
 
 					if (!hypedditUrl) {
 						return jsonResponse(
-							{ error: 'hypedditUrl is required' },
+							{ error: 'Gate URL (hypedditUrl) is required' },
 							{ status: 400 },
 						);
 					}
 
-					const validation = validateHypedditUrl(hypedditUrl);
+					const validation = validateGateUrl(hypedditUrl);
 					if (validation !== true) {
 						return jsonResponse({ error: validation }, { status: 400 });
 					}
@@ -402,10 +493,7 @@ const server = Bun.serve({
 					}
 
 					if (!job.hypedditUrl) {
-						return jsonResponse(
-							{ error: 'Hypeddit URL not set' },
-							{ status: 400 },
-						);
+						return jsonResponse({ error: 'Gate URL not set' }, { status: 400 });
 					}
 
 					if (
@@ -662,6 +750,18 @@ const server = Bun.serve({
 		if (hypedditDownloader) {
 			await hypedditDownloader.close();
 			hypedditDownloader = null;
+		}
+		if (droploudDownloader) {
+			await droploudDownloader.close();
+			droploudDownloader = null;
+		}
+		if (gaterushDownloader) {
+			await gaterushDownloader.close();
+			gaterushDownloader = null;
+		}
+		if (downloadgaterDownloader) {
+			await downloadgaterDownloader.close();
+			downloadgaterDownloader = null;
 		}
 		return jsonResponse({ error: 'Internal Server Error' }, { status: 500 });
 	},

--- a/src/soundcloud.ts
+++ b/src/soundcloud.ts
@@ -1,14 +1,43 @@
 import { join } from 'node:path';
 import { confirm } from '@inquirer/prompts';
-import Soundcloud, { type SoundcloudTrack } from 'soundcloud.ts';
-import { extractHypedditUrl } from './utils';
+import { execa } from 'execa';
+import { lookpath } from 'find-bin';
+import Soundcloud, {
+	type SoundcloudPlaylist,
+	type SoundcloudTrack,
+	type SoundcloudUser,
+} from 'soundcloud.ts';
+import {
+	extractCaptchaDeliveryUrl,
+	extractGateUrl,
+	loadCookies,
+} from './utils';
+
+interface SoundcloudCredentials {
+	clientId: string;
+	oauthToken: string;
+}
+
+interface SoundcloudClientOptions {
+	credentials?: SoundcloudCredentials;
+}
+
+interface ManagedAccountExport {
+	me: Record<string, unknown>;
+	followedUsers: SoundcloudUser[];
+	likedTracks: SoundcloudTrack[];
+	repostedTracks: SoundcloudTrack[];
+	ownedPlaylists: SoundcloudPlaylist[];
+	repostedPlaylists: SoundcloudPlaylist[];
+}
 
 export class SoundcloudClient {
 	private soundcloud: Soundcloud;
 
-	constructor() {
-		const clientId = process.env.SC_CLIENT_ID;
-		const oauthToken = process.env.SC_OAUTH_TOKEN;
+	constructor(options?: SoundcloudClientOptions) {
+		const clientId = options?.credentials?.clientId ?? process.env.SC_CLIENT_ID;
+		const oauthToken =
+			options?.credentials?.oauthToken ?? process.env.SC_OAUTH_TOKEN;
 
 		if (!clientId || !oauthToken) {
 			throw new Error(
@@ -23,23 +52,186 @@ export class SoundcloudClient {
 		return await this.soundcloud.tracks.get(url);
 	}
 
-	async getHypedditURL(track: SoundcloudTrack) {
-		const hypedditUrl = extractHypedditUrl(track);
-		if (hypedditUrl) {
-			if (hypedditUrl.type === 'purchase_url') {
-				console.log(
-					'Found Hypeddit URL from SoundCloud track purchase URL:',
-					hypedditUrl.url,
-				);
-			} else {
-				console.log(
-					'Found Hypeddit URL from SoundCloud track description:',
-					hypedditUrl.url,
+	/**
+	 * Repost a track (PUT me/track_reposts/:id) using the same soundcloud.ts API
+	 * path as deleteV2. DataDome protects this write; DELETE cleanup is not.
+	 * Falls back to Chrome-TLS curl (+ optional residential proxy) when Bun is blocked.
+	 */
+	async repostTrack(trackUrlOrId: string): Promise<SoundcloudTrack> {
+		const track = await this.getTrack(trackUrlOrId);
+		const endpoint = `me/track_reposts/${track.id}`;
+
+		try {
+			await this.soundcloud.api.putV2(endpoint);
+			return track;
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			if (!/status code 403/i.test(message) && !/403/.test(message)) {
+				// 422/409 from some gateways — treat as already reposted if we can detect
+				if (/status code (422|409)/i.test(message)) return track;
+				throw error;
+			}
+		}
+
+		// Bun TLS is often flagged for engagement PUTs; mirror real Chrome via curl-impersonate.
+		const chromeResult = await this.chromeTlsMutate('PUT', endpoint);
+		if (
+			chromeResult.status === 200 ||
+			chromeResult.status === 201 ||
+			chromeResult.status === 204 ||
+			chromeResult.status === 422 ||
+			chromeResult.status === 409
+		) {
+			return track;
+		}
+
+		const captchaUrl = extractCaptchaDeliveryUrl(chromeResult.body);
+		const hardBlocked = /you have been blocked|unusual activity/i.test(
+			chromeResult.body,
+		);
+		const proxyHint =
+			' Engagement PUTs are DataDome-protected (DELETE cleanup is not). Set SC_API_PROXY or CLOAKBROWSER_PROXY to a residential proxy and retry.';
+		const error = new Error(
+			hardBlocked
+				? `Failed to repost SoundCloud track ${track.id}: DataDome hard-blocked this IP.${proxyHint}`
+				: `Failed to repost SoundCloud track ${track.id}: HTTP ${chromeResult.status}${chromeResult.body ? ` ${chromeResult.body.slice(0, 200)}` : ''}.${proxyHint}`,
+		) as Error & { captchaUrl?: string; status?: number };
+		error.status = chromeResult.status;
+		if (captchaUrl) error.captchaUrl = captchaUrl;
+		throw error;
+	}
+
+	/**
+	 * Chrome-TLS PUT/DELETE via curl_chrome* / curl-impersonate (same OAuth query
+	 * params as soundcloud.ts fetchRequest). Optional SC_API_PROXY / CLOAKBROWSER_PROXY / PROXY_URL.
+	 */
+	private async chromeTlsMutate(
+		method: 'PUT' | 'DELETE',
+		endpoint: string,
+	): Promise<{ status: number; body: string }> {
+		const curlBin =
+			(await lookpath('curl_chrome131')) ||
+			(await lookpath('curl_chrome116')) ||
+			(await lookpath('curl-impersonate'));
+		if (!curlBin) {
+			// Fall back to Bun with the exact same headers/query as putV2.
+			return this.bunMutate(method, endpoint);
+		}
+
+		const clientId =
+			this.soundcloud.api.clientId ?? process.env.SC_CLIENT_ID ?? '';
+		const oauthToken =
+			this.soundcloud.api.oauthToken ?? process.env.SC_OAUTH_TOKEN ?? '';
+		const path = endpoint.startsWith('/') ? endpoint.slice(1) : endpoint;
+		const url = new URL(`https://api-v2.soundcloud.com/${path}`);
+		url.searchParams.set('client_id', clientId);
+		url.searchParams.set('oauth_token', oauthToken);
+
+		const headers = { ...this.soundcloud.api.headers };
+		const args = [
+			'-sS',
+			'-w',
+			'\n__STATUS__:%{http_code}',
+			'-X',
+			method,
+			'-H',
+			`Origin: ${headers.Origin ?? 'https://soundcloud.com'}`,
+			'-H',
+			`Referer: ${headers.Referer ?? 'https://soundcloud.com/'}`,
+			'-H',
+			`User-Agent: ${headers['User-Agent'] ?? 'Mozilla/5.0'}`,
+			'-H',
+			`Authorization: OAuth ${oauthToken}`,
+			'-H',
+			'Accept: application/json, text/javascript, */*; q=0.01',
+		];
+
+		try {
+			const cookies = await loadCookies('soundcloud-cookies.json');
+			const datadome = cookies.find((c) => c.name === 'datadome')?.value;
+			if (cookies.length) {
+				args.push(
+					'-H',
+					`Cookie: ${cookies.map((c) => `${c.name}=${c.value}`).join('; ')}`,
 				);
 			}
-			return hypedditUrl.url;
+			if (datadome) {
+				args.push('-H', `x-datadome-clientid: ${datadome}`);
+			}
+		} catch {
+			// optional
 		}
-		return null;
+
+		const proxy =
+			process.env.SC_API_PROXY?.trim() ||
+			process.env.CLOAKBROWSER_PROXY?.trim() ||
+			process.env.PROXY_URL?.trim();
+		if (proxy) {
+			args.push('-x', proxy);
+		}
+
+		args.push(url.toString());
+
+		const result = await execa(curlBin, args, { reject: false });
+		const output = `${result.stdout}${result.stderr}`;
+		const statusMatch = output.match(/__STATUS__:(\d+)\s*$/);
+		const status = statusMatch ? Number(statusMatch[1]) : 0;
+		const body = output.replace(/\n__STATUS__:\d+\s*$/, '');
+		return { status, body };
+	}
+
+	private async bunMutate(
+		method: 'PUT' | 'DELETE',
+		endpoint: string,
+	): Promise<{ status: number; body: string }> {
+		const clientId =
+			this.soundcloud.api.clientId ?? process.env.SC_CLIENT_ID ?? '';
+		const oauthToken =
+			this.soundcloud.api.oauthToken ?? process.env.SC_OAUTH_TOKEN ?? '';
+		const path = endpoint.startsWith('/') ? endpoint.slice(1) : endpoint;
+		const url = new URL(`https://api-v2.soundcloud.com/${path}`);
+		url.searchParams.set('client_id', clientId);
+		url.searchParams.set('oauth_token', oauthToken);
+		const response = await fetch(url, {
+			method,
+			headers: { ...this.soundcloud.api.headers },
+		});
+		return {
+			status: response.status,
+			body: await response.text().catch(() => ''),
+		};
+	}
+
+	async getMe(): Promise<Record<string, unknown>> {
+		return await this.soundcloud.api.getV2('me');
+	}
+
+	async getGateURL(track: SoundcloudTrack) {
+		const gate = extractGateUrl(track);
+		if (!gate) {
+			return null;
+		}
+		const providerLabel =
+			gate.provider === 'droploud'
+				? 'Droploud'
+				: gate.provider === 'gaterush'
+					? 'GateRush'
+					: gate.provider === 'downloadgater'
+						? 'DownloadGater'
+						: 'Hypeddit';
+		const sourceLabel =
+			gate.type === 'purchase_url' ? 'purchase URL' : 'description';
+		console.log(
+			`Found ${providerLabel} URL from SoundCloud track ${sourceLabel}:`,
+			gate.url,
+		);
+		return gate;
+	}
+
+	/** @deprecated Prefer getGateURL */
+	async getHypedditURL(track: SoundcloudTrack) {
+		const gate = await this.getGateURL(track);
+		return gate?.provider === 'hypeddit' ? gate.url : null;
 	}
 
 	getArtworkUrl(track: SoundcloudTrack): string {
@@ -91,16 +283,17 @@ export class SoundcloudClient {
 			}
 		}
 
-		const me = await this.soundcloud.api.getV2('me');
+		const me = await this.getMe();
 		if (!me) {
 			throw new Error(
 				'Failed to fetch your SoundCloud account. Please check your SoundCloud credentials.',
 			);
 		}
+		const meId = this.getMeId(me);
 
-		const unfollowed = await this.unfollowAllUsers(me.id);
-		const unliked = await this.unlikeAllTracks(me.id);
-		const deletedComments = await this.deleteAllComments(me.id);
+		const unfollowed = await this.unfollowAllUsers(meId);
+		const unliked = await this.unlikeAllTracks(meId);
+		const deletedComments = await this.deleteAllComments(meId);
 		const deletedReposts = await this.deleteAllReposts();
 
 		return {
@@ -210,5 +403,136 @@ export class SoundcloudClient {
 			}
 		}
 		return count;
+	}
+
+	async exportManagedAccountData(): Promise<ManagedAccountExport> {
+		const me = await this.getMe();
+		const meId = this.getMeId(me);
+
+		const [
+			followedUsers,
+			likedTracks,
+			repostedTracks,
+			ownedPlaylists,
+			repostedPlaylists,
+		] = await Promise.all([
+			this.getAllFollowedUsers(meId),
+			this.getAllLikedTracks(meId),
+			this.getRepostedTracks(),
+			this.getOwnedPlaylists(meId),
+			this.getRepostedPlaylists(),
+		]);
+
+		return {
+			me,
+			followedUsers,
+			likedTracks,
+			repostedTracks,
+			ownedPlaylists,
+			repostedPlaylists,
+		};
+	}
+
+	private getMeId(me: Record<string, unknown>): string {
+		const meId = me.id;
+		if (typeof meId !== 'number' && typeof meId !== 'string') {
+			throw new Error(
+				'Failed to determine the SoundCloud account id from the API response.',
+			);
+		}
+		return String(meId);
+	}
+
+	private async getAllFollowedUsers(meId: string): Promise<SoundcloudUser[]> {
+		return await this.paginateCollection<SoundcloudUser>(
+			`users/${meId}/followings`,
+			{ limit: 50, offset: 0 },
+		);
+	}
+
+	private async getAllLikedTracks(meId: string): Promise<SoundcloudTrack[]> {
+		const likes = await this.paginateCollection<{ track?: SoundcloudTrack }>(
+			`users/${meId}/likes`,
+			{ limit: 50, offset: 0 },
+		);
+		return likes.flatMap((like) => (like.track ? [like.track] : []));
+	}
+
+	private async getRepostedTracks(): Promise<SoundcloudTrack[]> {
+		const trackIds = await this.paginateCollection<number>(
+			'me/track_reposts/ids',
+			{
+				limit: 200,
+				offset: 0,
+			},
+		);
+
+		if (!trackIds.length) {
+			return [];
+		}
+
+		return await this.soundcloud.tracks.getArray(trackIds, true);
+	}
+
+	private async getOwnedPlaylists(meId: string): Promise<SoundcloudPlaylist[]> {
+		const playlists = await this.paginateCollection<SoundcloudPlaylist>(
+			`users/${meId}/playlists`,
+			{ limit: 50, offset: 0 },
+		);
+
+		if (!playlists.length) {
+			return [];
+		}
+
+		return await Promise.all(
+			playlists.map((playlist) => this.soundcloud.playlists.get(playlist.id)),
+		);
+	}
+
+	private async getRepostedPlaylists(): Promise<SoundcloudPlaylist[]> {
+		const playlistIds = await this.paginateCollection<number>(
+			'me/playlist_reposts/ids',
+			{ limit: 200, offset: 0 },
+		);
+
+		if (!playlistIds.length) {
+			return [];
+		}
+
+		return await Promise.all(
+			playlistIds.map((playlistId) =>
+				this.soundcloud.playlists.get(playlistId),
+			),
+		);
+	}
+
+	private async paginateCollection<T>(
+		endpoint: string,
+		params: Record<string, string | number>,
+	): Promise<T[]> {
+		const response = await this.soundcloud.api.getV2(endpoint, params);
+		const collection = Array.isArray(response?.collection)
+			? [...response.collection]
+			: [];
+		let nextHref = response?.next_href as string | null | undefined;
+
+		while (nextHref) {
+			const url = new URL(nextHref);
+			const nextParams: Record<string, string> = {};
+			for (const [key, value] of url.searchParams.entries()) {
+				nextParams[key] = value;
+			}
+
+			const nextPage = await this.soundcloud.api.getURL(
+				`${url.origin}${url.pathname}`,
+				nextParams,
+			);
+			if (Array.isArray(nextPage?.collection)) {
+				collection.push(...nextPage.collection);
+			}
+			nextHref = nextPage?.next_href as string | null | undefined;
+		}
+
+		return collection as T[];
 	}
 }

--- a/src/soundcloud.ts
+++ b/src/soundcloud.ts
@@ -128,6 +128,14 @@ export class SoundcloudClient {
 		url.searchParams.set('oauth_token', oauthToken);
 
 		const headers = { ...this.soundcloud.api.headers };
+		const escapeCurlConfig = (value: string) =>
+			value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+		// Keep OAuth out of argv (visible in `ps`); pass via curl --config stdin.
+		const configLines = [
+			`url = "${escapeCurlConfig(url.toString())}"`,
+			`header = "Authorization: OAuth ${escapeCurlConfig(oauthToken)}"`,
+		];
+
 		const args = [
 			'-sS',
 			'-w',
@@ -140,8 +148,6 @@ export class SoundcloudClient {
 			`Referer: ${headers.Referer ?? 'https://soundcloud.com/'}`,
 			'-H',
 			`User-Agent: ${headers['User-Agent'] ?? 'Mozilla/5.0'}`,
-			'-H',
-			`Authorization: OAuth ${oauthToken}`,
 			'-H',
 			'Accept: application/json, text/javascript, */*; q=0.01',
 		];
@@ -170,9 +176,12 @@ export class SoundcloudClient {
 			args.push('-x', proxy);
 		}
 
-		args.push(url.toString());
+		args.push('--config', '-');
 
-		const result = await execa(curlBin, args, { reject: false });
+		const result = await execa(curlBin, args, {
+			input: `${configLines.join('\n')}\n`,
+			reject: false,
+		});
 		const output = `${result.stdout}${result.stderr}`;
 		const statusMatch = output.match(/__STATUS__:(\d+)\s*$/);
 		const status = statusMatch ? Number(statusMatch[1]) : 0;
@@ -195,6 +204,7 @@ export class SoundcloudClient {
 		const response = await fetch(url, {
 			method,
 			headers: { ...this.soundcloud.api.headers },
+			signal: AbortSignal.timeout(30_000),
 		});
 		return {
 			status: response.status,
@@ -515,8 +525,18 @@ export class SoundcloudClient {
 			? [...response.collection]
 			: [];
 		let nextHref = response?.next_href as string | null | undefined;
+		const seen = new Set<string>();
+		const maxPages = 500;
+		let pages = 0;
 
 		while (nextHref) {
+			if (seen.has(nextHref) || ++pages > maxPages) {
+				console.warn(
+					`Stopped paginating ${endpoint} after ${pages} pages (repeated or excessive cursor).`,
+				);
+				break;
+			}
+			seen.add(nextHref);
 			const url = new URL(nextHref);
 			const nextParams: Record<string, string> = {};
 			for (const [key, value] of url.searchParams.entries()) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,8 +10,10 @@ export interface LocalCookieData {
 }
 
 export interface HypedditConfig {
-	name: string;
-	email: string;
+	/** Optional — only needed for Hypeddit/GateRush email gates that ask for a name. */
+	name?: string;
+	/** Optional — only needed for Hypeddit/GateRush email gates. */
+	email?: string;
 	comment: string;
 	headless: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,8 @@ export interface HypedditConfig {
 	email?: string;
 	comment: string;
 	headless: boolean;
+	/** Persistent Chromium profile. Defaults to `./browser-data`. */
+	userDataDir?: string;
 }
 
 export interface Metadata {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,6 +30,64 @@ export async function timeout(ms: number) {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/** Pull a DataDome / captcha-delivery challenge URL out of an API error body. */
+export function extractCaptchaDeliveryUrl(body: string): string | undefined {
+	try {
+		const json = JSON.parse(body) as { url?: unknown };
+		if (
+			typeof json.url === 'string' &&
+			/captcha-delivery\.com/i.test(json.url)
+		) {
+			return json.url;
+		}
+	} catch {
+		// not JSON
+	}
+	const match = body.match(
+		/https?:\/\/geo\.captcha-delivery\.com\/captcha\/[^"\\\s]+/i,
+	);
+	return match?.[0]?.replace(/\\u0026/g, '&');
+}
+
+/**
+ * Parse DataDome `/captcha/check` JSON: `{ "cookie": "datadome=...; Domain=.soundcloud.com; ..." }`
+ */
+export function parseDatadomeCheckCookie(body: string): {
+	name: string;
+	value: string;
+	domain: string;
+	path: string;
+	secure: boolean;
+} | null {
+	try {
+		const json = JSON.parse(body) as { cookie?: unknown };
+		if (typeof json.cookie !== 'string' || !json.cookie.includes('datadome=')) {
+			return null;
+		}
+		const parts = json.cookie.split(';').map((p) => p.trim());
+		const nameValue = parts[0];
+		if (!nameValue) return null;
+		const eq = nameValue.indexOf('=');
+		if (eq < 0) return null;
+		const name = nameValue.slice(0, eq);
+		const value = nameValue.slice(eq + 1);
+		let domain = '.soundcloud.com';
+		let path = '/';
+		let secure = true;
+		for (const attr of parts.slice(1)) {
+			const sep = attr.indexOf('=');
+			const k = (sep >= 0 ? attr.slice(0, sep) : attr).trim();
+			const v = sep >= 0 ? attr.slice(sep + 1).trim() : '';
+			if (/^domain$/i.test(k) && v) domain = v;
+			if (/^path$/i.test(k) && v) path = v;
+			if (/^secure$/i.test(k)) secure = true;
+		}
+		return { name, value, domain, path, secure };
+	} catch {
+		return null;
+	}
+}
+
 export async function loadCookies(filename: string): Promise<CookieData[]> {
 	const cookiesData: LocalCookieData[] = JSON.parse(
 		await Bun.file(filename).text(),
@@ -66,32 +124,152 @@ export function validateSoundcloudUrl(value: string): true | string {
 	return true;
 }
 
+export type GateProvider =
+	| 'hypeddit'
+	| 'droploud'
+	| 'gaterush'
+	| 'downloadgater';
+
+export type GateUrlMatch = {
+	url: string;
+	provider: GateProvider;
+	type: 'purchase_url' | 'description';
+};
+
+const HYPEDDIT_URL_RE = /https:\/\/hypeddit\.com\/[^\s]+/;
+const DROPLOUD_URL_RE = /https:\/\/droploud\.com\/(?:gate|track)\/[0-9a-f-]+/i;
+const GATERUSH_URL_RE = /https?:\/\/(?:www\.)?gaterush\.me\/[A-Za-z0-9_-]+/i;
+const DOWNLOADGATER_URL_RE =
+	/https?:\/\/(?:www\.)?downloadgater\.com\/g\/[A-Za-z0-9_-]+/i;
+
+export function isHypedditUrl(value: string): boolean {
+	return value.startsWith('https://hypeddit.com/');
+}
+
+export function isDroploudUrl(value: string): boolean {
+	return DROPLOUD_URL_RE.test(value);
+}
+
+export function isGaterushUrl(value: string): boolean {
+	return GATERUSH_URL_RE.test(value);
+}
+
+export function isDownloadgaterUrl(value: string): boolean {
+	return DOWNLOADGATER_URL_RE.test(value);
+}
+
+export function getGateProvider(value: string): GateProvider | null {
+	if (isHypedditUrl(value)) return 'hypeddit';
+	if (isDroploudUrl(value)) return 'droploud';
+	if (isGaterushUrl(value)) return 'gaterush';
+	if (isDownloadgaterUrl(value)) return 'downloadgater';
+	return null;
+}
+
 export function validateHypedditUrl(value: string): true | string {
-	if (!value?.startsWith('https://hypeddit.com/')) {
+	if (!isHypedditUrl(value)) {
 		return 'A valid Hypeddit URL is required';
 	}
 	return true;
 }
 
-export function extractHypedditUrl(
-	track: SoundcloudTrack,
-): { url: string; type: 'purchase_url' | 'description' } | null {
+export function validateGateUrl(value: string): true | string {
+	if (!getGateProvider(value)) {
+		return 'A valid Hypeddit, Droploud, GateRush, or DownloadGater URL is required';
+	}
+	return true;
+}
+
+function normalizeGateUrl(
+	url: string,
+	provider: GateProvider,
+): { url: string; provider: GateProvider } {
+	if (provider === 'gaterush' || provider === 'downloadgater') {
+		return {
+			url: url.replace(/^http:\/\//i, 'https://'),
+			provider,
+		};
+	}
+	return { url, provider };
+}
+
+function matchGateUrl(
+	value: string,
+): { url: string; provider: GateProvider } | null {
+	if (isHypedditUrl(value)) {
+		return { url: value, provider: 'hypeddit' };
+	}
+	const droploudMatch = value.match(DROPLOUD_URL_RE)?.[0];
+	if (droploudMatch) {
+		return { url: droploudMatch, provider: 'droploud' };
+	}
+	const gaterushMatch = value.match(GATERUSH_URL_RE)?.[0];
+	if (gaterushMatch) {
+		return normalizeGateUrl(gaterushMatch, 'gaterush');
+	}
+	const downloadgaterMatch = value.match(DOWNLOADGATER_URL_RE)?.[0];
+	if (downloadgaterMatch) {
+		return normalizeGateUrl(downloadgaterMatch, 'downloadgater');
+	}
+	return null;
+}
+
+/** Prefer Hypeddit, then Droploud, GateRush, DownloadGater from purchase_url or description. */
+export function extractGateUrl(track: SoundcloudTrack): GateUrlMatch | null {
 	const { purchase_url, description } = track;
 
-	if (purchase_url?.startsWith('https://hypeddit.com/')) {
-		return { url: purchase_url, type: 'purchase_url' };
+	if (purchase_url) {
+		const fromPurchase = matchGateUrl(purchase_url);
+		if (fromPurchase) {
+			return { ...fromPurchase, type: 'purchase_url' };
+		}
 	}
 
-	if (description?.includes('https://hypeddit.com/')) {
-		const matchedUrl = description.match(
-			/https:\/\/hypeddit\.com\/[^\s]+/,
-		)?.[0];
-		if (matchedUrl) {
-			return { url: matchedUrl, type: 'description' };
+	if (description) {
+		const hypedditMatch = description.match(HYPEDDIT_URL_RE)?.[0];
+		if (hypedditMatch) {
+			return {
+				url: hypedditMatch,
+				provider: 'hypeddit',
+				type: 'description',
+			};
+		}
+		const droploudMatch = description.match(DROPLOUD_URL_RE)?.[0];
+		if (droploudMatch) {
+			return {
+				url: droploudMatch,
+				provider: 'droploud',
+				type: 'description',
+			};
+		}
+		const gaterushMatch = description.match(GATERUSH_URL_RE)?.[0];
+		if (gaterushMatch) {
+			return {
+				...normalizeGateUrl(gaterushMatch, 'gaterush'),
+				type: 'description',
+			};
+		}
+		const downloadgaterMatch = description.match(DOWNLOADGATER_URL_RE)?.[0];
+		if (downloadgaterMatch) {
+			return {
+				...normalizeGateUrl(downloadgaterMatch, 'downloadgater'),
+				type: 'description',
+			};
 		}
 	}
 
 	return null;
+}
+
+/** @deprecated Prefer extractGateUrl */
+export function extractHypedditUrl(
+	track: SoundcloudTrack,
+): { url: string; type: 'purchase_url' | 'description' } | null {
+	const gate = extractGateUrl(track);
+	if (gate?.provider !== 'hypeddit') {
+		return null;
+	}
+	return { url: gate.url, type: gate.type };
 }
 
 export function getDefaultMetadata(track: SoundcloudTrack): Metadata {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "Preserve",
     "moduleDetection": "force",
     "jsx": "react-jsx",
+    "types": ["bun"],
     "allowJs": true,
 
     // Bundler mode

--- a/webui/src/components/App.css
+++ b/webui/src/components/App.css
@@ -250,6 +250,26 @@
 	cursor: not-allowed;
 }
 
+.checkbox-row {
+	display: flex;
+	align-items: center;
+	gap: var(--space-sm);
+	color: var(--text-secondary);
+	font-size: 0.9rem;
+	cursor: pointer;
+}
+
+.checkbox-row input {
+	width: 16px;
+	height: 16px;
+	accent-color: var(--neon-orange);
+	cursor: pointer;
+}
+
+.checkbox-row input:disabled {
+	cursor: not-allowed;
+}
+
 /* Notice box */
 .notice {
 	display: flex;

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -45,6 +45,7 @@ export default function App() {
 	const [step, setStep] = useState<Step>('url');
 	const [soundcloudUrl, setSoundcloudUrl] = useState('');
 	const [hypedditUrlInput, setHypedditUrlInput] = useState('');
+	const [skipAutomaticHypedditFetch, setSkipAutomaticHypedditFetch] = useState(false);
 	const [job, setJob] = useState<JobState>({
 		jobId: null,
 		track: null,
@@ -135,7 +136,10 @@ export default function App() {
 			const response = await fetch(`${API_BASE}/api/job`, {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ soundcloudUrl }),
+				body: JSON.stringify({
+					soundcloudUrl,
+					skipAutomaticHypedditFetch,
+				}),
 			});
 
 			const data = await response.json();
@@ -158,7 +162,7 @@ export default function App() {
 				setMetadata(data.defaultMetadata);
 			}
 
-			if (data.needsHypedditUrl) {
+			if (skipAutomaticHypedditFetch || data.needsHypedditUrl) {
 				setStep('hypeddit');
 			} else {
 				// Auto-start download
@@ -316,6 +320,7 @@ export default function App() {
 	const handleReset = () => {
 		setSoundcloudUrl('');
 		setHypedditUrlInput('');
+		setSkipAutomaticHypedditFetch(false);
 		setJob({
 			jobId: null,
 			track: null,
@@ -389,9 +394,9 @@ export default function App() {
 			<header className="header">
 				<div className="logo">
 					<span className="logo-icon">&#9654;</span>
-					<h1>Hypeddit Downloader</h1>
+					<h1>sc-gate-dl</h1>
 				</div>
-				<p className="tagline">Download & tag SoundCloud tracks from Hypeddit</p>
+				<p className="tagline">Download & tag SoundCloud tracks from Hypeddit, Droploud, GateRush, or DownloadGater</p>
 			</header>
 
 			{/* Step indicator */}
@@ -403,7 +408,7 @@ export default function App() {
 				<div className="step-connector" />
 				<div className={`step ${step === 'hypeddit' ? 'active' : ''} ${['progress', 'metadata', 'complete'].includes(step) ? 'completed' : ''}`}>
 					<span className="step-number">2</span>
-					<span className="step-label">Hypeddit</span>
+					<span className="step-label">Gate</span>
 				</div>
 				<div className="step-connector" />
 				<div className={`step ${step === 'progress' ? 'active' : ''} ${['metadata', 'complete'].includes(step) ? 'completed' : ''}`}>
@@ -467,6 +472,16 @@ export default function App() {
 								disabled={isLoading}
 							/>
 						</div>
+						<label className="checkbox-row" htmlFor="skip-hypeddit-fetch">
+							<input
+								id="skip-hypeddit-fetch"
+								type="checkbox"
+								checked={skipAutomaticHypedditFetch}
+								onChange={(e) => setSkipAutomaticHypedditFetch(e.target.checked)}
+								disabled={isLoading}
+							/>
+							<span>Skip automatic gate link fetching</span>
+						</label>
 						<button type="submit" className="btn-primary" disabled={isLoading}>
 							{isLoading ? (
 								<>
@@ -480,24 +495,26 @@ export default function App() {
 					</form>
 				)}
 
-				{/* Step 2: Hypeddit URL (if needed) */}
+				{/* Step 2: Gate URL (if needed) */}
 				{step === 'hypeddit' && (
 					<form onSubmit={handleHypedditSubmit} className="form animate-slide-up">
 						<div className="notice">
 							<span className="notice-icon">i</span>
 							<p>
-								Hypeddit URL not found in track. Please enter it manually.
+								{skipAutomaticHypedditFetch
+									? 'Automatic gate lookup is disabled. Please enter the URL manually.'
+									: 'Gate URL not found in track. Please enter a Hypeddit, Droploud, GateRush, or DownloadGater URL manually.'}
 							</p>
 						</div>
 						<div className="form-group">
-							<label htmlFor="hypeddit-url">Hypeddit URL</label>
+							<label htmlFor="hypeddit-url">Gate URL</label>
 							<input
 								id="hypeddit-url"
 								type="url"
 								name="hypeddit-url"
 								value={hypedditUrlInput}
 								onChange={(e) => setHypedditUrlInput(e.target.value)}
-								placeholder="https://hypeddit.com/..."
+								placeholder="https://hypeddit.com/... / droploud.com/gate/... / gaterush.me/... / downloadgater.com/g/..."
 								autoComplete="off"
 								required
 								disabled={isLoading}

--- a/webui/src/layouts/Layout.astro
+++ b/webui/src/layouts/Layout.astro
@@ -11,8 +11,8 @@ import 'sonner/dist/styles.css';
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<link rel="icon" href="/favicon.ico" />
 		<meta name="generator" content={Astro.generator} />
-		<title>Hypeddit Downloader</title>
-		<meta name="description" content="Download and tag SoundCloud tracks from Hypeddit" />
+		<title>sc-gate-dl</title>
+		<meta name="description" content="Download and tag SoundCloud tracks from Hypeddit, Droploud, or GateRush" />
 	</head>
 	<body>
 		<main class="main-container">


### PR DESCRIPTION
## Summary
- Add dedicated CloakBrowser downloaders for Droploud, GateRush, and DownloadGater, with shared browser launch and multi-provider routing in CLI / WebUI / server
- Harden SoundCloud engagement + OAuth flows (repost 204 handling, manual repost fallback, trusted Allow clicks, GateRush authorize wait without early popup close)
- Document managed-account export, optional proxies for DataDome, and rename the package to `sc-gate-dl`

## Test plan
- [ ] Run a Hypeddit gate end-to-end (HTTP fast path + browser fallback)
- [ ] Run a Droploud gate through email / social / SoundCloud steps and confirm download
- [ ] Run a GateRush gate and confirm `#submit_approval` Allow is clicked (`GateRush: Allow → …` in logs) without the authorize window closing early
- [ ] Run a DownloadGater gate through IG → SC OAuth Allow → unlock → download
- [ ] Smoke-test WebUI job creation for each provider URL
- [ ] Optional: `bun manage-acc` with `MANAGED_SC_*` credentials writes `./exports`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Droploud, GateRush, and DownloadGater links alongside Hypeddit.
  * Added manual gate-link entry, progress tracking, and provider-specific download flows.
  * Added managed SoundCloud account exports, including playlists, reposts, follows, and likes.
* **Bug Fixes**
  * Improved authentication, browser fallback, retries, validation, cleanup, and download error reporting.
* **Documentation**
  * Updated setup guidance, configuration examples, supported providers, and application branding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->