### PR TITLE
fix: SoundCloud GraphQL repost and browser mode controls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,5 +14,6 @@ MANAGED_SC_OAUTH_TOKEN=
 # SC_API_PROXY=http://user:pass@host:port
 # CLOAKBROWSER_PROXY=http://user:pass@host:port
 # PROXY_URL=http://user:pass@host:port
-# WebUI browser jobs default to headed CloakBrowser (needed for OAuth). Set true to force headless.
-# BROWSER_HEADLESS=true
+# WebUI browser jobs default to headless (also toggleable per job in the UI).
+# Set false to force headed for all jobs when the UI option is not sent.
+# BROWSER_HEADLESS=false

--- a/src/droploud.ts
+++ b/src/droploud.ts
@@ -637,8 +637,8 @@ export class DroploudDownloader {
 	}
 
 	/**
-	 * Manual Droploud repost step: open track URL, ensure a repost via API, then
-	 * fall back to clicking Repost in the SoundCloud UI if engagement PUTs fail.
+	 * Manual Droploud repost step: open the track in a full-size tab (Droploud's
+	 * window.open popup often never mounts `.soundActions`), then click Repost.
 	 */
 	private async performSoundcloudManualActions(
 		popup: Page,
@@ -648,137 +648,930 @@ export class DroploudDownloader {
 
 		const deadline = Date.now() + 25_000;
 		while (Date.now() < deadline) {
-			if (popup.isClosed()) return;
-			const url = popup.url();
+			const live = await this.resolveSoundcloudPage(popup);
+			if (!live) {
+				await timeout(200);
+				continue;
+			}
+			popup = live;
+			const url = live.url();
 			if (
 				url.includes('soundcloud.com') &&
 				url !== 'about:blank' &&
-				!url.includes('/web-auth')
+				!url.includes('/web-auth') &&
+				!url.includes('captcha-delivery.com')
 			) {
 				break;
 			}
 			await timeout(200);
 		}
 
-		const trackUrl = popup.url();
+		let page = popup;
+		let trackUrl = '';
+		try {
+			trackUrl = page.url();
+		} catch {
+			const live = await this.resolveSoundcloudPage(page);
+			if (live && !live.isClosed()) {
+				page = live;
+				trackUrl = live.url();
+			}
+		}
 		if (!trackUrl.includes('soundcloud.com')) {
 			throw new Error('SoundCloud popup never navigated to a track URL.');
 		}
 
+		// Stay on Droploud's SoundCloud window — do not open a second tab or strip
+		// login cookies (that logged the session out).
 		try {
-			const soundcloud = new SoundcloudClient();
-			await soundcloud.repostTrack(trackUrl);
-			console.log('Droploud: SoundCloud repost ensured via API.');
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			console.warn(
-				`Droploud: API repost failed (${message.slice(0, 180)}); trying browser UI…`,
-			);
-			await this.repostTrackInBrowser(popup);
-			console.log('Droploud: SoundCloud repost ensured via browser UI.');
-		}
-		await timeout(500);
-	}
-
-	/** Click SoundCloud's track-page Repost control (trusted UI path). */
-	private async repostTrackInBrowser(page: Page) {
-		try {
-			await page.bringToFront();
+			await page.setViewport({ width: 1440, height: 900 });
 		} catch {
-			// ignore
+			// popup may not allow resize; continue anyway
 		}
+		await page.bringToFront().catch(() => {});
+		console.log(`Droploud: SoundCloud Repost on existing tab (${trackUrl})…`);
 
-		const findRepostHandle = async () => {
-			const handles = await page.$$('button');
-			for (const handle of handles) {
-				const meta = await handle.evaluate((btn) => {
-					const text = (btn.textContent || '').trim();
-					const aria = btn.getAttribute('aria-label') || '';
-					const title = btn.title || '';
-					const pressed = btn.getAttribute('aria-pressed');
-					const label = `${aria} ${text} ${title}`;
-					return {
-						text,
-						aria,
-						pressed,
-						isRepost:
-							/^repost$/i.test(text) ||
-							/^repost$/i.test(aria) ||
-							(/^repost/i.test(label) && !/unrepost|reposted/i.test(label)),
-						already:
-							/unrepost|reposted/i.test(label) ||
-							(pressed === 'true' && /repost/i.test(label)),
-					};
-				});
-				if (meta.already) {
-					await handle.dispose();
-					return 'already' as const;
+		const soundcloud = new SoundcloudClient();
+		const alreadyReposted = async (target: Page) => {
+			if (!target.isClosed()) {
+				if (await this.pageLooksReposted(target).catch(() => false)) {
+					return 'ui' as const;
 				}
-				if (meta.isRepost) return handle;
-				await handle.dispose();
+			}
+			try {
+				if (await soundcloud.isTrackReposted(trackUrl)) return 'api' as const;
+			} catch {
+				// logged inside isTrackReposted
 			}
 			return null;
 		};
 
-		const started = Date.now();
-		let target: Awaited<ReturnType<typeof findRepostHandle>> = null;
-		while (Date.now() - started < 20_000) {
-			target = await findRepostHandle();
-			if (target) break;
-			await timeout(300);
-		}
-
-		if (target === 'already') {
-			console.log('Droploud: track already looks reposted in the browser.');
+		const already = await alreadyReposted(page);
+		if (already) {
+			console.log(`Droploud: SoundCloud track already reposted (${already}).`);
 			return;
 		}
-		if (!target) {
-			throw new Error(
-				'SoundCloud Repost button not found. Is the account logged in (Initialize Logins)?',
+
+		const loggedIn = await page
+			.evaluate(
+				() =>
+					!!document.querySelector('a[href="/you/library"]') &&
+					!(document.body?.innerText || '').includes(
+						'Sign in or create an account',
+					),
+			)
+			.catch(() => false);
+		if (!loggedIn) {
+			console.warn(
+				'Droploud: SoundCloud tab does not look logged in — GraphQL/UI repost will likely fail. Re-run Initialize Logins.',
 			);
 		}
 
-		await target.click({ delay: 40 });
-		await target.dispose();
-
-		// Some layouts open a menu; confirm "Repost to profile" / plain Repost.
-		await timeout(600);
-		const menuHandles = await page.$$('button, [role="menuitem"], a');
-		for (const handle of menuHandles) {
-			const text = await handle.evaluate((el) => (el.textContent || '').trim());
-			if (
-				/^repost( to (your )?profile)?$/i.test(text) ||
-				/^repost track$/i.test(text)
-			) {
-				await handle.click({ delay: 40 });
-				await handle.dispose();
-				break;
-			}
-			await handle.dispose();
+		// Prefer webi GraphQL (same mutation the real Repost button fires).
+		if (await this.repostViaPageFetch(page, trackUrl)) {
+			console.log('Droploud: SoundCloud repost ensured via GraphQL.');
+			await timeout(500);
+			return;
 		}
 
-		await page
-			.waitForFunction(
-				() => {
-					const buttons = Array.from(document.querySelectorAll('button'));
-					return buttons.some((btn) => {
-						const label =
-							`${btn.getAttribute('aria-label') || ''} ${btn.textContent || ''} ${btn.title || ''}`.toLowerCase();
-						return (
-							/unrepost|reposted/i.test(label) ||
-							(btn.getAttribute('aria-pressed') === 'true' &&
-								/repost/i.test(label))
-						);
-					});
-				},
-				{ timeout: 15_000 },
-			)
-			.catch(() => {
-				// Soft-ok: Droploud verify-repost API is the real check.
-				console.warn(
-					'Droploud: browser Repost click did not show a clear Reposted state; continuing for Droploud verify.',
+		const uiError = await this.repostTrackInBrowser(page)
+			.then(() => null)
+			.catch((error: unknown) => error);
+
+		if (!uiError) {
+			const confirmed = await alreadyReposted(page);
+			if (confirmed) {
+				console.log(
+					`Droploud: SoundCloud repost ensured via browser UI (${confirmed}).`,
 				);
+				await timeout(500);
+				return;
+			}
+			console.warn(
+				'Droploud: browser Repost click finished but repost not confirmed; trying API…',
+			);
+		}
+
+		const uiMessage =
+			uiError instanceof Error
+				? uiError.message
+				: uiError
+					? String(uiError)
+					: 'repost not confirmed after UI click';
+		const closed = /track tab closed|Target closed|Session closed/i.test(
+			uiMessage,
+		);
+		console.warn(
+			`Droploud: browser Repost UI failed (${uiMessage.slice(0, 160)}); trying API GraphQL…`,
+		);
+
+		try {
+			await soundcloud.repostTrack(trackUrl);
+			console.log('Droploud: SoundCloud repost ensured via API GraphQL.');
+			return;
+		} catch (apiError) {
+			console.warn(
+				`Droploud: API GraphQL/PUT repost failed (${apiError instanceof Error ? apiError.message.slice(0, 160) : String(apiError)})`,
+			);
+		}
+
+		const after = await alreadyReposted(page);
+		if (after) {
+			console.log(
+				`Droploud: SoundCloud repost confirmed after attempts (${after}).`,
+			);
+			return;
+		}
+
+		if (!this.config.headless && !closed && !page.isClosed()) {
+			console.log(
+				'Droploud: waiting up to 2 minutes for manual Repost / captcha solve…',
+			);
+			const manualDeadline = Date.now() + 120_000;
+			while (Date.now() < manualDeadline) {
+				if (page.isClosed()) break;
+				await this.handlePossibleCaptcha(page).catch(() => false);
+				if (await this.repostViaPageFetch(page, trackUrl)) {
+					console.log(
+						'Droploud: SoundCloud repost ensured via GraphQL during manual wait.',
+					);
+					return;
+				}
+				const status = await alreadyReposted(page);
+				if (status) {
+					console.log(
+						`Droploud: SoundCloud repost confirmed after manual UI (${status}).`,
+					);
+					return;
+				}
+				await this.tryClickRepostButton(page).catch(() => null);
+				await timeout(1_000);
+			}
+		}
+
+		if (closed) {
+			console.warn(
+				'Droploud: SoundCloud tab closed during repost; continuing so Droploud can verify.',
+			);
+			return;
+		}
+
+		const finalCheck = await alreadyReposted(page);
+		if (finalCheck) {
+			console.log(`Droploud: SoundCloud repost confirmed (${finalCheck}).`);
+			return;
+		}
+
+		throw new Error(
+			`SoundCloud repost failed (${uiMessage.slice(0, 180)}). Stay logged in on SoundCloud (Initialize Logins), complete Repost + captcha if shown, then retry.`,
+		);
+	}
+
+	/** Prefer a live SoundCloud (or DataDome) tab — popups can swap/navigate. */
+	private async resolveSoundcloudPage(
+		preferred?: Page,
+	): Promise<Page | undefined> {
+		if (preferred && !preferred.isClosed()) {
+			try {
+				const url = preferred.url();
+				if (
+					url.includes('soundcloud.com') ||
+					url.includes('captcha-delivery.com')
+				) {
+					return preferred;
+				}
+			} catch {
+				// fall through
+			}
+		}
+		return this.findSoundcloudTrackPage();
+	}
+
+	private async findSoundcloudTrackPage(): Promise<Page | undefined> {
+		const pages = (await this.browser.pages(true)).filter((p) => !p.isClosed());
+		const scored: { page: Page; score: number }[] = [];
+		for (const candidate of pages) {
+			try {
+				const url = candidate.url();
+				if (url === 'about:blank') continue;
+				if (url.includes('captcha-delivery.com')) {
+					scored.push({ page: candidate, score: 1 });
+				} else if (
+					url.includes('soundcloud.com') &&
+					!url.includes('/web-auth')
+				) {
+					const trackLike = /soundcloud\.com\/[^/]+\/[^/?#]+/.test(url);
+					scored.push({ page: candidate, score: trackLike ? 3 : 2 });
+				}
+			} catch {
+				// ignore
+			}
+		}
+		scored.sort((a, b) => b.score - a.score);
+		return scored[0]?.page;
+	}
+
+	private async pageLooksReposted(page: Page): Promise<boolean> {
+		if (page.isClosed()) return false;
+		return page.evaluate(() => {
+			const classic = document.querySelector('button.sc-button-repost');
+			if (
+				classic?.classList.contains('sc-button-selected') ||
+				classic?.getAttribute('aria-pressed') === 'true'
+			) {
+				return true;
+			}
+			return Array.from(
+				document.querySelectorAll('button, [role="button"]'),
+			).some((btn) => {
+				const label =
+					`${btn.getAttribute('aria-label') || ''} ${btn.textContent || ''} ${btn.getAttribute('title') || ''} ${(btn as HTMLElement).title || ''}`.toLowerCase();
+				if (
+					/unrepost|unpost|delete\s*repost|reposted|edit\s*repost/i.test(label)
+				)
+					return true;
+				if (
+					/repost/i.test(label) &&
+					(btn.classList.contains('sc-button-selected') ||
+						btn.getAttribute('aria-pressed') === 'true')
+				) {
+					return true;
+				}
+				return false;
 			});
+		});
+	}
+
+	/** Click the track Repost control if present. Returns status. */
+	private async tryClickRepostButton(
+		page: Page,
+	): Promise<'clicked' | 'already' | 'missing'> {
+		if (page.isClosed()) return 'missing';
+
+		const classicHandle = await page.$(Selectors.SOUNDCLOUD_REPOST_BUTTON);
+		if (classicHandle) {
+			const already = await classicHandle.evaluate(
+				(btn) =>
+					btn.classList.contains('sc-button-selected') ||
+					btn.getAttribute('aria-pressed') === 'true',
+			);
+			if (already) {
+				await classicHandle.dispose();
+				return 'already';
+			}
+			await classicHandle.evaluate((el) =>
+				el.scrollIntoView({ block: 'center', inline: 'center' }),
+			);
+			await classicHandle.click({ delay: 40 });
+			await classicHandle.dispose();
+
+			await timeout(600);
+			// Caption overlay after a successful webi/classic repost
+			const overlayClosed = await page.evaluate(() => {
+				const close = document.querySelector(
+					'.repostOverlay__closeButton',
+				) as HTMLElement | null;
+				if (close) {
+					close.click();
+					return true;
+				}
+				return false;
+			});
+			if (overlayClosed) return 'clicked';
+
+			await page.evaluate(() => {
+				for (const el of Array.from(
+					document.querySelectorAll(
+						'button, [role="menuitem"], a, .sc-button-dropdown, .repostDialog button',
+					),
+				)) {
+					const text = (el.textContent || '').replace(/\s+/g, ' ').trim();
+					if (
+						/^repost( to (your )?profile)?$/i.test(text) ||
+						/^repost track$/i.test(text) ||
+						/^reposten$/i.test(text) ||
+						/repost(en)?\s+(auf|to)\s+(dein|your|mein)/i.test(text) ||
+						/^republier$/i.test(text)
+					) {
+						(el as HTMLElement).click();
+						return;
+					}
+				}
+			});
+			return 'clicked';
+		}
+
+		return page.evaluate(() => {
+			const isAlready = (btn: Element) => {
+				const label =
+					`${btn.getAttribute('aria-label') || ''} ${btn.textContent || ''} ${btn.getAttribute('title') || ''} ${(btn as HTMLElement).title || ''}`.toLowerCase();
+				return (
+					btn.classList.contains('sc-button-selected') ||
+					/unrepost|unpost|reposted|delete\s*repost|edit\s*repost|rückgängig|entfernen/i.test(
+						label,
+					) ||
+					btn.getAttribute('aria-pressed') === 'true'
+				);
+			};
+
+			const mui = document.querySelector<HTMLElement>(
+				'button[aria-label="Repost"], button[title="Repost"], [title="Repost"] > button',
+			);
+			if (mui) {
+				if (isAlready(mui)) return 'already' as const;
+				mui.scrollIntoView({ block: 'center', inline: 'center' });
+				mui.click();
+				return 'clicked' as const;
+			}
+
+			for (const btn of Array.from(
+				document.querySelectorAll('button, [role="button"]'),
+			)) {
+				const text = (btn.textContent || '').replace(/\s+/g, ' ').trim();
+				const aria = (btn.getAttribute('aria-label') || '').trim();
+				const title = (
+					btn.getAttribute('title') ||
+					(btn as HTMLElement).title ||
+					''
+				).trim();
+				const parentTitle = (
+					btn.parentElement?.getAttribute('title') || ''
+				).trim();
+				const cls =
+					typeof (btn as HTMLElement).className === 'string'
+						? (btn as HTMLElement).className
+						: '';
+				const parts = [aria, text, title, parentTitle].filter(Boolean);
+				const label = parts.join(' ');
+				const looksRepost =
+					cls.includes('sc-button-repost') ||
+					parts.some((p) =>
+						/^(repost|reposted|reposts|reposting|republier|reposten|erneut\s*posten)$/i.test(
+							p,
+						),
+					) ||
+					/^(repost|reposten|republier)\b/i.test(label);
+				if (!looksRepost) continue;
+				if (isAlready(btn)) return 'already' as const;
+				btn.scrollIntoView({ block: 'center', inline: 'center' });
+				(btn as HTMLElement).click();
+				return 'clicked' as const;
+			}
+			return 'missing' as const;
+		});
+	}
+
+	/**
+	 * Drag DataDome slider when visible. After solve, reload — SPA often stays
+	 * without `.soundActions` until a fresh navigation.
+	 * @returns true if a captcha was present and cleared
+	 */
+	private async handlePossibleCaptcha(page: Page): Promise<boolean> {
+		const visible = await page
+			.evaluate((sel) => {
+				const el = document.querySelector(sel) as HTMLElement | null;
+				if (!el) return false;
+				if (el.getClientRects().length === 0) return false;
+				const style = window.getComputedStyle(el);
+				if (style.display === 'none' || style.visibility === 'hidden') {
+					return false;
+				}
+				const rect = el.getBoundingClientRect();
+				return rect.width > 1 && rect.height > 1;
+			}, Selectors.SOUNDCLOUD_CAPTCHA_CONTAINER)
+			.catch(() => false);
+		if (!visible) return false;
+
+		const captchaIframe = await page.$(Selectors.SOUNDCLOUD_CAPTCHA_IFRAME);
+		if (!captchaIframe) {
+			console.log(
+				'Droploud: SoundCloud captcha visible; waiting for solve (no iframe yet)…',
+			);
+			await page
+				.waitForSelector(Selectors.SOUNDCLOUD_CAPTCHA_CONTAINER, {
+					hidden: true,
+					timeout: 120_000,
+				})
+				.catch(() => {});
+		} else {
+			console.log('Droploud: attempting DataDome slider solve…');
+			await timeout(1_500);
+			const frame = await captchaIframe.contentFrame();
+			if (!frame) {
+				await captchaIframe.dispose();
+				return false;
+			}
+
+			try {
+				await frame.waitForSelector(Selectors.SOUNDCLOUD_CAPTCHA_SLIDER, {
+					timeout: 20_000,
+				});
+			} catch {
+				await captchaIframe.dispose();
+				console.log(
+					'Droploud: captcha slider not ready; waiting for manual solve…',
+				);
+				await page
+					.waitForSelector(Selectors.SOUNDCLOUD_CAPTCHA_CONTAINER, {
+						hidden: true,
+						timeout: 120_000,
+					})
+					.catch(() => {});
+				await this.reloadTrackAfterCaptcha(page);
+				return true;
+			}
+
+			const slider = await frame.$(Selectors.SOUNDCLOUD_CAPTCHA_SLIDER);
+			const sliderTrack = await frame.$(Selectors.SOUNDCLOUD_CAPTCHA_TRACK);
+			const iframeBox = await captchaIframe.boundingBox();
+			const sliderBox = slider ? await slider.boundingBox() : null;
+			const trackBox = sliderTrack ? await sliderTrack.boundingBox() : null;
+			await slider?.dispose();
+			await sliderTrack?.dispose();
+			await captchaIframe.dispose();
+
+			if (iframeBox && sliderBox && trackBox) {
+				const startX = iframeBox.x + sliderBox.x + sliderBox.width / 2;
+				const startY = iframeBox.y + sliderBox.y + sliderBox.height / 2;
+				const endX =
+					iframeBox.x + trackBox.x + trackBox.width - sliderBox.width / 2;
+
+				await page.mouse.move(startX, startY);
+				await page.mouse.down();
+				await page.mouse.move(endX, startY, { steps: 25 });
+				await timeout(400);
+				await page.mouse.up();
+				console.log('Droploud: DataDome slider drag performed');
+			}
+
+			await page
+				.waitForSelector(Selectors.SOUNDCLOUD_CAPTCHA_CONTAINER, {
+					hidden: true,
+					timeout: 60_000,
+				})
+				.catch(() => {
+					console.warn(
+						'Droploud: captcha still visible after slider drag — solve it manually if needed.',
+					);
+				});
+		}
+
+		await this.reloadTrackAfterCaptcha(page);
+		return true;
+	}
+
+	private async reloadTrackAfterCaptcha(page: Page) {
+		if (page.isClosed()) return;
+		const url = page.url();
+		if (!url.includes('soundcloud.com')) return;
+		console.log(
+			'Droploud: captcha cleared — reloading track so engagement UI can mount…',
+		);
+		await page
+			.goto(url, { waitUntil: 'domcontentloaded', timeout: 45_000 })
+			.catch(() => page.reload({ waitUntil: 'domcontentloaded' }));
+		await timeout(1_500);
+		await this.dismissSoundcloudConsent(page);
+		await page
+			.waitForSelector(
+				`${Selectors.SOUNDCLOUD_REPOST_BUTTON}, ${Selectors.SOUNDCLOUD_SOUND_ACTIONS}`,
+				{ timeout: 25_000 },
+			)
+			.catch(() => {});
+	}
+
+	private isTransientPageError(error: unknown): boolean {
+		const message = error instanceof Error ? error.message : String(error);
+		return /detached Frame|Execution context was destroyed|Target closed|Session closed|frame was detached|Navigating frame was detached/i.test(
+			message,
+		);
+	}
+
+	/** Dismiss OneTrust preference center / banner so the engagement bar can mount. */
+	private async dismissSoundcloudConsent(page: Page) {
+		const clicked = await page
+			.evaluate(
+				(sels) => {
+					const pc = document.querySelector(sels.pc);
+					const banner = document.querySelector(sels.banner);
+					const pcOpen =
+						!!pc &&
+						!pc.classList.contains('ot-hide') &&
+						window.getComputedStyle(pc).display !== 'none';
+					const bannerOpen =
+						!!banner &&
+						!banner.classList.contains('ot-hide') &&
+						window.getComputedStyle(banner).display !== 'none' &&
+						(banner as HTMLElement).getBoundingClientRect().height > 1;
+
+					// Preference center open: force-click Allow All even if OT reports 0×0.
+					if (pcOpen) {
+						const allow = document.querySelector(
+							'#accept-recommended-btn-handler',
+						) as HTMLElement | null;
+						if (allow) {
+							allow.click();
+							return 'ot-pc-allow-all';
+						}
+						const confirm = document.querySelector(
+							'button.save-preference-btn-handler',
+						) as HTMLElement | null;
+						if (confirm) {
+							confirm.click();
+							return 'ot-pc-confirm';
+						}
+						const close = document.querySelector(
+							'#close-pc-btn-handler',
+						) as HTMLElement | null;
+						if (close) {
+							close.click();
+							return 'ot-pc-close';
+						}
+					}
+
+					if (bannerOpen) {
+						const accept = document.querySelector(
+							'#onetrust-accept-btn-handler',
+						) as HTMLElement | null;
+						if (accept) {
+							accept.click();
+							return 'ot-banner-accept';
+						}
+					}
+
+					const isVisible = (el: Element | null): el is HTMLElement => {
+						if (!el) return false;
+						const html = el as HTMLElement;
+						if (html.getClientRects().length === 0) return false;
+						const style = window.getComputedStyle(html);
+						if (style.display === 'none' || style.visibility === 'hidden') {
+							return false;
+						}
+						if (Number.parseFloat(style.opacity || '1') === 0) return false;
+						const rect = html.getBoundingClientRect();
+						return rect.width > 1 && rect.height > 1;
+					};
+
+					for (const sel of sels.accept.split(',')) {
+						const el = document.querySelector(sel.trim());
+						if (isVisible(el)) {
+							el.click();
+							return 'known';
+						}
+					}
+
+					const accept = Array.from(document.querySelectorAll('button')).find(
+						(btn) =>
+							isVisible(btn) &&
+							/^(allow\s*all|accept\s*(all|cookies)?|alle\s*akzeptieren|zustimmen|alles\s*erlauben|confirm\s*my\s*choices|reject\s*all)$/i.test(
+								(btn.textContent || '').replace(/\s+/g, ' ').trim(),
+							),
+					);
+					if (accept) {
+						accept.click();
+						return 'text';
+					}
+					return null;
+				},
+				{
+					accept: Selectors.SOUNDCLOUD_COOKIE_ACCEPT,
+					pc: Selectors.SOUNDCLOUD_COOKIE_PC,
+					banner: Selectors.SOUNDCLOUD_COOKIE_BANNER,
+				},
+			)
+			.catch(() => null);
+
+		if (clicked) {
+			console.log(`Droploud: dismissed SoundCloud consent (${clicked})`);
+			await page
+				.waitForFunction(
+					(pcSel) => {
+						const pc = document.querySelector(pcSel);
+						if (!pc) return true;
+						return (
+							pc.classList.contains('ot-hide') ||
+							window.getComputedStyle(pc).display === 'none'
+						);
+					},
+					{ timeout: 10_000 },
+					Selectors.SOUNDCLOUD_COOKIE_PC,
+				)
+				.catch(() => {});
+			await timeout(800);
+		}
+	}
+
+	/** Ensure the track engagement bar exists; reload once if consent blocked it. */
+	private async ensureSoundcloudEngagement(page: Page): Promise<Page> {
+		try {
+			await page.setViewport({ width: 1400, height: 900 });
+		} catch {
+			// ignore
+		}
+
+		await this.dismissSoundcloudConsent(page);
+
+		const ready = await page
+			.waitForSelector(
+				`${Selectors.SOUNDCLOUD_REPOST_BUTTON}, ${Selectors.SOUNDCLOUD_REPOST_BUTTON_MUI}, ${Selectors.SOUNDCLOUD_SOUND_ACTIONS}`,
+				{ timeout: 12_000 },
+			)
+			.then(() => true)
+			.catch(() => false);
+		if (ready) return page;
+
+		const url = page.url();
+		if (url.includes('soundcloud.com')) {
+			console.log('Droploud: engagement bar missing — reloading track page…');
+			await page.goto(url, {
+				waitUntil: 'domcontentloaded',
+				timeout: 30_000,
+			});
+			await timeout(1_000);
+			await this.dismissSoundcloudConsent(page);
+			await page
+				.waitForSelector(
+					`${Selectors.SOUNDCLOUD_REPOST_BUTTON}, ${Selectors.SOUNDCLOUD_REPOST_BUTTON_MUI}, ${Selectors.SOUNDCLOUD_SOUND_ACTIONS}`,
+					{ timeout: 20_000 },
+				)
+				.catch(() => {});
+		}
+		return page;
+	}
+
+	/**
+	 * In-page webi GraphQL repost (same mutation the MUI Repost button fires).
+	 */
+	private async repostViaPageFetch(
+		page: Page,
+		trackUrl?: string,
+	): Promise<boolean> {
+		let trackIdHint = '';
+		let oauthHint = process.env.SC_OAUTH_TOKEN?.trim() || '';
+		try {
+			const cookies = await loadCookies('soundcloud-cookies.json');
+			oauthHint =
+				cookies.find((c) => c.name === 'oauth_token')?.value || oauthHint;
+		} catch {
+			// optional
+		}
+		if (trackUrl) {
+			try {
+				const track = await new SoundcloudClient().getTrack(trackUrl);
+				trackIdHint = String(track.id);
+			} catch {
+				// page HTML may still have the urn
+			}
+		}
+
+		const result = await page
+			.evaluate(
+				async (hints) => {
+					const urnMatch =
+						document.body.innerHTML.match(/soundcloud:tracks:(\d+)/) ||
+						document.documentElement.innerHTML.match(/soundcloud:tracks:(\d+)/);
+					const trackId = urnMatch?.[1] || hints.trackIdHint;
+					if (!trackId) return { ok: false, reason: 'no-track-id' };
+
+					const clientId = (
+						document.cookie.match(/(?:^|;\s*)client_id=([^;]+)/)?.[1] ||
+						document.body.innerHTML.match(
+							/client_id["'=:\s]+([a-zA-Z0-9]{16,})/,
+						)?.[1] ||
+						'yNSW5UvBmb1A5j7qPUtIMuB9Itx3jsOC'
+					).trim();
+
+					const oauth =
+						document.cookie.match(/(?:^|;\s*)oauth_token=([^;]+)/)?.[1] ||
+						hints.oauthHint ||
+						'';
+					const datadome =
+						document.cookie.match(/(?:^|;\s*)datadome=([^;]+)/)?.[1] || '';
+
+					if (!oauth) {
+						return { ok: false, reason: 'no-oauth' };
+					}
+
+					const headers: Record<string, string> = {
+						accept: '*/*',
+						'content-type': 'application/json',
+						origin: 'https://soundcloud.com',
+						referer: location.href,
+						'apollographql-client-name': 'webi',
+						'apollographql-client-version': '0.1.0',
+						'app-locale': 'en',
+						Authorization: `OAuth ${oauth}`,
+					};
+					if (datadome) headers['x-datadome-clientid'] = datadome;
+
+					const res = await fetch(
+						`https://graph.soundcloud.com/graphql?client_id=${encodeURIComponent(clientId)}`,
+						{
+							method: 'POST',
+							credentials: 'include',
+							headers,
+							body: JSON.stringify({
+								query: `
+    mutation RepostTrack($trackUrn: ID!) {
+  repostTrack(trackRepost: {urn: $trackUrn}) {
+    __typename
+    ... on Repost {
+      caption
+    }
+    ... on TrackRepostFailedError {
+      errorMessage
+    }
+    ... on TrackRepostCaptionFailedError {
+      errorMessage
+    }
+  }
+}
+    `,
+								variables: { trackUrn: `soundcloud:tracks:${trackId}` },
+							}),
+						},
+					);
+					const body = await res.text();
+					if (!res.ok) {
+						return {
+							ok: false,
+							status: res.status,
+							reason: `http-${res.status}`,
+							body: body.slice(0, 160),
+						};
+					}
+					try {
+						const json = JSON.parse(body) as {
+							data?: {
+								repostTrack?: {
+									__typename?: string;
+									errorMessage?: string;
+								};
+							};
+						};
+						const typename = json.data?.repostTrack?.__typename || '';
+						if (typename === 'Repost' || typename === 'TrackRepost') {
+							return { ok: true, status: 200, reason: typename };
+						}
+						if (/FailedError$/i.test(typename)) {
+							return {
+								ok: false,
+								status: 200,
+								reason: json.data?.repostTrack?.errorMessage || typename,
+							};
+						}
+						if (typename) return { ok: true, status: 200, reason: typename };
+					} catch {
+						// ignore
+					}
+					return {
+						ok: false,
+						status: res.status,
+						reason: 'graphql-unexpected',
+						body: body.slice(0, 160),
+					};
+				},
+				{ trackIdHint, oauthHint },
+			)
+			.catch((error: unknown) => ({
+				ok: false as const,
+				reason:
+					error instanceof Error
+						? error.message.slice(0, 80)
+						: 'evaluate-failed',
+			}));
+
+		if (result?.ok) {
+			console.log(
+				`Droploud: SoundCloud repost via GraphQL (${'reason' in result ? result.reason : 'ok'})`,
+			);
+			return true;
+		}
+		console.warn(
+			`Droploud: in-page GraphQL repost failed (${'reason' in (result ?? {}) ? (result as { reason?: string }).reason : 'unknown'})`,
+		);
+		return false;
+	}
+
+	/**
+	 * Click Repost on the dedicated full-size track tab.
+	 */
+	private async repostTrackInBrowser(page: Page) {
+		const started = Date.now();
+		let ensured = false;
+		let fetchTried = false;
+
+		while (Date.now() - started < 60_000) {
+			if (page.isClosed()) {
+				throw new Error('SoundCloud track tab closed during repost.');
+			}
+
+			try {
+				await page.bringToFront().catch(() => {});
+
+				if (!ensured) {
+					page = await this.ensureSoundcloudEngagement(page);
+					ensured = true;
+				} else {
+					const solved = await this.handlePossibleCaptcha(page);
+					if (solved) {
+						// reloadTrackAfterCaptcha already ran — try click immediately
+						const afterCaptcha = await this.tryClickRepostButton(page);
+						if (afterCaptcha === 'already') {
+							console.log(
+								'Droploud: SoundCloud already reposted after captcha',
+							);
+							return;
+						}
+						if (afterCaptcha === 'clicked') {
+							await timeout(800);
+							await this.handlePossibleCaptcha(page);
+							if (await this.pageLooksReposted(page)) return;
+							if (await this.repostViaPageFetch(page, page.url())) return;
+						}
+					}
+					await this.dismissSoundcloudConsent(page);
+				}
+
+				if (await this.pageLooksReposted(page)) {
+					console.log('Droploud: track already looks reposted in the browser.');
+					return;
+				}
+
+				const action = await this.tryClickRepostButton(page);
+				if (action === 'already') {
+					console.log('Droploud: track already looks reposted in the browser.');
+					return;
+				}
+				if (action === 'clicked') {
+					console.log('Droploud: clicked SoundCloud Repost button');
+					await timeout(800);
+					const solved = await this.handlePossibleCaptcha(page);
+					if (solved) {
+						const again = await this.tryClickRepostButton(page);
+						if (again === 'already') {
+							console.log(
+								'Droploud: SoundCloud already reposted after post-click captcha',
+							);
+							return;
+						}
+					}
+					if (await this.pageLooksReposted(page)) return;
+					if (await this.repostViaPageFetch(page, page.url())) return;
+					console.warn(
+						'Droploud: browser Repost click did not confirm repost; retrying…',
+					);
+					await timeout(500);
+					continue;
+				}
+
+				// Still missing — try in-page GraphQL once, then keep waiting for UI.
+				if (!fetchTried) {
+					fetchTried = true;
+					if (await this.repostViaPageFetch(page, page.url())) return;
+				}
+			} catch (error) {
+				if (!this.isTransientPageError(error)) throw error;
+				console.warn(
+					`Droploud: transient page error during repost (${error instanceof Error ? error.message : String(error)}); retrying…`,
+				);
+				ensured = false;
+				await timeout(500);
+				continue;
+			}
+
+			await timeout(500);
+		}
+
+		const debug = await page
+			.evaluate(() => ({
+				url: location.href,
+				w: window.innerWidth,
+				h: window.innerHeight,
+				hasClassic: !!document.querySelector('button.sc-button-repost'),
+				hasSelected: !!document.querySelector(
+					'button.sc-button-repost.sc-button-selected',
+				),
+				hasSoundActions: !!document.querySelector(
+					'.soundActions, .listenEngagement__actions',
+				),
+				hasListen: !!document.querySelector(
+					'.l-listen-wrapper, .fullHero, .listenEngagement',
+				),
+				otPcOpen: (() => {
+					const pc = document.querySelector('#onetrust-pc-sdk');
+					return (
+						!!pc &&
+						!pc.classList.contains('ot-hide') &&
+						window.getComputedStyle(pc).display !== 'none'
+					);
+				})(),
+			}))
+			.catch(() => null);
+		console.warn('Droploud: Repost button debug', debug);
+		throw new Error(
+			'SoundCloud Repost button not found. Is the account logged in (Initialize Logins)?',
+		);
 	}
 
 	private async handleSoundcloudConnect(page: Page) {
@@ -950,12 +1743,24 @@ export class DroploudDownloader {
 			}
 
 			if (url.includes('soundcloud.com')) {
+				// Wait for the OAuth document to settle — early navigations can briefly
+				// show marketing/login copy before the session cookies apply.
 				const needsLogin = await oauthPage
-					.evaluate(() =>
-						/sign in or create an account/i.test(
-							document.body?.innerText || '',
-						),
-					)
+					.evaluate(async () => {
+						const loginRe = /sign in or create an account/i;
+						if (!loginRe.test(document.body?.innerText || '')) return false;
+						await new Promise((r) => setTimeout(r, 1_500));
+						const text = document.body?.innerText || '';
+						const hasApproval =
+							!!document.querySelector('button#submit_approval') ||
+							!!document.querySelector('button[name="accept"]') ||
+							Array.from(document.querySelectorAll('button')).some((btn) =>
+								/^(allow|accept|connect)$/i.test(
+									(btn.textContent || '').trim(),
+								),
+							);
+						return loginRe.test(text) && !hasApproval;
+					})
 					.catch(() => false);
 				if (needsLogin) {
 					throw new Error(

--- a/src/droploud.ts
+++ b/src/droploud.ts
@@ -788,6 +788,7 @@ export class DroploudDownloader {
 				'Droploud: waiting up to 2 minutes for manual Repost / captcha solve…',
 			);
 			const manualDeadline = Date.now() + 120_000;
+			let nextApiCheck = 0;
 			while (Date.now() < manualDeadline) {
 				if (page.isClosed()) break;
 				await this.handlePossibleCaptcha(page).catch(() => false);
@@ -797,12 +798,27 @@ export class DroploudDownloader {
 					);
 					return;
 				}
-				const status = await alreadyReposted(page);
-				if (status) {
+				if (
+					!page.isClosed() &&
+					(await this.pageLooksReposted(page).catch(() => false))
+				) {
 					console.log(
-						`Droploud: SoundCloud repost confirmed after manual UI (${status}).`,
+						'Droploud: SoundCloud repost confirmed after manual UI (ui).',
 					);
 					return;
+				}
+				if (Date.now() >= nextApiCheck) {
+					nextApiCheck = Date.now() + 15_000;
+					try {
+						if (await soundcloud.isTrackReposted(trackUrl)) {
+							console.log(
+								'Droploud: SoundCloud repost confirmed after manual UI (api).',
+							);
+							return;
+						}
+					} catch {
+						// logged inside isTrackReposted
+					}
 				}
 				await this.tryClickRepostButton(page).catch(() => null);
 				await timeout(1_000);

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,13 +147,12 @@ try {
 			await downloadgaterDownloader.close();
 		}
 	} else {
-		// Fast path: gates that are purely client-side (email + social follow/like/
-		// repost buttons) can be satisfied with plain HTTP, skipping the browser.
+		// Hypeddit: always try plain HTTP first (email + social skip gates).
 		const httpDownloader = new HypedditHttpDownloader(gateConfig);
 		downloadFilename = await httpDownloader.tryDownload(gateUrl);
 
-		// Fall back to the browser for gates that need real verification (Spotify, ...).
-		if (!downloadFilename) {
+		// HTTP first. Browser fallback only when not headless (user wants a window).
+		if (!downloadFilename && !gateConfig.headless) {
 			usedBrowser = true;
 			const hypedditDownloader = new HypedditDownloader(gateConfig);
 			try {
@@ -171,6 +170,10 @@ try {
 			} finally {
 				await hypedditDownloader.close();
 			}
+		} else if (!downloadFilename && gateConfig.headless) {
+			console.log(
+				'Browserless: Hypeddit gate needs a browser (e.g. Spotify). Re-run with headless disabled to allow a browser fallback.',
+			);
 		}
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ try {
 		? config.headless
 		: await confirm({
 				message:
-					'Do you want to run the browser in headless mode? (You will not see the browser window but the process will run in the background). If something does not work it is recommended to turn it off.',
+					'Run headless? (no browser window). Headless also skips the Hypeddit browser fallback — gates that need Spotify/etc. will fail unless you turn headless off.',
 				default: true,
 			});
 
@@ -171,8 +171,8 @@ try {
 				await hypedditDownloader.close();
 			}
 		} else if (!downloadFilename && gateConfig.headless) {
-			console.log(
-				'Browserless: Hypeddit gate needs a browser (e.g. Spotify). Re-run with headless disabled to allow a browser fallback.',
+			throw new Error(
+				'This Hypeddit gate needs a browser (e.g. Spotify). Re-run with headless disabled to allow a browser fallback.',
 			);
 		}
 	}

--- a/src/jobStore.ts
+++ b/src/jobStore.ts
@@ -19,6 +19,7 @@ class JobStore {
 			id,
 			soundcloudUrl,
 			hypedditUrl: null,
+			headless: process.env.BROWSER_HEADLESS !== 'false',
 			track: null,
 			defaultMetadata: null,
 			progress: {

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -7,6 +7,19 @@ const SOUNDCLOUD_CAPTCHA_TRACK = '.sliderText';
 
 const SPOTIFY_ACCOUNT_SETTINGS_LINK = '#account-settings-link';
 
+// SoundCloud track page — classic (sc-button-*) and Next/MUI (aria-label)
+const SOUNDCLOUD_REPOST_BUTTON = 'button.sc-button-repost';
+const SOUNDCLOUD_REPOST_BUTTON_SELECTED =
+	'button.sc-button-repost.sc-button-selected';
+const SOUNDCLOUD_REPOST_BUTTON_MUI =
+	'button[aria-label="Repost"], button[title="Repost"], [title="Repost"] > button';
+const SOUNDCLOUD_SOUND_ACTIONS =
+	'.soundActions, .listenEngagement__footer, .listenEngagement__actions';
+const SOUNDCLOUD_COOKIE_ACCEPT =
+	'#onetrust-accept-btn-handler, #accept-recommended-btn-handler, button.ot-pc-refuse-all-handler, button.save-preference-btn-handler.onetrust-close-btn-handler';
+const SOUNDCLOUD_COOKIE_PC = '#onetrust-pc-sdk';
+const SOUNDCLOUD_COOKIE_BANNER = '#onetrust-banner-sdk';
+
 // Hypeddit smart link selection page (shown when the URL is a multi-platform smart link)
 const HYPEDDIT_SMART_LINK_SECTION = '.hype-smart-link-list-section';
 const HYPEDDIT_SMART_LINK_HYPEDDIT_ANCHOR = `${HYPEDDIT_SMART_LINK_SECTION} a.smartlink-click-button[data-type="hypeddit"]`;
@@ -101,6 +114,13 @@ export default {
 	SOUNDCLOUD_CAPTCHA_IFRAME,
 	SOUNDCLOUD_CAPTCHA_SLIDER,
 	SOUNDCLOUD_CAPTCHA_TRACK,
+	SOUNDCLOUD_REPOST_BUTTON,
+	SOUNDCLOUD_REPOST_BUTTON_SELECTED,
+	SOUNDCLOUD_REPOST_BUTTON_MUI,
+	SOUNDCLOUD_SOUND_ACTIONS,
+	SOUNDCLOUD_COOKIE_ACCEPT,
+	SOUNDCLOUD_COOKIE_PC,
+	SOUNDCLOUD_COOKIE_BANNER,
 	SPOTIFY_ACCOUNT_SETTINGS_LINK,
 	HYPEDDIT_SMART_LINK_SECTION,
 	HYPEDDIT_SMART_LINK_HYPEDDIT_ANCHOR,

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
-import { rm } from 'node:fs/promises';
-import { join } from 'node:path';
+import { cp, mkdir, rm } from 'node:fs/promises';
+import { basename, join } from 'node:path';
 import type { SoundcloudTrack } from 'soundcloud.ts';
 import { AudioProcessor } from './audioProcessor';
 import { DownloadgaterDownloader } from './downloadgater';
@@ -22,6 +22,8 @@ import {
 
 const ffmpegBin = await getFfmpegBin();
 const ffprobeBin = await getFfprobeBin();
+
+const SHARED_BROWSER_DATA = './browser-data';
 
 function getRequiredEnv(name: string): string {
 	const value = process.env[name];
@@ -57,6 +59,47 @@ const activeDownloaders = new Map<string, AnyDownloader>();
 const jobProfileDirs = new Map<string, string>();
 /** In-flight close+profile cleanup so SIGINT cannot delete a profile mid-close. */
 const closingJobs = new Map<string, Promise<void>>();
+
+/**
+ * Job profiles start empty, which drops the SoundCloud session from Initialize
+ * Logins (stored in ./browser-data). Seed each job dir from that shared profile
+ * so OAuth still sees a logged-in session while jobs stay isolated.
+ */
+async function prepareJobUserDataDir(jobId: string): Promise<string> {
+	const userDataDir = join(SHARED_BROWSER_DATA, 'jobs', jobId);
+	await rm(userDataDir, { recursive: true, force: true }).catch(() => {});
+	await mkdir(userDataDir, { recursive: true });
+
+	const sharedDefault = join(SHARED_BROWSER_DATA, 'Default');
+	const skipDirNames = new Set([
+		'Cache',
+		'Code Cache',
+		'GPUCache',
+		'GrShaderCache',
+		'ShaderCache',
+		'DawnGraphiteCache',
+		'DawnWebGPUCache',
+		'Service Worker',
+		'Blob',
+		'File System',
+	]);
+
+	try {
+		await cp(sharedDefault, join(userDataDir, 'Default'), {
+			recursive: true,
+			filter: (source) => {
+				const name = basename(source);
+				if (name === 'LOCK' || name === 'SingletonLock') return false;
+				if (skipDirNames.has(name)) return false;
+				return true;
+			},
+		});
+	} catch {
+		// No shared profile yet — soundcloud-cookies.json injection still applies.
+	}
+
+	return userDataDir;
+}
 
 async function closeJobDownloader(jobId: string): Promise<void> {
 	const existing = closingJobs.get(jobId);
@@ -126,15 +169,17 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 			extra?: Partial<Job['progress']>,
 		) => jobStore.updateProgress(jobId, stage, message, percent, extra);
 
-		// CloakBrowser + DataDome: headed is more reliable (captcha reuses main session).
-		const headless = process.env.BROWSER_HEADLESS === 'true';
-		const userDataDir = join('./browser-data', 'jobs', jobId);
-		const gateConfig = {
+		const gateConfigBase = {
 			name: HYPEDDIT_NAME,
 			email: HYPEDDIT_EMAIL,
 			comment: SC_COMMENT,
-			headless,
-			userDataDir,
+			headless: job.headless,
+		};
+
+		const prepareBrowserConfig = async () => {
+			const userDataDir = await prepareJobUserDataDir(jobId);
+			jobProfileDirs.set(jobId, userDataDir);
+			return { ...gateConfigBase, userDataDir };
 		};
 
 		let downloadFilename: string | null = null;
@@ -146,8 +191,9 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 				'Launching browser for Droploud...',
 				10,
 			);
-			const droploudDownloader = new DroploudDownloader(gateConfig);
-			jobProfileDirs.set(jobId, userDataDir);
+			const droploudDownloader = new DroploudDownloader(
+				await prepareBrowserConfig(),
+			);
 			activeDownloaders.set(jobId, droploudDownloader);
 			droploudDownloader.setProgressCallback(emitProgress);
 			await droploudDownloader.initialize();
@@ -166,8 +212,9 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 				'Launching browser for GateRush...',
 				10,
 			);
-			const gaterushDownloader = new GaterushDownloader(gateConfig);
-			jobProfileDirs.set(jobId, userDataDir);
+			const gaterushDownloader = new GaterushDownloader(
+				await prepareBrowserConfig(),
+			);
 			activeDownloaders.set(jobId, gaterushDownloader);
 			gaterushDownloader.setProgressCallback(emitProgress);
 			await gaterushDownloader.initialize();
@@ -186,8 +233,9 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 				'Launching browser for DownloadGater...',
 				10,
 			);
-			const downloadgaterDownloader = new DownloadgaterDownloader(gateConfig);
-			jobProfileDirs.set(jobId, userDataDir);
+			const downloadgaterDownloader = new DownloadgaterDownloader(
+				await prepareBrowserConfig(),
+			);
 			activeDownloaders.set(jobId, downloadgaterDownloader);
 			downloadgaterDownloader.setProgressCallback(emitProgress);
 			await downloadgaterDownloader.initialize();
@@ -200,31 +248,33 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 			downloadFilename = await downloadgaterDownloader.downloadAudio(gateUrl);
 			await closeJobDownloader(jobId);
 		} else {
-			// Fast path: gates that are purely client-side (email + social follow/like/
-			// repost buttons) can be satisfied with plain HTTP, skipping the browser.
+			// Hypeddit: always try plain HTTP first (email + social skip gates).
 			jobStore.updateProgress(
 				jobId,
 				'handling_gates',
-				'Trying browserless download...',
+				'Trying browserless Hypeddit download...',
 				15,
 			);
 			const httpDownloader = new HypedditHttpDownloader(
-				gateConfig,
+				gateConfigBase,
 				emitProgress,
 			);
 			downloadFilename = await httpDownloader.tryDownload(gateUrl);
 
-			// Fall back to the browser for gates that need real verification (Spotify, ...).
-			if (!downloadFilename) {
+			// Always try HTTP first. Open a browser only when the user checked
+			// “Show browser window” (headful) and the gate needs real verification
+			// (e.g. Spotify). Headless stays fully browserless for Hypeddit.
+			if (!downloadFilename && !job.headless) {
 				jobStore.updateProgress(
 					jobId,
 					'initializing_browser',
-					'Launching browser...',
+					'Launching browser for Hypeddit...',
 					10,
 				);
 
-				const hypedditDownloader = new HypedditDownloader(gateConfig);
-				jobProfileDirs.set(jobId, userDataDir);
+				const hypedditDownloader = new HypedditDownloader(
+					await prepareBrowserConfig(),
+				);
 				activeDownloaders.set(jobId, hypedditDownloader);
 				hypedditDownloader.setProgressCallback(emitProgress);
 				await hypedditDownloader.initialize();
@@ -238,6 +288,10 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 
 				downloadFilename = await hypedditDownloader.downloadAudio(gateUrl);
 				await closeJobDownloader(jobId);
+			} else if (!downloadFilename && job.headless) {
+				console.log(
+					'Browserless: Hypeddit gate needs a browser (e.g. Spotify). Enable “Show browser window (headful)” to continue.',
+				);
 			}
 		}
 
@@ -531,6 +585,15 @@ const server = Bun.serve({
 							{ error: 'Job is already in progress or completed' },
 							{ status: 400 },
 						);
+					}
+
+					try {
+						const body = (await req.json()) as { headless?: boolean };
+						if (typeof body.headless === 'boolean') {
+							jobStore.update(jobId, { headless: body.headless });
+						}
+					} catch {
+						// No/empty JSON body — keep job default / BROWSER_HEADLESS
 					}
 
 					runDownloadProcess(jobId);

--- a/src/server.ts
+++ b/src/server.ts
@@ -289,9 +289,11 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 				downloadFilename = await hypedditDownloader.downloadAudio(gateUrl);
 				await closeJobDownloader(jobId);
 			} else if (!downloadFilename && job.headless) {
-				console.log(
-					'Browserless: Hypeddit gate needs a browser (e.g. Spotify). Enable “Show browser window (headful)” to continue.',
+				jobStore.setError(
+					jobId,
+					'This Hypeddit gate needs a browser (e.g. Spotify). Enable “Show browser window (headful)” and retry.',
 				);
+				return;
 			}
 		}
 

--- a/src/soundcloud.ts
+++ b/src/soundcloud.ts
@@ -53,27 +53,59 @@ export class SoundcloudClient {
 	}
 
 	/**
-	 * Repost a track (PUT me/track_reposts/:id) using the same soundcloud.ts API
-	 * path as deleteV2. DataDome protects this write; DELETE cleanup is not.
-	 * Falls back to Chrome-TLS curl (+ optional residential proxy) when Bun is blocked.
+	 * True if this track is already in the account's reposts (GET, not DataDome PUT).
+	 */
+	async isTrackReposted(trackUrlOrId: string): Promise<boolean> {
+		const track = await this.getTrack(trackUrlOrId);
+		const trackId = Number(track.id);
+		try {
+			const reposts = await this.paginateCollection<
+				number | { id?: number | string }
+			>('me/track_reposts/ids', { limit: 200, offset: 0 });
+			return reposts.some((entry) => {
+				const id = typeof entry === 'number' ? entry : Number(entry?.id);
+				return id === trackId;
+			});
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			console.warn(
+				`SoundCloud isTrackReposted check failed for ${trackId}: ${message.slice(0, 160)}`,
+			);
+			throw error;
+		}
+	}
+
+	/**
+	 * Webi/MUI SoundCloud uses GraphQL `RepostTrack` (not classic PUT
+	 * me/track_reposts). Prefer that; fall back to PUT + Chrome-TLS curl.
 	 */
 	async repostTrack(trackUrlOrId: string): Promise<SoundcloudTrack> {
 		const track = await this.getTrack(trackUrlOrId);
-		const endpoint = `me/track_reposts/${track.id}`;
 
+		const gql = await this.repostTrackViaGraphql(track);
+		if (gql.ok) return track;
+
+		// Bun/fetch GraphQL is often DataDome 403; retry with Chrome TLS.
+		if (gql.status === 403 || /captcha-delivery/i.test(gql.body)) {
+			const chromeGql = await this.chromeTlsGraphqlRepost(track);
+			if (chromeGql.ok) return track;
+			gql.status = chromeGql.status;
+			gql.reason = chromeGql.reason;
+			gql.body = chromeGql.body;
+		}
+
+		const endpoint = `me/track_reposts/${track.id}`;
 		try {
 			await this.soundcloud.api.putV2(endpoint);
 			return track;
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			if (!/status code 403/i.test(message) && !/403/.test(message)) {
-				// 422/409 from some gateways — treat as already reposted if we can detect
 				if (/status code (422|409)/i.test(message)) return track;
 				throw error;
 			}
 		}
 
-		// Bun TLS is often flagged for engagement PUTs; mirror real Chrome via curl-impersonate.
 		const chromeResult = await this.chromeTlsMutate('PUT', endpoint);
 		if (
 			chromeResult.status === 200 ||
@@ -85,20 +117,268 @@ export class SoundcloudClient {
 			return track;
 		}
 
-		const captchaUrl = extractCaptchaDeliveryUrl(chromeResult.body);
+		const captchaUrl =
+			extractCaptchaDeliveryUrl(chromeResult.body) ||
+			extractCaptchaDeliveryUrl(gql.body);
 		const hardBlocked = /you have been blocked|unusual activity/i.test(
-			chromeResult.body,
+			`${chromeResult.body}\n${gql.body}`,
 		);
 		const proxyHint =
-			' Engagement PUTs are DataDome-protected (DELETE cleanup is not). Set SC_API_PROXY or CLOAKBROWSER_PROXY to a residential proxy and retry.';
+			' Engagement writes are DataDome-protected. Set SC_API_PROXY or CLOAKBROWSER_PROXY to a residential proxy and retry.';
 		const error = new Error(
 			hardBlocked
 				? `Failed to repost SoundCloud track ${track.id}: DataDome hard-blocked this IP.${proxyHint}`
-				: `Failed to repost SoundCloud track ${track.id}: HTTP ${chromeResult.status}${chromeResult.body ? ` ${chromeResult.body.slice(0, 200)}` : ''}.${proxyHint}`,
+				: `Failed to repost SoundCloud track ${track.id}: GraphQL ${gql.status}/${gql.reason}; PUT HTTP ${chromeResult.status}${chromeResult.body ? ` ${chromeResult.body.slice(0, 160)}` : ''}.${proxyHint}`,
 		) as Error & { captchaUrl?: string; status?: number };
-		error.status = chromeResult.status;
+		error.status = chromeResult.status || gql.status;
 		if (captchaUrl) error.captchaUrl = captchaUrl;
 		throw error;
+	}
+
+	/**
+	 * Same mutation the webi player fires on Repost
+	 * (apollographql-client-name: webi).
+	 */
+	async repostTrackViaGraphql(
+		track: SoundcloudTrack | string,
+	): Promise<{ ok: boolean; status: number; reason: string; body: string }> {
+		const resolved =
+			typeof track === 'string' ? await this.getTrack(track) : track;
+		const trackUrn = `soundcloud:tracks:${resolved.id}`;
+		const clientId =
+			this.soundcloud.api.clientId ?? process.env.SC_CLIENT_ID ?? '';
+		const oauthToken =
+			this.soundcloud.api.oauthToken ?? process.env.SC_OAUTH_TOKEN ?? '';
+
+		const url = new URL('https://graph.soundcloud.com/graphql');
+		url.searchParams.set('client_id', clientId);
+
+		const query = `
+    mutation RepostTrack($trackUrn: ID!) {
+  repostTrack(trackRepost: {urn: $trackUrn}) {
+    __typename
+    ... on Repost {
+      caption
+    }
+    ... on TrackRepostFailedError {
+      errorMessage
+    }
+    ... on TrackRepostCaptionFailedError {
+      errorMessage
+    }
+  }
+}
+    `;
+
+		const headers: Record<string, string> = {
+			accept: '*/*',
+			'content-type': 'application/json',
+			origin: 'https://soundcloud.com',
+			referer: 'https://soundcloud.com/',
+			'apollographql-client-name': 'webi',
+			'apollographql-client-version': '0.1.0',
+			'app-locale': 'en',
+			Authorization: `OAuth ${oauthToken}`,
+		};
+
+		try {
+			const cookies = await loadCookies('soundcloud-cookies.json');
+			const datadome = cookies.find((c) => c.name === 'datadome')?.value;
+			if (cookies.length) {
+				headers.Cookie = cookies.map((c) => `${c.name}=${c.value}`).join('; ');
+			}
+			if (datadome) headers['x-datadome-clientid'] = datadome;
+		} catch {
+			// optional
+		}
+
+		const response = await fetch(url, {
+			method: 'POST',
+			headers,
+			body: JSON.stringify({
+				query,
+				variables: { trackUrn },
+			}),
+			signal: AbortSignal.timeout(30_000),
+		});
+		const body = await response.text().catch(() => '');
+
+		if (!response.ok) {
+			return {
+				ok: false,
+				status: response.status,
+				reason: `http-${response.status}`,
+				body,
+			};
+		}
+
+		try {
+			const json = JSON.parse(body) as {
+				data?: {
+					repostTrack?: {
+						__typename?: string;
+						errorMessage?: string;
+					};
+				};
+				errors?: { message?: string }[];
+			};
+			const result = json.data?.repostTrack;
+			const typename = result?.__typename || '';
+			if (typename === 'Repost') {
+				return { ok: true, status: 200, reason: 'repost', body };
+			}
+			if (/FailedError$/i.test(typename)) {
+				return {
+					ok: false,
+					status: 200,
+					reason: result?.errorMessage || typename,
+					body,
+				};
+			}
+			if (json.errors?.length) {
+				return {
+					ok: false,
+					status: 200,
+					reason: json.errors[0]?.message || 'graphql-errors',
+					body,
+				};
+			}
+			// Already reposted often still returns a Repost-like payload; accept empty ok typename edge cases via ids check later
+			if (typename) {
+				return { ok: true, status: 200, reason: typename, body };
+			}
+		} catch {
+			// fall through
+		}
+
+		return { ok: false, status: response.status, reason: 'parse-failed', body };
+	}
+
+	private async chromeTlsGraphqlRepost(
+		track: SoundcloudTrack,
+	): Promise<{ ok: boolean; status: number; reason: string; body: string }> {
+		const curlBin =
+			(await lookpath('curl_chrome131')) ||
+			(await lookpath('curl_chrome116')) ||
+			(await lookpath('curl-impersonate'));
+		if (!curlBin) {
+			return {
+				ok: false,
+				status: 0,
+				reason: 'no-curl-chrome',
+				body: '',
+			};
+		}
+
+		const clientId =
+			this.soundcloud.api.clientId ?? process.env.SC_CLIENT_ID ?? '';
+		const oauthToken =
+			this.soundcloud.api.oauthToken ?? process.env.SC_OAUTH_TOKEN ?? '';
+		const trackUrn = `soundcloud:tracks:${track.id}`;
+		const url = `https://graph.soundcloud.com/graphql?client_id=${encodeURIComponent(clientId)}`;
+		const payload = JSON.stringify({
+			query: `
+    mutation RepostTrack($trackUrn: ID!) {
+  repostTrack(trackRepost: {urn: $trackUrn}) {
+    __typename
+    ... on Repost {
+      caption
+    }
+    ... on TrackRepostFailedError {
+      errorMessage
+    }
+    ... on TrackRepostCaptionFailedError {
+      errorMessage
+    }
+  }
+}
+    `,
+			variables: { trackUrn },
+		});
+
+		const escapeCurlConfig = (value: string) =>
+			value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+		const configLines = [
+			`url = "${escapeCurlConfig(url)}"`,
+			`header = "Authorization: OAuth ${escapeCurlConfig(oauthToken)}"`,
+		];
+		const args = [
+			'-sS',
+			'-w',
+			'\n__STATUS__:%{http_code}',
+			'-X',
+			'POST',
+			'-H',
+			'Origin: https://soundcloud.com',
+			'-H',
+			'Referer: https://soundcloud.com/',
+			'-H',
+			'content-type: application/json',
+			'-H',
+			'apollographql-client-name: webi',
+			'-H',
+			'apollographql-client-version: 0.1.0',
+			'-H',
+			'app-locale: en',
+			'-H',
+			'accept: */*',
+			'--data-binary',
+			payload,
+		];
+
+		try {
+			const cookies = await loadCookies('soundcloud-cookies.json');
+			const datadome = cookies.find((c) => c.name === 'datadome')?.value;
+			if (cookies.length) {
+				args.push(
+					'-H',
+					`Cookie: ${cookies.map((c) => `${c.name}=${c.value}`).join('; ')}`,
+				);
+			}
+			if (datadome) args.push('-H', `x-datadome-clientid: ${datadome}`);
+		} catch {
+			// optional
+		}
+
+		const proxy =
+			process.env.SC_API_PROXY?.trim() ||
+			process.env.CLOAKBROWSER_PROXY?.trim() ||
+			process.env.PROXY_URL?.trim();
+		if (proxy) args.push('-x', proxy);
+		args.push('--config', '-');
+
+		const result = await execa(curlBin, args, {
+			input: `${configLines.join('\n')}\n`,
+			reject: false,
+		});
+		const output = `${result.stdout}${result.stderr}`;
+		const statusMatch = output.match(/__STATUS__:(\d+)\s*$/);
+		const status = statusMatch ? Number(statusMatch[1]) : 0;
+		const body = output.replace(/\n__STATUS__:\d+\s*$/, '');
+
+		if (status < 200 || status >= 300) {
+			return { ok: false, status, reason: `http-${status}`, body };
+		}
+		try {
+			const json = JSON.parse(body) as {
+				data?: { repostTrack?: { __typename?: string; errorMessage?: string } };
+			};
+			const typename = json.data?.repostTrack?.__typename || '';
+			if (
+				typename === 'Repost' ||
+				(!!typename && !/FailedError$/i.test(typename))
+			) {
+				return { ok: true, status, reason: typename || 'ok', body };
+			}
+			return {
+				ok: false,
+				status,
+				reason: json.data?.repostTrack?.errorMessage || typename || 'failed',
+				body,
+			};
+		} catch {
+			return { ok: false, status, reason: 'parse-failed', body };
+		}
 	}
 
 	/**

--- a/src/soundcloud.ts
+++ b/src/soundcloud.ts
@@ -192,15 +192,26 @@ export class SoundcloudClient {
 			// optional
 		}
 
-		const response = await fetch(url, {
-			method: 'POST',
-			headers,
-			body: JSON.stringify({
-				query,
-				variables: { trackUrn },
-			}),
-			signal: AbortSignal.timeout(30_000),
-		});
+		let response: Response;
+		try {
+			response = await fetch(url, {
+				method: 'POST',
+				headers,
+				body: JSON.stringify({
+					query,
+					variables: { trackUrn },
+				}),
+				signal: AbortSignal.timeout(30_000),
+			});
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			return {
+				ok: false,
+				status: 0,
+				reason: `fetch-failed:${message.slice(0, 80)}`,
+				body: '',
+			};
+		}
 		const body = await response.text().catch(() => '');
 
 		if (!response.ok) {
@@ -330,12 +341,18 @@ export class SoundcloudClient {
 			const cookies = await loadCookies('soundcloud-cookies.json');
 			const datadome = cookies.find((c) => c.name === 'datadome')?.value;
 			if (cookies.length) {
-				args.push(
-					'-H',
-					`Cookie: ${cookies.map((c) => `${c.name}=${c.value}`).join('; ')}`,
+				const cookieHeader = cookies
+					.map((c) => `${c.name}=${c.value}`)
+					.join('; ');
+				configLines.push(
+					`header = "Cookie: ${escapeCurlConfig(cookieHeader)}"`,
 				);
 			}
-			if (datadome) args.push('-H', `x-datadome-clientid: ${datadome}`);
+			if (datadome) {
+				configLines.push(
+					`header = "x-datadome-clientid: ${escapeCurlConfig(datadome)}"`,
+				);
+			}
 		} catch {
 			// optional
 		}
@@ -436,13 +453,17 @@ export class SoundcloudClient {
 			const cookies = await loadCookies('soundcloud-cookies.json');
 			const datadome = cookies.find((c) => c.name === 'datadome')?.value;
 			if (cookies.length) {
-				args.push(
-					'-H',
-					`Cookie: ${cookies.map((c) => `${c.name}=${c.value}`).join('; ')}`,
+				const cookieHeader = cookies
+					.map((c) => `${c.name}=${c.value}`)
+					.join('; ');
+				configLines.push(
+					`header = "Cookie: ${escapeCurlConfig(cookieHeader)}"`,
 				);
 			}
 			if (datadome) {
-				args.push('-H', `x-datadome-clientid: ${datadome}`);
+				configLines.push(
+					`header = "x-datadome-clientid: ${escapeCurlConfig(datadome)}"`,
+				);
 			}
 		} catch {
 			// optional

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,8 @@ export interface Job {
 	id: string;
 	soundcloudUrl: string;
 	hypedditUrl: string | null;
+	/** Whether browser automation runs headless. Defaults to true. */
+	headless: boolean;
 	track: {
 		title: string;
 		artworkUrl: string | null;

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -46,6 +46,7 @@ export default function App() {
 	const [soundcloudUrl, setSoundcloudUrl] = useState('');
 	const [hypedditUrlInput, setHypedditUrlInput] = useState('');
 	const [skipAutomaticHypedditFetch, setSkipAutomaticHypedditFetch] = useState(false);
+	const [headfulMode, setHeadfulMode] = useState(false);
 	const [job, setJob] = useState<JobState>({
 		jobId: null,
 		track: null,
@@ -221,6 +222,8 @@ export default function App() {
 		try {
 			const response = await fetch(`${API_BASE}/api/job/${jobId}/start`, {
 				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ headless: !headfulMode }),
 			});
 
 			if (!response.ok) {
@@ -266,7 +269,7 @@ export default function App() {
 				error: err instanceof Error ? err.message : 'Unknown error',
 			}));
 		}
-	}, [showCleanupSoundcloudToast]);
+	}, [headfulMode, showCleanupSoundcloudToast]);
 
 	// Process metadata and finalize
 	const handleMetadataSubmit = async (e: React.FormEvent) => {
@@ -321,6 +324,7 @@ export default function App() {
 		setSoundcloudUrl('');
 		setHypedditUrlInput('');
 		setSkipAutomaticHypedditFetch(false);
+		setHeadfulMode(false);
 		setJob({
 			jobId: null,
 			track: null,
@@ -482,6 +486,16 @@ export default function App() {
 							/>
 							<span>Skip automatic gate link fetching</span>
 						</label>
+						<label className="checkbox-row" htmlFor="headful-mode">
+							<input
+								id="headful-mode"
+								type="checkbox"
+								checked={headfulMode}
+								onChange={(e) => setHeadfulMode(e.target.checked)}
+								disabled={isLoading}
+							/>
+							<span>Show browser window (headful)</span>
+						</label>
 						<button type="submit" className="btn-primary" disabled={isLoading}>
 							{isLoading ? (
 								<>
@@ -520,6 +534,16 @@ export default function App() {
 								disabled={isLoading}
 							/>
 						</div>
+						<label className="checkbox-row" htmlFor="headful-mode-gate">
+							<input
+								id="headful-mode-gate"
+								type="checkbox"
+								checked={headfulMode}
+								onChange={(e) => setHeadfulMode(e.target.checked)}
+								disabled={isLoading}
+							/>
+							<span>Show browser window (headful)</span>
+						</label>
 						<button type="submit" className="btn-primary" disabled={isLoading}>
 							{isLoading ? (
 								<>


### PR DESCRIPTION
## Summary
- Droploud SoundCloud repost uses the webi `RepostTrack` GraphQL mutation on Droploud’s existing tab (no extra tab, no login-cookie stripping), and only treats the step as done when UI/API confirms it.
- WebUI defaults to headless with an optional “Show browser window (headful)” toggle; `BROWSER_HEADLESS` docs updated accordingly.
- Hypeddit still tries browserless HTTP first; a browser is only opened when headful mode is enabled and the gate needs real verification (e.g. Spotify).

## Test plan
- [ ] Run a Droploud gate with SoundCloud Repost (headful): stay logged in, see GraphQL success log, Droploud verify passes
- [ ] Confirm a track that cannot be reposted manually still fails cleanly (no fake UI success)
- [ ] Hypeddit email/social-only gate with headful unchecked: completes via HTTP, no browser
- [ ] Hypeddit gate needing Spotify with headful checked: HTTP fails over to visible browser
- [ ] WebUI headful checkbox toggles headed vs headless CloakBrowser for Droploud

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a headful mode option to show the browser during download jobs.
  - Browser jobs now default to headless mode, with configuration available to enable visible browsing.
  - Improved SoundCloud reposting with existing-repost detection and multiple fallback methods.
  - Added isolated browser profiles that preserve authenticated sessions across jobs.

- **Bug Fixes**
  - Improved handling of SoundCloud consent prompts, login states, CAPTCHA challenges, and repost controls.
  - Hypeddit downloads now try direct downloads first and explain when visible-browser verification is required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->