### PR TITLE
feat: download Bandcamp and ungated SoundCloud via yt-dlp

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Download and tag SoundCloud tracks unlocked via Hypeddit, Droploud, GateRush, Do
 
 - [**Bun**](https://bun.sh) - JavaScript runtime and package manager
 - [**ffmpeg**](https://ffmpeg.org) - Must be installed and available in your `PATH`
-- [**yt-dlp**](https://github.com/yt-dlp/yt-dlp) - Required for Bandcamp purchase/download links
+- [**yt-dlp**](https://github.com/yt-dlp/yt-dlp) - Required for Bandcamp purchase/download links and for downloading a SoundCloud track directly when no gate is found
 - **SoundCloud account** - It is recommended to create a throwaway account for this. Even though there were no reports of accounts getting banned I can't guarantee it. Also most gate downloads require reposts/likes/follows which you might not want to do with your main account
 - **Spotify account** (optional) - Required when a Hypeddit post has an unskippable Spotify gate. I also recommend creating a throwaway account as most Hypeddit downloads require saving playlists/songs to your library or following artists which you might not want on your main account.
 
@@ -156,7 +156,7 @@ If it's the first time you're running it you will need to initialize the logins 
 
 Droploud, GateRush, and DownloadGater gates are handled via their own downloaders with similar email / social unlock flows.
 
-**Bandcamp**: When a SoundCloud track’s purchase URL (or description) points at Bandcamp instead of a gate, the file is downloaded with [yt-dlp](https://github.com/yt-dlp/yt-dlp) (browserless). Traditional unlock gates still take priority if both are present.
+**Bandcamp / yt-dlp**: When a SoundCloud track’s purchase URL (or description) points at Bandcamp instead of a gate, the file is downloaded with [yt-dlp](https://github.com/yt-dlp/yt-dlp) (browserless). For Bandcamp album links, the matching track is selected from the SoundCloud title. Traditional unlock gates still take priority if both are present. If no gate or Bandcamp URL is found, the CLI and Web UI can fall back to downloading the SoundCloud track itself via yt-dlp.
 
 **File Processing**:
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # sc-gate-dl
 
-Download and tag SoundCloud tracks unlocked via Hypeddit, Droploud, or GateRush gates.
+Download and tag SoundCloud tracks unlocked via Hypeddit, Droploud, GateRush, DownloadGater, or Bandcamp.
 
 ## Features
 
-- 🎵 Automatically download audio from Hypeddit, Droploud, and GateRush gates
+- 🎵 Automatically download audio from Hypeddit, Droploud, GateRush, DownloadGater, and Bandcamp links
 - ⚡ Browserless fast path that skips the browser for gates that don't need real verification (see [How It Works](#how-it-works))
 - 🔄 Handles multiple gate types (see [How It Works](#how-it-works))
 - 📝 Fetches metadata from the provided SoundCloud link
@@ -17,6 +17,7 @@ Download and tag SoundCloud tracks unlocked via Hypeddit, Droploud, or GateRush 
 
 - [**Bun**](https://bun.sh) - JavaScript runtime and package manager
 - [**ffmpeg**](https://ffmpeg.org) - Must be installed and available in your `PATH`
+- [**yt-dlp**](https://github.com/yt-dlp/yt-dlp) - Required for Bandcamp purchase/download links
 - **SoundCloud account** - It is recommended to create a throwaway account for this. Even though there were no reports of accounts getting banned I can't guarantee it. Also most gate downloads require reposts/likes/follows which you might not want to do with your main account
 - **Spotify account** (optional) - Required when a Hypeddit post has an unskippable Spotify gate. I also recommend creating a throwaway account as most Hypeddit downloads require saving playlists/songs to your library or following artists which you might not want on your main account.
 
@@ -153,7 +154,9 @@ If it's the first time you're running it you will need to initialize the logins 
 - Spotify gate: Authorizes Spotify access
 - Download gate: Triggers the audio download
 
-Droploud and GateRush gates are handled via their own downloaders with similar email / social unlock flows.
+Droploud, GateRush, and DownloadGater gates are handled via their own downloaders with similar email / social unlock flows.
+
+**Bandcamp**: When a SoundCloud track’s purchase URL (or description) points at Bandcamp instead of a gate, the file is downloaded with [yt-dlp](https://github.com/yt-dlp/yt-dlp) (browserless). Traditional unlock gates still take priority if both are present.
 
 **File Processing**:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { SoundcloudClient } from './soundcloud';
 import {
 	getFfmpegBin,
 	getFfprobeBin,
-	getGateProvider,
+	resolveGateProviderUrl,
 	validateSoundcloudUrl,
 } from './utils';
 import { YtDlpDownloader } from './ytdlp';
@@ -79,18 +79,25 @@ try {
 				message:
 					'Enter the Hypeddit, Droploud, GateRush, DownloadGater, or Bandcamp URL',
 				validate: (value) => {
-					const provider = getGateProvider(value);
-					if (!provider || provider === 'soundcloud') {
+					const resolved = resolveGateProviderUrl(value);
+					if (!resolved || resolved.provider === 'soundcloud') {
 						return 'A valid Hypeddit, Droploud, GateRush, DownloadGater, or Bandcamp URL is required';
 					}
 					return true;
 				},
 			});
-			const provider = getGateProvider(gateUrl);
+			const resolved = resolveGateProviderUrl(gateUrl);
 			gate =
-				provider && provider !== 'soundcloud'
-					? { url: gateUrl, provider, type: 'purchase_url' }
+				resolved && resolved.provider !== 'soundcloud'
+					? {
+							url: resolved.url,
+							provider: resolved.provider,
+							type: 'purchase_url',
+						}
 					: null;
+			if (gate) {
+				gateUrl = gate.url;
+			}
 		}
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { confirm, input } from '@inquirer/prompts';
+import { confirm, input, select } from '@inquirer/prompts';
 import { AudioProcessor } from './audioProcessor';
 import { loadConfig, saveConfig } from './config';
 import { DownloadgaterDownloader } from './downloadgater';
@@ -11,9 +11,9 @@ import {
 	getFfmpegBin,
 	getFfprobeBin,
 	getGateProvider,
-	validateGateUrl,
 	validateSoundcloudUrl,
 } from './utils';
+import { YtDlpDownloader } from './ytdlp';
 
 try {
 	const ffmpegBin = await getFfmpegBin();
@@ -57,36 +57,71 @@ try {
 	let gateUrl = gate?.url ?? null;
 
 	if (!gateUrl) {
-		gateUrl = await input({
-			message:
-				'Enter the Hypeddit, Droploud, GateRush, or DownloadGater gate URL',
-			validate: validateGateUrl,
+		const fallback = await select({
+			message: 'No gate / Bandcamp URL found on this track. What next?',
+			choices: [
+				{
+					name: 'Download via yt-dlp from SoundCloud',
+					value: 'ytdlp' as const,
+				},
+				{
+					name: 'Enter a Hypeddit / Droploud / GateRush / DownloadGater / Bandcamp URL',
+					value: 'manual' as const,
+				},
+			],
 		});
-		const provider = getGateProvider(gateUrl);
-		gate = provider ? { url: gateUrl, provider, type: 'purchase_url' } : null;
+
+		if (fallback === 'ytdlp') {
+			gateUrl = soundcloudUrl;
+			gate = { url: gateUrl, provider: 'soundcloud', type: 'purchase_url' };
+		} else {
+			gateUrl = await input({
+				message:
+					'Enter the Hypeddit, Droploud, GateRush, DownloadGater, or Bandcamp URL',
+				validate: (value) => {
+					const provider = getGateProvider(value);
+					if (!provider || provider === 'soundcloud') {
+						return 'A valid Hypeddit, Droploud, GateRush, DownloadGater, or Bandcamp URL is required';
+					}
+					return true;
+				},
+			});
+			const provider = getGateProvider(gateUrl);
+			gate =
+				provider && provider !== 'soundcloud'
+					? { url: gateUrl, provider, type: 'purchase_url' }
+					: null;
+		}
 	}
 
 	if (!gateUrl || !gate) {
 		throw new Error(
-			'A valid Hypeddit, Droploud, GateRush, or DownloadGater URL is required',
+			'A valid Hypeddit, Droploud, GateRush, DownloadGater, Bandcamp, or SoundCloud URL is required',
 		);
 	}
 
-	const headless = config
-		? config.headless
-		: await confirm({
-				message:
-					'Run headless? (no browser window). Headless also skips the Hypeddit browser fallback — gates that need Spotify/etc. will fail unless you turn headless off.',
-				default: true,
-			});
+	const isYtDlp =
+		gate.provider === 'bandcamp' || gate.provider === 'soundcloud';
 
-	const initializeLogins = config
-		? config.initializeLogins
-		: await confirm({
-				message:
-					"Do you want to initialize logins? This is required for the first run. You can skip it for subsequent runs. If you don't use the tool for a while it might be required again.",
-				default: false,
-			});
+	const headless = isYtDlp
+		? true
+		: config
+			? config.headless
+			: await confirm({
+					message:
+						'Run headless? (no browser window). Headless also skips the Hypeddit browser fallback — gates that need Spotify/etc. will fail unless you turn headless off.',
+					default: true,
+				});
+
+	const initializeLogins = isYtDlp
+		? false
+		: config
+			? config.initializeLogins
+			: await confirm({
+					message:
+						"Do you want to initialize logins? This is required for the first run. You can skip it for subsequent runs. If you don't use the tool for a while it might be required again.",
+					default: false,
+				});
 
 	const gateConfig = {
 		name: HYPEDDIT_NAME,
@@ -98,7 +133,14 @@ try {
 	let downloadFilename: string | null = null;
 	let usedBrowser = false;
 
-	if (gate.provider === 'droploud') {
+	if (gate.provider === 'bandcamp' || gate.provider === 'soundcloud') {
+		const sourceLabel =
+			gate.provider === 'bandcamp' ? 'Bandcamp' : 'SoundCloud';
+		const ytDlpDownloader = new YtDlpDownloader(sourceLabel);
+		downloadFilename = await ytDlpDownloader.downloadAudio(gateUrl, {
+			matchTitle: track.title,
+		});
+	} else if (gate.provider === 'droploud') {
 		usedBrowser = true;
 		const droploudDownloader = new DroploudDownloader(gateConfig);
 		try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -655,32 +655,55 @@ const server = Bun.serve({
 				const stream = new ReadableStream({
 					start(controller) {
 						const encoder = new TextEncoder();
+						let closed = false;
+						let unsubscribe: (() => void) | null = null;
+
+						const safeEnqueue = (chunk: string) => {
+							if (closed) return;
+							try {
+								controller.enqueue(encoder.encode(chunk));
+							} catch {
+								closed = true;
+							}
+						};
+
+						const cleanup = () => {
+							if (closed) return;
+							closed = true;
+							clearInterval(heartbeat);
+							unsubscribe?.();
+						};
 
 						const initialData = `data: ${JSON.stringify(job.progress)}\n\n`;
-						controller.enqueue(encoder.encode(initialData));
+						safeEnqueue(initialData);
 
-						const unsubscribe = jobStore.subscribe(jobId, (progress) => {
-							const data = `data: ${JSON.stringify(progress)}\n\n`;
-							try {
-								controller.enqueue(encoder.encode(data));
-							} catch {
-								unsubscribe();
+						// Keep the SSE connection alive during long silent stretches
+						// (e.g. yt-dlp downloads up to 10 minutes with no progress events).
+						// Bun closes idle connections after idleTimeout (~255s).
+						const heartbeat = setInterval(() => {
+							safeEnqueue(': keepalive\n\n');
+							if (closed) {
+								clearInterval(heartbeat);
 							}
+						}, 30_000);
+
+						unsubscribe = jobStore.subscribe(jobId, (progress) => {
+							safeEnqueue(`data: ${JSON.stringify(progress)}\n\n`);
 
 							if (progress.stage === 'ready' || progress.stage === 'error') {
 								setTimeout(() => {
+									cleanup();
 									try {
 										controller.close();
 									} catch {
 										// Already closed
 									}
 								}, 100);
-								unsubscribe();
 							}
 						});
 
 						req.signal.addEventListener('abort', () => {
-							unsubscribe();
+							cleanup();
 							try {
 								controller.close();
 							} catch {

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,7 @@ import {
 	validateGateUrl,
 	validateSoundcloudUrl,
 } from './utils';
+import { YtDlpDownloader } from './ytdlp';
 
 const ffmpegBin = await getFfmpegBin();
 const ffprobeBin = await getFfprobeBin();
@@ -184,7 +185,21 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 
 		let downloadFilename: string | null = null;
 
-		if (provider === 'droploud') {
+		if (provider === 'bandcamp' || provider === 'soundcloud') {
+			const sourceLabel = provider === 'bandcamp' ? 'Bandcamp' : 'SoundCloud';
+			jobStore.updateProgress(
+				jobId,
+				'downloading',
+				`Downloading from ${sourceLabel} via yt-dlp...`,
+				40,
+				{ browserless: true },
+			);
+			const ytDlpDownloader = new YtDlpDownloader(sourceLabel);
+			ytDlpDownloader.setProgressCallback(emitProgress);
+			downloadFilename = await ytDlpDownloader.downloadAudio(gateUrl, {
+				matchTitle: job.track?.title,
+			});
+		} else if (provider === 'droploud') {
 			jobStore.updateProgress(
 				jobId,
 				'initializing_browser',

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,7 +15,7 @@ import {
 	getDefaultMetadata,
 	getFfmpegBin,
 	getFfprobeBin,
-	getGateProvider,
+	resolveGateProviderUrl,
 	validateGateUrl,
 	validateSoundcloudUrl,
 } from './utils';
@@ -156,11 +156,12 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 	if (!job?.hypedditUrl) return;
 
 	const gateUrl = job.hypedditUrl;
-	const provider = getGateProvider(gateUrl);
-	if (!provider) {
+	const resolved = resolveGateProviderUrl(gateUrl);
+	if (!resolved) {
 		jobStore.setError(jobId, 'Unsupported gate URL');
 		return;
 	}
+	const { url: downloadSourceUrl, provider } = resolved;
 
 	try {
 		const emitProgress = (
@@ -196,9 +197,12 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 			);
 			const ytDlpDownloader = new YtDlpDownloader(sourceLabel);
 			ytDlpDownloader.setProgressCallback(emitProgress);
-			downloadFilename = await ytDlpDownloader.downloadAudio(gateUrl, {
-				matchTitle: job.track?.title,
-			});
+			downloadFilename = await ytDlpDownloader.downloadAudio(
+				downloadSourceUrl,
+				{
+					matchTitle: job.track?.title,
+				},
+			);
 		} else if (provider === 'droploud') {
 			jobStore.updateProgress(
 				jobId,
@@ -218,7 +222,8 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 				'Processing Droploud gates...',
 				25,
 			);
-			downloadFilename = await droploudDownloader.downloadAudio(gateUrl);
+			downloadFilename =
+				await droploudDownloader.downloadAudio(downloadSourceUrl);
 			await closeJobDownloader(jobId);
 		} else if (provider === 'gaterush') {
 			jobStore.updateProgress(
@@ -239,7 +244,8 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 				'Processing GateRush gates...',
 				25,
 			);
-			downloadFilename = await gaterushDownloader.downloadAudio(gateUrl);
+			downloadFilename =
+				await gaterushDownloader.downloadAudio(downloadSourceUrl);
 			await closeJobDownloader(jobId);
 		} else if (provider === 'downloadgater') {
 			jobStore.updateProgress(
@@ -260,7 +266,8 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 				'Processing DownloadGater gates...',
 				25,
 			);
-			downloadFilename = await downloadgaterDownloader.downloadAudio(gateUrl);
+			downloadFilename =
+				await downloadgaterDownloader.downloadAudio(downloadSourceUrl);
 			await closeJobDownloader(jobId);
 		} else {
 			// Hypeddit: always try plain HTTP first (email + social skip gates).
@@ -274,7 +281,7 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 				gateConfigBase,
 				emitProgress,
 			);
-			downloadFilename = await httpDownloader.tryDownload(gateUrl);
+			downloadFilename = await httpDownloader.tryDownload(downloadSourceUrl);
 
 			// Always try HTTP first. Open a browser only when the user checked
 			// “Show browser window” (headful) and the gate needs real verification
@@ -301,7 +308,8 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 					25,
 				);
 
-				downloadFilename = await hypedditDownloader.downloadAudio(gateUrl);
+				downloadFilename =
+					await hypedditDownloader.downloadAudio(downloadSourceUrl);
 				await closeJobDownloader(jobId);
 			} else if (!downloadFilename && job.headless) {
 				jobStore.setError(
@@ -565,9 +573,17 @@ const server = Bun.serve({
 						return jsonResponse({ error: validation }, { status: 400 });
 					}
 
-					jobStore.update(jobId, { hypedditUrl });
+					const resolved = resolveGateProviderUrl(hypedditUrl);
+					if (!resolved) {
+						return jsonResponse(
+							{ error: 'Could not extract a supported URL' },
+							{ status: 400 },
+						);
+					}
 
-					return jsonResponse({ success: true, hypedditUrl });
+					jobStore.update(jobId, { hypedditUrl: resolved.url });
+
+					return jsonResponse({ success: true, hypedditUrl: resolved.url });
 				} catch (error) {
 					return jsonResponse(
 						{

--- a/src/server.ts
+++ b/src/server.ts
@@ -655,61 +655,71 @@ const server = Bun.serve({
 				const stream = new ReadableStream({
 					start(controller) {
 						const encoder = new TextEncoder();
-						let closed = false;
+						let cleanedUp = false;
 						let unsubscribe: (() => void) | null = null;
-
-						const safeEnqueue = (chunk: string) => {
-							if (closed) return;
-							try {
-								controller.enqueue(encoder.encode(chunk));
-							} catch {
-								closed = true;
-							}
-						};
+						let heartbeat: ReturnType<typeof setInterval> | null = null;
 
 						const cleanup = () => {
-							if (closed) return;
-							closed = true;
-							clearInterval(heartbeat);
+							if (cleanedUp) return;
+							cleanedUp = true;
+							if (heartbeat !== null) {
+								clearInterval(heartbeat);
+								heartbeat = null;
+							}
 							unsubscribe?.();
+							unsubscribe = null;
 						};
 
-						const initialData = `data: ${JSON.stringify(job.progress)}\n\n`;
-						safeEnqueue(initialData);
-
-						// Keep the SSE connection alive during long silent stretches
-						// (e.g. yt-dlp downloads up to 10 minutes with no progress events).
-						// Bun closes idle connections after idleTimeout (~255s).
-						const heartbeat = setInterval(() => {
-							safeEnqueue(': keepalive\n\n');
-							if (closed) {
-								clearInterval(heartbeat);
-							}
-						}, 30_000);
-
-						unsubscribe = jobStore.subscribe(jobId, (progress) => {
-							safeEnqueue(`data: ${JSON.stringify(progress)}\n\n`);
-
-							if (progress.stage === 'ready' || progress.stage === 'error') {
-								setTimeout(() => {
-									cleanup();
-									try {
-										controller.close();
-									} catch {
-										// Already closed
-									}
-								}, 100);
-							}
-						});
-
-						req.signal.addEventListener('abort', () => {
+						const closeStream = () => {
 							cleanup();
 							try {
 								controller.close();
 							} catch {
 								// Already closed
 							}
+						};
+
+						const safeEnqueue = (chunk: string): boolean => {
+							if (cleanedUp) return false;
+							try {
+								controller.enqueue(encoder.encode(chunk));
+								return true;
+							} catch {
+								cleanup();
+								return false;
+							}
+						};
+
+						if (!safeEnqueue(`data: ${JSON.stringify(job.progress)}\n\n`)) {
+							return;
+						}
+
+						// Keep the SSE connection alive during long silent stretches
+						// (e.g. yt-dlp downloads up to 10 minutes with no progress events).
+						// Bun closes idle connections after idleTimeout (~255s).
+						heartbeat = setInterval(() => {
+							safeEnqueue(': keepalive\n\n');
+						}, 30_000);
+
+						unsubscribe = jobStore.subscribe(jobId, (progress) => {
+							if (!safeEnqueue(`data: ${JSON.stringify(progress)}\n\n`)) {
+								return;
+							}
+
+							if (progress.stage === 'ready' || progress.stage === 'error') {
+								setTimeout(closeStream, 100);
+							}
 						});
+
+						// subscribe() does not replay — close if the job is already done.
+						if (
+							job.progress.stage === 'ready' ||
+							job.progress.stage === 'error'
+						) {
+							setTimeout(closeStream, 100);
+						}
+
+						req.signal.addEventListener('abort', closeStream);
 					},
 				});
 

--- a/src/soundcloud.ts
+++ b/src/soundcloud.ts
@@ -529,7 +529,11 @@ export class SoundcloudClient {
 					? 'GateRush'
 					: gate.provider === 'downloadgater'
 						? 'DownloadGater'
-						: 'Hypeddit';
+						: gate.provider === 'bandcamp'
+							? 'Bandcamp'
+							: gate.provider === 'soundcloud'
+								? 'SoundCloud'
+								: 'Hypeddit';
 		const sourceLabel =
 			gate.type === 'purchase_url' ? 'purchase URL' : 'description';
 		console.log(

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test';
+import { resolveGateProviderUrl } from './utils';
+
+describe('resolveGateProviderUrl', () => {
+	test('extracts Bandcamp track URLs from surrounding prose', () => {
+		expect(
+			resolveGateProviderUrl(
+				'grab it (https://artist.bandcamp.com/track/song).',
+			),
+		).toEqual({
+			url: 'https://artist.bandcamp.com/track/song',
+			provider: 'bandcamp',
+		});
+	});
+
+	test('strips trailing sentence punctuation from SoundCloud URLs', () => {
+		expect(
+			resolveGateProviderUrl('listen: https://soundcloud.com/a/b!'),
+		).toEqual({
+			url: 'https://soundcloud.com/a/b',
+			provider: 'soundcloud',
+		});
+	});
+
+	test('strips Markdown-style closing delimiters', () => {
+		expect(
+			resolveGateProviderUrl('[buy](https://x.bandcamp.com/album/y)'),
+		).toEqual({
+			url: 'https://x.bandcamp.com/album/y',
+			provider: 'bandcamp',
+		});
+	});
+
+	test('prefers traditional gates over Bandcamp', () => {
+		expect(
+			resolveGateProviderUrl(
+				'https://hypeddit.com/foo and https://x.bandcamp.com/track/y',
+			),
+		).toEqual({
+			url: 'https://hypeddit.com/foo',
+			provider: 'hypeddit',
+		});
+	});
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -148,9 +148,17 @@ const DROPLOUD_URL_RE = /https:\/\/droploud\.com\/(?:gate|track)\/[0-9a-f-]+/i;
 const GATERUSH_URL_RE = /https?:\/\/(?:www\.)?gaterush\.me\/[A-Za-z0-9_-]+/i;
 const DOWNLOADGATER_URL_RE =
 	/https?:\/\/(?:www\.)?downloadgater\.com\/g\/[A-Za-z0-9_-]+/i;
+const BANDCAMP_HOST = String.raw`https?:\/\/(?:[\w-]+\.)?bandcamp\.com`;
 /** artist.bandcamp.com/track|album/... (and bare bandcamp.com). */
-const BANDCAMP_URL_RE =
-	/https?:\/\/(?:[\w-]+\.)?bandcamp\.com\/(?:track|album)\/[^\s?#]+/i;
+const BANDCAMP_URL_RE = new RegExp(
+	`${BANDCAMP_HOST}\\/(?:track|album)\\/[^\\s?#]+`,
+	'i',
+);
+const BANDCAMP_ALBUM_URL_RE = new RegExp(
+	`${BANDCAMP_HOST}\\/album\\/[^\\s?#]+`,
+	'i',
+);
+const SOUNDCLOUD_URL_RE = /https:\/\/soundcloud\.com\/[^\s?#]+/i;
 
 export function isHypedditUrl(value: string): boolean {
 	return value.startsWith('https://hypeddit.com/');
@@ -172,14 +180,32 @@ export function isBandcampUrl(value: string): boolean {
 	return BANDCAMP_URL_RE.test(value);
 }
 
-export function getGateProvider(value: string): GateProvider | null {
-	if (isHypedditUrl(value)) return 'hypeddit';
-	if (isDroploudUrl(value)) return 'droploud';
-	if (isGaterushUrl(value)) return 'gaterush';
-	if (isDownloadgaterUrl(value)) return 'downloadgater';
-	if (isBandcampUrl(value)) return 'bandcamp';
-	if (isSoundcloudUrl(value)) return 'soundcloud';
+export function isBandcampAlbumUrl(value: string): boolean {
+	return BANDCAMP_ALBUM_URL_RE.test(value);
+}
+
+/**
+ * Extract the canonical provider URL from a string (possibly with surrounding
+ * text). Prefer traditional gates, then Bandcamp, then SoundCloud.
+ */
+export function resolveGateProviderUrl(
+	value: string,
+): { url: string; provider: GateProvider } | null {
+	const traditional = matchTraditionalGateUrl(value);
+	if (traditional) return traditional;
+
+	const bandcamp = matchBandcampUrl(value);
+	if (bandcamp) return bandcamp;
+
+	const soundcloudMatch = value.match(SOUNDCLOUD_URL_RE)?.[0];
+	if (soundcloudMatch) {
+		return { url: soundcloudMatch, provider: 'soundcloud' };
+	}
 	return null;
+}
+
+export function getGateProvider(value: string): GateProvider | null {
+	return resolveGateProviderUrl(value)?.provider ?? null;
 }
 
 export function validateHypedditUrl(value: string): true | string {
@@ -190,7 +216,7 @@ export function validateHypedditUrl(value: string): true | string {
 }
 
 export function validateGateUrl(value: string): true | string {
-	if (!getGateProvider(value)) {
+	if (!resolveGateProviderUrl(value)) {
 		return 'A valid Hypeddit, Droploud, GateRush, DownloadGater, Bandcamp, or SoundCloud URL is required';
 	}
 	return true;
@@ -217,8 +243,9 @@ function normalizeGateUrl(
 function matchTraditionalGateUrl(
 	value: string,
 ): { url: string; provider: GateProvider } | null {
-	if (isHypedditUrl(value)) {
-		return { url: value, provider: 'hypeddit' };
+	const hypedditMatch = value.match(HYPEDDIT_URL_RE)?.[0];
+	if (hypedditMatch) {
+		return { url: hypedditMatch, provider: 'hypeddit' };
 	}
 	const droploudMatch = value.match(DROPLOUD_URL_RE)?.[0];
 	if (droploudMatch) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -148,17 +148,17 @@ const DROPLOUD_URL_RE = /https:\/\/droploud\.com\/(?:gate|track)\/[0-9a-f-]+/i;
 const GATERUSH_URL_RE = /https?:\/\/(?:www\.)?gaterush\.me\/[A-Za-z0-9_-]+/i;
 const DOWNLOADGATER_URL_RE =
 	/https?:\/\/(?:www\.)?downloadgater\.com\/g\/[A-Za-z0-9_-]+/i;
-const BANDCAMP_HOST = String.raw`https?:\/\/(?:[\w-]+\.)?bandcamp\.com`;
 /** artist.bandcamp.com/track|album/... (and bare bandcamp.com). */
-const BANDCAMP_URL_RE = new RegExp(
-	`${BANDCAMP_HOST}\\/(?:track|album)\\/[^\\s?#]+`,
-	'i',
-);
-const BANDCAMP_ALBUM_URL_RE = new RegExp(
-	`${BANDCAMP_HOST}\\/album\\/[^\\s?#]+`,
-	'i',
-);
+const BANDCAMP_URL_RE =
+	/https?:\/\/(?:[\w-]+\.)?bandcamp\.com\/(?:track|album)\/[^\s?#]+/i;
+const BANDCAMP_ALBUM_URL_RE =
+	/https?:\/\/(?:[\w-]+\.)?bandcamp\.com\/album\/[^\s?#]+/i;
 const SOUNDCLOUD_URL_RE = /https:\/\/soundcloud\.com\/[^\s?#]+/i;
+
+/** Strip prose/Markdown delimiters glued to the end of a matched URL. */
+function trimExtractedUrl(url: string): string {
+	return url.replace(/[)\]}>.,;:!?'"…]+$/g, '');
+}
 
 export function isHypedditUrl(value: string): boolean {
 	return value.startsWith('https://hypeddit.com/');
@@ -199,7 +199,10 @@ export function resolveGateProviderUrl(
 
 	const soundcloudMatch = value.match(SOUNDCLOUD_URL_RE)?.[0];
 	if (soundcloudMatch) {
-		return { url: soundcloudMatch, provider: 'soundcloud' };
+		return {
+			url: trimExtractedUrl(soundcloudMatch),
+			provider: 'soundcloud',
+		};
 	}
 	return null;
 }
@@ -245,19 +248,22 @@ function matchTraditionalGateUrl(
 ): { url: string; provider: GateProvider } | null {
 	const hypedditMatch = value.match(HYPEDDIT_URL_RE)?.[0];
 	if (hypedditMatch) {
-		return { url: hypedditMatch, provider: 'hypeddit' };
+		return { url: trimExtractedUrl(hypedditMatch), provider: 'hypeddit' };
 	}
 	const droploudMatch = value.match(DROPLOUD_URL_RE)?.[0];
 	if (droploudMatch) {
-		return { url: droploudMatch, provider: 'droploud' };
+		return { url: trimExtractedUrl(droploudMatch), provider: 'droploud' };
 	}
 	const gaterushMatch = value.match(GATERUSH_URL_RE)?.[0];
 	if (gaterushMatch) {
-		return normalizeGateUrl(gaterushMatch, 'gaterush');
+		return normalizeGateUrl(trimExtractedUrl(gaterushMatch), 'gaterush');
 	}
 	const downloadgaterMatch = value.match(DOWNLOADGATER_URL_RE)?.[0];
 	if (downloadgaterMatch) {
-		return normalizeGateUrl(downloadgaterMatch, 'downloadgater');
+		return normalizeGateUrl(
+			trimExtractedUrl(downloadgaterMatch),
+			'downloadgater',
+		);
 	}
 	return null;
 }
@@ -267,7 +273,7 @@ function matchBandcampUrl(
 ): { url: string; provider: GateProvider } | null {
 	const bandcampMatch = value.match(BANDCAMP_URL_RE)?.[0];
 	if (bandcampMatch) {
-		return normalizeGateUrl(bandcampMatch, 'bandcamp');
+		return normalizeGateUrl(trimExtractedUrl(bandcampMatch), 'bandcamp');
 	}
 	return null;
 }
@@ -287,35 +293,9 @@ export function extractGateUrl(track: SoundcloudTrack): GateUrlMatch | null {
 	}
 
 	if (description) {
-		const hypedditMatch = description.match(HYPEDDIT_URL_RE)?.[0];
-		if (hypedditMatch) {
-			return {
-				url: hypedditMatch,
-				provider: 'hypeddit',
-				type: 'description',
-			};
-		}
-		const droploudMatch = description.match(DROPLOUD_URL_RE)?.[0];
-		if (droploudMatch) {
-			return {
-				url: droploudMatch,
-				provider: 'droploud',
-				type: 'description',
-			};
-		}
-		const gaterushMatch = description.match(GATERUSH_URL_RE)?.[0];
-		if (gaterushMatch) {
-			return {
-				...normalizeGateUrl(gaterushMatch, 'gaterush'),
-				type: 'description',
-			};
-		}
-		const downloadgaterMatch = description.match(DOWNLOADGATER_URL_RE)?.[0];
-		if (downloadgaterMatch) {
-			return {
-				...normalizeGateUrl(downloadgaterMatch, 'downloadgater'),
-				type: 'description',
-			};
+		const fromDescription = matchTraditionalGateUrl(description);
+		if (fromDescription) {
+			return { ...fromDescription, type: 'description' };
 		}
 	}
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -117,8 +117,12 @@ export async function loadCookies(filename: string): Promise<CookieData[]> {
 	});
 }
 
+export function isSoundcloudUrl(value: string): boolean {
+	return value?.startsWith('https://soundcloud.com/') ?? false;
+}
+
 export function validateSoundcloudUrl(value: string): true | string {
-	if (!value?.startsWith('https://soundcloud.com/')) {
+	if (!isSoundcloudUrl(value)) {
 		return 'A valid SoundCloud URL is required';
 	}
 	return true;
@@ -128,7 +132,10 @@ export type GateProvider =
 	| 'hypeddit'
 	| 'droploud'
 	| 'gaterush'
-	| 'downloadgater';
+	| 'downloadgater'
+	| 'bandcamp'
+	/** Direct track download via yt-dlp (manual fallback, not auto-extracted). */
+	| 'soundcloud';
 
 export type GateUrlMatch = {
 	url: string;
@@ -141,6 +148,9 @@ const DROPLOUD_URL_RE = /https:\/\/droploud\.com\/(?:gate|track)\/[0-9a-f-]+/i;
 const GATERUSH_URL_RE = /https?:\/\/(?:www\.)?gaterush\.me\/[A-Za-z0-9_-]+/i;
 const DOWNLOADGATER_URL_RE =
 	/https?:\/\/(?:www\.)?downloadgater\.com\/g\/[A-Za-z0-9_-]+/i;
+/** artist.bandcamp.com/track|album/... (and bare bandcamp.com). */
+const BANDCAMP_URL_RE =
+	/https?:\/\/(?:[\w-]+\.)?bandcamp\.com\/(?:track|album)\/[^\s?#]+/i;
 
 export function isHypedditUrl(value: string): boolean {
 	return value.startsWith('https://hypeddit.com/');
@@ -158,11 +168,17 @@ export function isDownloadgaterUrl(value: string): boolean {
 	return DOWNLOADGATER_URL_RE.test(value);
 }
 
+export function isBandcampUrl(value: string): boolean {
+	return BANDCAMP_URL_RE.test(value);
+}
+
 export function getGateProvider(value: string): GateProvider | null {
 	if (isHypedditUrl(value)) return 'hypeddit';
 	if (isDroploudUrl(value)) return 'droploud';
 	if (isGaterushUrl(value)) return 'gaterush';
 	if (isDownloadgaterUrl(value)) return 'downloadgater';
+	if (isBandcampUrl(value)) return 'bandcamp';
+	if (isSoundcloudUrl(value)) return 'soundcloud';
 	return null;
 }
 
@@ -175,7 +191,7 @@ export function validateHypedditUrl(value: string): true | string {
 
 export function validateGateUrl(value: string): true | string {
 	if (!getGateProvider(value)) {
-		return 'A valid Hypeddit, Droploud, GateRush, or DownloadGater URL is required';
+		return 'A valid Hypeddit, Droploud, GateRush, DownloadGater, Bandcamp, or SoundCloud URL is required';
 	}
 	return true;
 }
@@ -184,7 +200,11 @@ function normalizeGateUrl(
 	url: string,
 	provider: GateProvider,
 ): { url: string; provider: GateProvider } {
-	if (provider === 'gaterush' || provider === 'downloadgater') {
+	if (
+		provider === 'gaterush' ||
+		provider === 'downloadgater' ||
+		provider === 'bandcamp'
+	) {
 		return {
 			url: url.replace(/^http:\/\//i, 'https://'),
 			provider,
@@ -193,7 +213,8 @@ function normalizeGateUrl(
 	return { url, provider };
 }
 
-function matchGateUrl(
+/** Traditional unlock gates (browser / HTTP). Prefer these over Bandcamp. */
+function matchTraditionalGateUrl(
 	value: string,
 ): { url: string; provider: GateProvider } | null {
 	if (isHypedditUrl(value)) {
@@ -214,12 +235,25 @@ function matchGateUrl(
 	return null;
 }
 
-/** Prefer Hypeddit, then Droploud, GateRush, DownloadGater from purchase_url or description. */
+function matchBandcampUrl(
+	value: string,
+): { url: string; provider: GateProvider } | null {
+	const bandcampMatch = value.match(BANDCAMP_URL_RE)?.[0];
+	if (bandcampMatch) {
+		return normalizeGateUrl(bandcampMatch, 'bandcamp');
+	}
+	return null;
+}
+
+/**
+ * Prefer Hypeddit / Droploud / GateRush / DownloadGater from purchase_url or
+ * description, then fall back to a Bandcamp purchase/description link.
+ */
 export function extractGateUrl(track: SoundcloudTrack): GateUrlMatch | null {
 	const { purchase_url, description } = track;
 
 	if (purchase_url) {
-		const fromPurchase = matchGateUrl(purchase_url);
+		const fromPurchase = matchTraditionalGateUrl(purchase_url);
 		if (fromPurchase) {
 			return { ...fromPurchase, type: 'purchase_url' };
 		}
@@ -255,6 +289,20 @@ export function extractGateUrl(track: SoundcloudTrack): GateUrlMatch | null {
 				...normalizeGateUrl(downloadgaterMatch, 'downloadgater'),
 				type: 'description',
 			};
+		}
+	}
+
+	if (purchase_url) {
+		const bandcamp = matchBandcampUrl(purchase_url);
+		if (bandcamp) {
+			return { ...bandcamp, type: 'purchase_url' };
+		}
+	}
+
+	if (description) {
+		const bandcamp = matchBandcampUrl(description);
+		if (bandcamp) {
+			return { ...bandcamp, type: 'description' };
 		}
 	}
 

--- a/src/ytdlp.ts
+++ b/src/ytdlp.ts
@@ -1,0 +1,252 @@
+import { mkdir } from 'node:fs/promises';
+import { basename, join } from 'node:path';
+import { execa } from 'execa';
+import { lookpath } from 'find-bin';
+import type { JobProgress } from './types';
+
+type ProgressCallback = (
+	stage: JobProgress['stage'],
+	message: string,
+	percent: number,
+	extra?: Partial<JobProgress>,
+) => void;
+
+export type YtDlpDownloadOptions = {
+	/** Prefer this title when the URL is a Bandcamp album (or multi-entry). */
+	matchTitle?: string;
+};
+
+const DOWNLOADS_DIR = './downloads';
+const BANDCAMP_ALBUM_RE =
+	/https?:\/\/(?:[\w-]+\.)?bandcamp\.com\/album\/[^\s?#]+/i;
+
+type FlatEntry = {
+	id?: string;
+	title?: string;
+	url?: string;
+	webpage_url?: string;
+};
+
+export async function getYtDlpBin(): Promise<string> {
+	const ytDlpBin = await lookpath('yt-dlp');
+	if (!ytDlpBin) {
+		throw new Error(
+			'yt-dlp is not installed. Please make sure it is in your PATH (required for Bandcamp / SoundCloud downloads).',
+		);
+	}
+	return ytDlpBin;
+}
+
+/** Strip (Clip)/(Preview)/brackets and normalize for fuzzy title compare. */
+export function normalizeTrackTitle(title: string): string {
+	return title
+		.toLowerCase()
+		.replace(/\(.*?\)/g, ' ')
+		.replace(/\[.*?\]/g, ' ')
+		.replace(/[^a-z0-9]+/g, ' ')
+		.trim()
+		.replace(/\s+/g, ' ');
+}
+
+/** 0–1 score; exact normalized match → 1. */
+export function titleMatchScore(candidate: string, wanted: string): number {
+	const a = normalizeTrackTitle(candidate);
+	const b = normalizeTrackTitle(wanted);
+	if (!a || !b) return 0;
+	if (a === b) return 1;
+	if (a.includes(b) || b.includes(a)) return 0.9;
+
+	const tokensA = new Set(a.split(' '));
+	const tokensB = new Set(b.split(' '));
+	let inter = 0;
+	for (const t of tokensA) {
+		if (tokensB.has(t)) inter += 1;
+	}
+	const union = tokensA.size + tokensB.size - inter;
+	return union === 0 ? 0 : inter / union;
+}
+
+function isBandcampAlbumUrl(url: string): boolean {
+	return BANDCAMP_ALBUM_RE.test(url);
+}
+
+/**
+ * Downloads audio via yt-dlp into ./downloads (Bandcamp, SoundCloud, …).
+ * Browserless — no gate browser / SoundCloud session automation.
+ *
+ * Bandcamp album URLs: when `matchTitle` is set, resolves the best-matching
+ * track on the album and downloads only that entry (avoids grabbing the whole
+ * album and offering the wrong file).
+ */
+export class YtDlpDownloader {
+	private progressCallback: ProgressCallback | null = null;
+	private sourceLabel: string;
+
+	constructor(sourceLabel = 'yt-dlp') {
+		this.sourceLabel = sourceLabel;
+	}
+
+	setProgressCallback(callback: ProgressCallback) {
+		this.progressCallback = callback;
+	}
+
+	async downloadAudio(
+		url: string,
+		options: YtDlpDownloadOptions = {},
+	): Promise<string> {
+		const ytDlpBin = await getYtDlpBin();
+		let downloadUrl = url;
+
+		if (isBandcampAlbumUrl(url) && options.matchTitle) {
+			downloadUrl = await this.resolveBandcampAlbumTrack(
+				ytDlpBin,
+				url,
+				options.matchTitle,
+			);
+		} else if (isBandcampAlbumUrl(url) && !options.matchTitle) {
+			throw new Error(
+				'Bandcamp album URL needs a track title to pick the right song. Re-fetch the SoundCloud track and try again.',
+			);
+		}
+
+		this.progressCallback?.(
+			'downloading',
+			`Downloading from ${this.sourceLabel} via yt-dlp...`,
+			50,
+			{ browserless: true },
+		);
+		console.log(`${this.sourceLabel}: downloading via yt-dlp → ${downloadUrl}`);
+
+		await mkdir(DOWNLOADS_DIR, { recursive: true });
+
+		const outputTemplate = join(DOWNLOADS_DIR, '%(title)s [%(id)s].%(ext)s');
+
+		const { stdout } = await execa(ytDlpBin, [
+			'--no-mtime',
+			'--no-playlist',
+			'-f',
+			'bestaudio/best',
+			'-o',
+			outputTemplate,
+			'--print',
+			'after_move:filepath',
+			'--no-warnings',
+			downloadUrl,
+		]);
+
+		const filepaths = stdout
+			.trim()
+			.split('\n')
+			.map((line) => line.trim())
+			.filter(Boolean);
+
+		if (filepaths.length === 0) {
+			throw new Error('yt-dlp finished but did not report an output filepath');
+		}
+
+		const matchTitle = options.matchTitle;
+		let filepath = filepaths[filepaths.length - 1] ?? '';
+		if (filepaths.length > 1 && matchTitle) {
+			const ranked = filepaths
+				.map((path) => ({
+					path,
+					score: titleMatchScore(basename(path), matchTitle),
+				}))
+				.sort((a, b) => b.score - a.score);
+			const bestPath = ranked[0]?.path;
+			if (bestPath) {
+				filepath = bestPath;
+				console.log(
+					`${this.sourceLabel}: yt-dlp wrote ${filepaths.length} files; picked ${basename(filepath)} (score ${ranked[0]?.score.toFixed(2)})`,
+				);
+			}
+		} else if (filepaths.length > 1) {
+			console.warn(
+				`${this.sourceLabel}: yt-dlp wrote ${filepaths.length} files; using last: ${basename(filepath)}`,
+			);
+		}
+
+		const filename = basename(filepath);
+		const dest = join(DOWNLOADS_DIR, filename);
+		if (!(await Bun.file(dest).exists())) {
+			throw new Error(`yt-dlp reported ${filename} but file is missing`);
+		}
+
+		console.log(`${this.sourceLabel}: downloaded ${filename}`);
+		this.progressCallback?.('downloading', 'Download complete', 85, {
+			browserless: true,
+		});
+		return filename;
+	}
+
+	private async resolveBandcampAlbumTrack(
+		ytDlpBin: string,
+		albumUrl: string,
+		matchTitle: string,
+	): Promise<string> {
+		this.progressCallback?.(
+			'downloading',
+			`Matching “${matchTitle}” on Bandcamp album...`,
+			45,
+			{ browserless: true },
+		);
+		console.log(
+			`${this.sourceLabel}: album URL — matching track “${matchTitle}”…`,
+		);
+
+		const { stdout } = await execa(ytDlpBin, [
+			'--flat-playlist',
+			'-J',
+			'--no-warnings',
+			albumUrl,
+		]);
+
+		const data = JSON.parse(stdout) as {
+			_type?: string;
+			entries?: FlatEntry[];
+			title?: string;
+		};
+		const entries = (data.entries ?? []).filter(
+			(e): e is FlatEntry & { title: string } => Boolean(e.title),
+		);
+
+		if (entries.length === 0) {
+			throw new Error(`No tracks found on Bandcamp album: ${albumUrl}`);
+		}
+
+		const ranked = entries
+			.map((entry) => ({
+				entry,
+				score: titleMatchScore(entry.title, matchTitle),
+			}))
+			.sort((a, b) => b.score - a.score);
+
+		const best = ranked[0];
+		if (!best || best.score < 0.5) {
+			const available = entries.map((e) => e.title).join(', ');
+			throw new Error(
+				`Could not match SoundCloud title “${matchTitle}” to a track on the Bandcamp album. Available: ${available}`,
+			);
+		}
+
+		const finalUrl = best.entry.url || best.entry.webpage_url;
+		if (!finalUrl) {
+			throw new Error(
+				`Matched “${best.entry.title}” but yt-dlp did not provide a track URL`,
+			);
+		}
+
+		console.log(
+			`${this.sourceLabel}: matched “${best.entry.title}” (score ${best.score.toFixed(2)}) → ${finalUrl}`,
+		);
+
+		return finalUrl;
+	}
+}
+
+/** @deprecated Prefer YtDlpDownloader */
+export class BandcampDownloader extends YtDlpDownloader {
+	constructor() {
+		super('Bandcamp');
+	}
+}

--- a/src/ytdlp.ts
+++ b/src/ytdlp.ts
@@ -3,6 +3,7 @@ import { basename, join } from 'node:path';
 import { execa } from 'execa';
 import { lookpath } from 'find-bin';
 import type { JobProgress } from './types';
+import { isBandcampAlbumUrl } from './utils';
 
 type ProgressCallback = (
 	stage: JobProgress['stage'],
@@ -17,8 +18,8 @@ export type YtDlpDownloadOptions = {
 };
 
 const DOWNLOADS_DIR = './downloads';
-const BANDCAMP_ALBUM_RE =
-	/https?:\/\/(?:[\w-]+\.)?bandcamp\.com\/album\/[^\s?#]+/i;
+const YTDLP_DOWNLOAD_TIMEOUT_MS = 10 * 60_000;
+const YTDLP_METADATA_TIMEOUT_MS = 60_000;
 
 type FlatEntry = {
 	id?: string;
@@ -64,10 +65,6 @@ export function titleMatchScore(candidate: string, wanted: string): number {
 	}
 	const union = tokensA.size + tokensB.size - inter;
 	return union === 0 ? 0 : inter / union;
-}
-
-function isBandcampAlbumUrl(url: string): boolean {
-	return BANDCAMP_ALBUM_RE.test(url);
 }
 
 /**
@@ -121,18 +118,22 @@ export class YtDlpDownloader {
 
 		const outputTemplate = join(DOWNLOADS_DIR, '%(title)s [%(id)s].%(ext)s');
 
-		const { stdout } = await execa(ytDlpBin, [
-			'--no-mtime',
-			'--no-playlist',
-			'-f',
-			'bestaudio/best',
-			'-o',
-			outputTemplate,
-			'--print',
-			'after_move:filepath',
-			'--no-warnings',
-			downloadUrl,
-		]);
+		const { stdout } = await execa(
+			ytDlpBin,
+			[
+				'--no-mtime',
+				'--no-playlist',
+				'-f',
+				'bestaudio/best',
+				'-o',
+				outputTemplate,
+				'--print',
+				'after_move:filepath',
+				'--no-warnings',
+				downloadUrl,
+			],
+			{ timeout: YTDLP_DOWNLOAD_TIMEOUT_MS, killSignal: 'SIGTERM' },
+		);
 
 		const filepaths = stdout
 			.trim()
@@ -194,12 +195,11 @@ export class YtDlpDownloader {
 			`${this.sourceLabel}: album URL — matching track “${matchTitle}”…`,
 		);
 
-		const { stdout } = await execa(ytDlpBin, [
-			'--flat-playlist',
-			'-J',
-			'--no-warnings',
-			albumUrl,
-		]);
+		const { stdout } = await execa(
+			ytDlpBin,
+			['--flat-playlist', '-J', '--no-warnings', albumUrl],
+			{ timeout: YTDLP_METADATA_TIMEOUT_MS, killSignal: 'SIGTERM' },
+		);
 
 		const data = JSON.parse(stdout) as {
 			_type?: string;

--- a/webui/src/components/App.css
+++ b/webui/src/components/App.css
@@ -207,6 +207,12 @@
 	gap: var(--space-lg);
 }
 
+.form > form {
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-lg);
+}
+
 .form-group {
 	display: flex;
 	flex-direction: column;
@@ -355,6 +361,33 @@
 .btn-secondary:hover {
 	border-color: var(--neon-cyan);
 	color: var(--neon-cyan);
+}
+
+.btn-secondary:disabled {
+	opacity: 0.7;
+	cursor: not-allowed;
+}
+
+.btn-full {
+	width: 100%;
+}
+
+.form-divider {
+	display: flex;
+	align-items: center;
+	gap: var(--space-md);
+	color: var(--text-muted);
+	font-size: 0.85rem;
+	text-transform: lowercase;
+	letter-spacing: 0.04em;
+}
+
+.form-divider::before,
+.form-divider::after {
+	content: '';
+	flex: 1;
+	height: 1px;
+	background: var(--border-strong);
 }
 
 /* Spinner */

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -214,6 +214,41 @@ export default function App() {
 		}
 	};
 
+	/** No gate found — download the SoundCloud track itself via yt-dlp. */
+	const handleYtdlpSoundcloudDownload = async () => {
+		if (!job.jobId || !soundcloudUrl.trim()) return;
+
+		setIsLoading(true);
+		setJob((prev) => ({ ...prev, error: null }));
+
+		try {
+			const response = await fetch(
+				`${API_BASE}/api/job/${job.jobId}/hypeddit`,
+				{
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ hypedditUrl: soundcloudUrl }),
+				},
+			);
+
+			const data = await response.json();
+
+			if (!response.ok) {
+				throw new Error(data.error || 'Failed to start yt-dlp download');
+			}
+
+			setJob((prev) => ({ ...prev, hypedditUrl: soundcloudUrl }));
+			startDownload(job.jobId);
+		} catch (err) {
+			setJob((prev) => ({
+				...prev,
+				error: err instanceof Error ? err.message : 'Unknown error',
+			}));
+		} finally {
+			setIsLoading(false);
+		}
+	};
+
 	// Start download process
 	const startDownload = useCallback(async (jobId: string) => {
 		setStep('progress');
@@ -400,7 +435,7 @@ export default function App() {
 					<span className="logo-icon">&#9654;</span>
 					<h1>sc-gate-dl</h1>
 				</div>
-				<p className="tagline">Download & tag SoundCloud tracks from Hypeddit, Droploud, GateRush, or DownloadGater</p>
+				<p className="tagline">Download & tag SoundCloud tracks from Hypeddit, Droploud, GateRush, DownloadGater, or Bandcamp</p>
 			</header>
 
 			{/* Step indicator */}
@@ -511,50 +546,70 @@ export default function App() {
 
 				{/* Step 2: Gate URL (if needed) */}
 				{step === 'hypeddit' && (
-					<form onSubmit={handleHypedditSubmit} className="form animate-slide-up">
+					<div className="form animate-slide-up">
 						<div className="notice">
 							<span className="notice-icon">i</span>
 							<p>
 								{skipAutomaticHypedditFetch
-									? 'Automatic gate lookup is disabled. Please enter the URL manually.'
-									: 'Gate URL not found in track. Please enter a Hypeddit, Droploud, GateRush, or DownloadGater URL manually.'}
+									? 'Automatic gate lookup is disabled. Enter a gate URL manually, or download the SoundCloud track via yt-dlp.'
+									: 'Gate URL not found in track. Enter a Hypeddit, Droploud, GateRush, DownloadGater, or Bandcamp URL, or download via yt-dlp from SoundCloud.'}
 							</p>
 						</div>
-						<div className="form-group">
-							<label htmlFor="hypeddit-url">Gate URL</label>
-							<input
-								id="hypeddit-url"
-								type="url"
-								name="hypeddit-url"
-								value={hypedditUrlInput}
-								onChange={(e) => setHypedditUrlInput(e.target.value)}
-								placeholder="https://hypeddit.com/... / droploud.com/gate/... / gaterush.me/... / downloadgater.com/g/..."
-								autoComplete="off"
-								required
-								disabled={isLoading}
-							/>
+						<form onSubmit={handleHypedditSubmit}>
+							<div className="form-group">
+								<label htmlFor="hypeddit-url">Gate URL</label>
+								<input
+									id="hypeddit-url"
+									type="url"
+									name="hypeddit-url"
+									value={hypedditUrlInput}
+									onChange={(e) => setHypedditUrlInput(e.target.value)}
+									placeholder="https://hypeddit.com/... / droploud.com/gate/... / gaterush.me/... / downloadgater.com/g/... / artist.bandcamp.com/track/..."
+									autoComplete="off"
+									required
+									disabled={isLoading}
+								/>
+							</div>
+							<label className="checkbox-row" htmlFor="headful-mode-gate">
+								<input
+									id="headful-mode-gate"
+									type="checkbox"
+									checked={headfulMode}
+									onChange={(e) => setHeadfulMode(e.target.checked)}
+									disabled={isLoading}
+								/>
+								<span>Show browser window (headful)</span>
+							</label>
+							<button type="submit" className="btn-primary" disabled={isLoading}>
+								{isLoading ? (
+									<>
+										<span className="spinner" />
+										Starting...
+									</>
+								) : (
+									'Start Download'
+								)}
+							</button>
+						</form>
+						<div className="form-divider" aria-hidden="true">
+							<span>or</span>
 						</div>
-						<label className="checkbox-row" htmlFor="headful-mode-gate">
-							<input
-								id="headful-mode-gate"
-								type="checkbox"
-								checked={headfulMode}
-								onChange={(e) => setHeadfulMode(e.target.checked)}
-								disabled={isLoading}
-							/>
-							<span>Show browser window (headful)</span>
-						</label>
-						<button type="submit" className="btn-primary" disabled={isLoading}>
+						<button
+							type="button"
+							className="btn-secondary btn-full"
+							disabled={isLoading || !soundcloudUrl.trim()}
+							onClick={handleYtdlpSoundcloudDownload}
+						>
 							{isLoading ? (
 								<>
 									<span className="spinner" />
 									Starting...
 								</>
 							) : (
-								'Start Download'
+								'Download via yt-dlp from SoundCloud'
 							)}
 						</button>
-					</form>
+					</div>
 				)}
 
 				{/* Step 3: Progress */}


### PR DESCRIPTION
## Summary
- Detect Bandcamp purchase/description links on SoundCloud tracks and download them with yt-dlp (browserless), matching album entries to the SoundCloud track title so the correct song is kept
- When no gate/Bandcamp URL is found, allow downloading the SoundCloud track itself via yt-dlp (Web UI button + CLI prompt)
- Document yt-dlp as a prerequisite

## Test plan
- [ ] SoundCloud track with Bandcamp **track** purchase URL downloads the expected file
- [ ] SoundCloud track with Bandcamp **album** purchase URL (e.g. collective-recs / in-the-dance-clip) matches and downloads only the matching track, not the whole album
- [ ] Track with no gate shows the “Download via yt-dlp from SoundCloud” option and completes a browserless download
- [ ] Traditional Hypeddit/Droploud gates still take priority over Bandcamp when both are present
- [ ] CLI offers the same yt-dlp vs manual gate choice when no URL is found

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DownloadGater and Bandcamp support, including track and album downloads.
  * Added browserless downloads for SoundCloud tracks and Bandcamp purchases using yt-dlp.
  * Added a choice between direct SoundCloud downloading and entering a supported gate URL.
  * Improved gate detection, provider selection, and download validation.

* **UI Improvements**
  * Added clearer instructions, form dividers, full-width buttons, and disabled-button styling.
  * Improved loading and error handling for direct downloads.

* **Documentation**
  * Updated prerequisites and usage guidance, including yt-dlp requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->