### PR TITLE
feat: output format choice and existing MP3 metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Download and tag SoundCloud tracks unlocked via Hypeddit, Droploud, GateRush, Do
 Clone the repository
 
 ```bash
-git clone https://github.com/D3SOX/hypeddit-soundcloud-downloader
-cd hypeddit-soundcloud-downloader
+git clone https://github.com/D3SOX/sc-gate-dl
+cd sc-gate-dl
 ```
 
 Install dependencies

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"private": true,
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/D3SOX/hypeddit-soundcloud-downloader"
+		"url": "https://github.com/D3SOX/sc-gate-dl"
 	},
 	"author": {
 		"name": "D3SOX",

--- a/src/jobStore.ts
+++ b/src/jobStore.ts
@@ -1,4 +1,4 @@
-import type { Job, JobProgress, JobStage } from './types';
+import type { Job, JobProgress, JobStage, OutputFormat } from './types';
 
 type ProgressListener = (progress: JobProgress) => void;
 
@@ -12,7 +12,7 @@ class JobStore {
 	/**
 	 * Creates a new job and returns its ID
 	 */
-	create(soundcloudUrl: string): Job {
+	create(soundcloudUrl: string, outputFormat: OutputFormat): Job {
 		const id = crypto.randomUUID();
 		const now = new Date();
 		const job: Job = {
@@ -20,8 +20,10 @@ class JobStore {
 			soundcloudUrl,
 			hypedditUrl: null,
 			headless: process.env.BROWSER_HEADLESS !== 'false',
+			outputFormat,
 			track: null,
 			defaultMetadata: null,
+			existingMetadata: null,
 			progress: {
 				stage: 'pending',
 				message: 'Job created',

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,12 +9,13 @@ import { HypedditDownloader } from './hypeddit';
 import { HypedditHttpDownloader } from './hypedditHttp';
 import { jobStore } from './jobStore';
 import { SoundcloudClient } from './soundcloud';
-import type { Job, Metadata } from './types';
+import type { Job, Metadata, OutputFormat } from './types';
 import {
 	extractGateUrl,
 	getDefaultMetadata,
 	getFfmpegBin,
 	getFfprobeBin,
+	isMp3Format,
 	resolveGateProviderUrl,
 	validateGateUrl,
 	validateSoundcloudUrl,
@@ -327,6 +328,19 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 
 		jobStore.update(jobId, { downloadFilename });
 
+		if (job.outputFormat === 'original') {
+			jobStore.update(jobId, { outputFilename: downloadFilename });
+			jobStore.updateProgress(jobId, 'ready', 'Original file ready', 100);
+			return;
+		}
+
+		if (isMp3Format(downloadFilename)) {
+			const existingMetadata = await audioProcessor.readMp3Metadata(
+				join('./downloads', downloadFilename),
+			);
+			jobStore.update(jobId, { existingMetadata: existingMetadata ?? {} });
+		}
+
 		jobStore.updateProgress(
 			jobId,
 			'processing_audio',
@@ -336,11 +350,17 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 
 		const artworkFetchUrl = job.track?.artworkUrl || job.track?.user.avatarUrl;
 		if (artworkFetchUrl) {
-			const artwork = await soundcloudClient.fetchArtwork(artworkFetchUrl);
-			jobStore.update(jobId, {
-				artworkBuffer: artwork.buffer,
-				artworkFileName: artwork.fileName,
-			});
+			try {
+				const artwork = await soundcloudClient.fetchArtwork(artworkFetchUrl);
+				jobStore.update(jobId, {
+					artworkBuffer: artwork.buffer,
+					artworkFileName: artwork.fileName,
+				});
+			} catch (error) {
+				console.warn(
+					`Failed to fetch artwork: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
 		}
 
 		jobStore.updateProgress(jobId, 'ready', 'Ready for metadata editing', 100);
@@ -461,10 +481,12 @@ const server = Bun.serve({
 			POST: async (req) => {
 				try {
 					const body = await req.json();
-					const { soundcloudUrl, skipAutomaticHypedditFetch } = body as {
-						soundcloudUrl?: string;
-						skipAutomaticHypedditFetch?: boolean;
-					};
+					const { soundcloudUrl, skipAutomaticHypedditFetch, outputFormat } =
+						body as {
+							soundcloudUrl?: string;
+							skipAutomaticHypedditFetch?: boolean;
+							outputFormat?: OutputFormat;
+						};
 
 					if (!soundcloudUrl) {
 						return jsonResponse(
@@ -478,7 +500,18 @@ const server = Bun.serve({
 						return jsonResponse({ error: validation }, { status: 400 });
 					}
 
-					const job = jobStore.create(soundcloudUrl);
+					if (
+						outputFormat !== undefined &&
+						outputFormat !== 'original' &&
+						outputFormat !== 'mp3-320'
+					) {
+						return jsonResponse(
+							{ error: 'outputFormat must be "original" or "mp3-320"' },
+							{ status: 400 },
+						);
+					}
+
+					const job = jobStore.create(soundcloudUrl, outputFormat ?? 'mp3-320');
 					jobStore.updateProgress(
 						job.id,
 						'fetching_track',
@@ -535,6 +568,7 @@ const server = Bun.serve({
 						track: updatedJob.track,
 						hypedditUrl: updatedJob.hypedditUrl,
 						defaultMetadata: updatedJob.defaultMetadata,
+						outputFormat: updatedJob.outputFormat,
 						needsHypedditUrl: !hypedditUrl,
 					});
 				} catch (error) {
@@ -742,8 +776,11 @@ const server = Bun.serve({
 					hypedditUrl: job.hypedditUrl,
 					track: job.track,
 					defaultMetadata: job.defaultMetadata,
+					existingMetadata: job.existingMetadata,
+					outputFormat: job.outputFormat,
 					progress: job.progress,
 					downloadFilename: job.downloadFilename,
+					outputFilename: job.outputFilename,
 					hasArtwork: !!job.artworkBuffer,
 					error: job.error,
 				});
@@ -795,6 +832,7 @@ const server = Bun.serve({
 
 					const contentType = req.headers.get('content-type') || '';
 					let metadata: Metadata;
+					let preserveMetadata = false;
 					let customArtwork: { buffer: ArrayBuffer; fileName: string } | null =
 						null;
 
@@ -806,6 +844,7 @@ const server = Bun.serve({
 							album: formData.get('album')?.toString() || undefined,
 							genre: formData.get('genre')?.toString() || undefined,
 						};
+						preserveMetadata = formData.get('preserveMetadata') === 'true';
 
 						const artworkFile = formData.get('artwork');
 						if (artworkFile instanceof File) {
@@ -815,8 +854,43 @@ const server = Bun.serve({
 							};
 						}
 					} else {
-						const body = await req.json();
-						metadata = body as Metadata;
+						const body = (await req.json()) as Metadata & {
+							preserveMetadata?: boolean;
+						};
+						metadata = {
+							title: body.title,
+							artist: body.artist,
+							album: body.album,
+							genre: body.genre,
+						};
+						preserveMetadata = body.preserveMetadata === true;
+					}
+
+					if (preserveMetadata && !isMp3Format(job.downloadFilename)) {
+						return jsonResponse(
+							{
+								error: 'Existing metadata can only be preserved for MP3 files',
+							},
+							{ status: 400 },
+						);
+					}
+
+					if (job.outputFormat === 'original' || preserveMetadata) {
+						jobStore.update(jobId, {
+							outputFilename: job.downloadFilename,
+						});
+						jobStore.updateProgress(
+							jobId,
+							'ready',
+							job.outputFormat === 'original'
+								? 'Original file ready'
+								: 'Existing MP3 metadata preserved',
+							100,
+						);
+						return jsonResponse({
+							success: true,
+							outputFilename: job.downloadFilename,
+						});
 					}
 
 					jobStore.updateProgress(
@@ -889,11 +963,12 @@ const server = Bun.serve({
 				}
 
 				const filePath = join('./downloads', filename);
+				const file = Bun.file(filePath);
 
-				return new Response(Bun.file(filePath), {
+				return new Response(file, {
 					headers: {
 						...corsHeaders,
-						'Content-Type': 'audio/mpeg',
+						'Content-Type': file.type || 'application/octet-stream',
 						'Content-Disposition': `attachment; filename="${filename}"`,
 					},
 				});

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,8 @@ export interface Metadata {
 	genre?: string;
 }
 
+export type OutputFormat = 'original' | 'mp3-320';
+
 // Job system types for Web UI
 export type JobStage =
 	| 'pending'
@@ -58,6 +60,7 @@ export interface Job {
 	hypedditUrl: string | null;
 	/** Whether browser automation runs headless. Defaults to true. */
 	headless: boolean;
+	outputFormat: OutputFormat;
 	track: {
 		title: string;
 		artworkUrl: string | null;
@@ -75,6 +78,7 @@ export interface Job {
 		genre?: string;
 	} | null;
 	defaultMetadata: Metadata | null;
+	existingMetadata: Metadata | null;
 	progress: JobProgress;
 	downloadFilename: string | null;
 	outputFilename: string | null;

--- a/webui/src/components/App.css
+++ b/webui/src/components/App.css
@@ -49,11 +49,10 @@
 
 /* Steps indicator */
 .steps {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	gap: var(--space-xs);
-	flex-wrap: wrap;
+	display: grid;
+	grid-template-columns: 1fr auto 1fr auto 1fr auto 1fr auto 1fr;
+	align-items: start;
+	width: 100%;
 }
 
 .step {
@@ -63,6 +62,7 @@
 	gap: var(--space-xs);
 	opacity: 0.4;
 	transition: opacity var(--transition-normal);
+	min-width: 0;
 }
 
 .step.active {
@@ -113,10 +113,10 @@
 }
 
 .step-connector {
-	width: 20px;
+	width: 24px;
 	height: 2px;
 	background: var(--border-subtle);
-	margin-bottom: 20px;
+	margin-top: 15px;
 }
 
 /* Error banner */
@@ -227,7 +227,8 @@
 	letter-spacing: 0.05em;
 }
 
-.form-group input {
+.form-group input,
+.form-group select {
 	padding: var(--space-md) var(--space-lg);
 	background: var(--bg-surface);
 	border: 2px solid var(--border-subtle);
@@ -238,11 +239,17 @@
 	transition: all var(--transition-fast);
 }
 
-.form-group input:hover {
+.form-group select {
+	cursor: pointer;
+}
+
+.form-group input:hover,
+.form-group select:hover {
 	border-color: var(--border-strong);
 }
 
-.form-group input:focus {
+.form-group input:focus,
+.form-group select:focus {
 	outline: none;
 	border-color: var(--neon-cyan);
 	box-shadow: 0 0 0 3px rgba(0, 217, 255, 0.1);
@@ -252,9 +259,35 @@
 	color: var(--text-muted);
 }
 
-.form-group input:disabled {
+.form-group input:disabled,
+.form-group select:disabled {
 	opacity: 0.6;
 	cursor: not-allowed;
+}
+
+.url-settings {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: flex-end;
+	gap: var(--space-md) var(--space-xl);
+	width: 100%;
+}
+
+.url-settings-format {
+	flex: 1 1 12rem;
+	min-width: 0;
+}
+
+.url-settings-format select {
+	width: 100%;
+}
+
+.checkbox-settings {
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-end;
+	gap: var(--space-md);
+	flex: 0 1 auto;
 }
 
 .checkbox-row {
@@ -314,7 +347,11 @@
 	justify-content: center;
 	gap: var(--space-sm);
 	padding: var(--space-md) var(--space-xl);
-	background: linear-gradient(135deg, var(--neon-orange), var(--neon-orange-dim));
+	background: linear-gradient(
+		135deg,
+		var(--neon-orange),
+		var(--neon-orange-dim)
+	);
 	border: none;
 	border-radius: 8px;
 	color: white;
@@ -384,7 +421,7 @@
 
 .form-divider::before,
 .form-divider::after {
-	content: '';
+	content: "";
 	flex: 1;
 	height: 1px;
 	background: var(--border-strong);
@@ -453,7 +490,7 @@
 }
 
 .progress-fill::after {
-	content: '';
+	content: "";
 	position: absolute;
 	inset: 0;
 	background: linear-gradient(
@@ -487,6 +524,57 @@
 	grid-template-columns: auto 1fr;
 	gap: var(--space-xl);
 	margin-bottom: var(--space-xl);
+}
+
+.existing-metadata {
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-md);
+	padding: var(--space-lg);
+	background: rgba(0, 217, 255, 0.05);
+	border: 1px solid rgba(0, 217, 255, 0.2);
+	border-radius: 8px;
+}
+
+.existing-metadata h3 {
+	font-size: 1rem;
+	color: var(--neon-cyan);
+}
+
+.existing-metadata p {
+	margin-top: var(--space-xs);
+	font-size: 0.85rem;
+	color: var(--text-secondary);
+}
+
+.existing-metadata dl {
+	display: grid;
+	grid-template-columns: auto 1fr;
+	gap: var(--space-xs) var(--space-lg);
+	font-family: var(--font-mono);
+	font-size: 0.85rem;
+}
+
+.existing-metadata dt {
+	color: var(--text-muted);
+}
+
+.existing-metadata dd {
+	color: var(--text-primary);
+	word-break: break-word;
+	user-select: text;
+}
+
+.existing-metadata-actions {
+	display: flex;
+	gap: var(--space-sm);
+	flex-wrap: wrap;
+}
+
+.existing-metadata-actions .btn-secondary {
+	flex: 1;
+	padding: var(--space-sm) var(--space-md);
+	font-size: 0.85rem;
 }
 
 @media (max-width: 600px) {

--- a/webui/src/components/App.css
+++ b/webui/src/components/App.css
@@ -561,7 +561,7 @@
 
 .existing-metadata dd {
 	color: var(--text-primary);
-	word-break: break-word;
+	overflow-wrap: anywhere;
 	user-select: text;
 }
 

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -932,7 +932,7 @@ export default function App() {
 				<p>
 					Built for personal use &middot;{' '}
 					<a
-						href="https://github.com/D3SOX/hypeddit-soundcloud-downloader"
+						href="https://github.com/D3SOX/sc-gate-dl"
 						target="_blank"
 						rel="noopener noreferrer"
 					>

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { toast, Toaster } from 'sonner';
+import { useCallback, useRef, useState } from 'react';
+import { Toaster, toast } from 'sonner';
 import './App.css';
 
 type Step = 'url' | 'hypeddit' | 'progress' | 'metadata' | 'complete';
+type OutputFormat = 'original' | 'mp3-320';
 
 interface Metadata {
 	title?: string;
@@ -33,6 +34,8 @@ interface JobState {
 	track: TrackInfo | null;
 	hypedditUrl: string | null;
 	defaultMetadata: Metadata | null;
+	existingMetadata: Metadata | null;
+	outputFormat: OutputFormat;
 	progress: JobProgress | null;
 	downloadFilename: string | null;
 	outputFilename: string | null;
@@ -45,13 +48,17 @@ export default function App() {
 	const [step, setStep] = useState<Step>('url');
 	const [soundcloudUrl, setSoundcloudUrl] = useState('');
 	const [hypedditUrlInput, setHypedditUrlInput] = useState('');
-	const [skipAutomaticHypedditFetch, setSkipAutomaticHypedditFetch] = useState(false);
+	const [skipAutomaticHypedditFetch, setSkipAutomaticHypedditFetch] =
+		useState(false);
 	const [headfulMode, setHeadfulMode] = useState(false);
+	const [outputFormat, setOutputFormat] = useState<OutputFormat>('mp3-320');
 	const [job, setJob] = useState<JobState>({
 		jobId: null,
 		track: null,
 		hypedditUrl: null,
 		defaultMetadata: null,
+		existingMetadata: null,
+		outputFormat: 'mp3-320',
 		progress: null,
 		downloadFilename: null,
 		outputFilename: null,
@@ -85,26 +92,35 @@ export default function App() {
 						const data = await response.json();
 
 						if (!response.ok) {
-							throw new Error(data.error || 'Failed to cleanup SoundCloud account');
+							throw new Error(
+								data.error || 'Failed to cleanup SoundCloud account',
+							);
 						}
 
 						const parts: string[] = [];
 						if (data.unfollowed > 0) {
-							parts.push(`${data.unfollowed} unfollow${data.unfollowed === 1 ? '' : 's'}`);
+							parts.push(
+								`${data.unfollowed} unfollow${data.unfollowed === 1 ? '' : 's'}`,
+							);
 						}
 						if (data.unliked > 0) {
-							parts.push(`${data.unliked} unlike${data.unliked === 1 ? '' : 's'}`);
+							parts.push(
+								`${data.unliked} unlike${data.unliked === 1 ? '' : 's'}`,
+							);
 						}
 						if (data.deletedComments > 0) {
-							parts.push(`${data.deletedComments} comment${data.deletedComments === 1 ? '' : 's'} deleted`);
+							parts.push(
+								`${data.deletedComments} comment${data.deletedComments === 1 ? '' : 's'} deleted`,
+							);
 						}
 						if (data.deletedReposts > 0) {
-							parts.push(`${data.deletedReposts} repost${data.deletedReposts === 1 ? '' : 's'} deleted`);
+							parts.push(
+								`${data.deletedReposts} repost${data.deletedReposts === 1 ? '' : 's'} deleted`,
+							);
 						}
 
-						const description = parts.length > 0
-							? parts.join(', ')
-							: 'No items to clean up.';
+						const description =
+							parts.length > 0 ? parts.join(', ') : 'No items to clean up.';
 
 						toast.success('SoundCloud account cleanup completed.', {
 							id: toastId,
@@ -140,6 +156,7 @@ export default function App() {
 				body: JSON.stringify({
 					soundcloudUrl,
 					skipAutomaticHypedditFetch,
+					outputFormat,
 				}),
 			});
 
@@ -155,6 +172,8 @@ export default function App() {
 				track: data.track,
 				hypedditUrl: data.hypedditUrl,
 				defaultMetadata: data.defaultMetadata,
+				existingMetadata: null,
+				outputFormat,
 				error: null,
 			});
 
@@ -250,65 +269,88 @@ export default function App() {
 	};
 
 	// Start download process
-	const startDownload = useCallback(async (jobId: string) => {
-		setStep('progress');
-		cleanupToastShownRef.current = false;
+	const startDownload = useCallback(
+		async (jobId: string) => {
+			setStep('progress');
+			cleanupToastShownRef.current = false;
 
-		try {
-			const response = await fetch(`${API_BASE}/api/job/${jobId}/start`, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ headless: !headfulMode }),
-			});
+			try {
+				const response = await fetch(`${API_BASE}/api/job/${jobId}/start`, {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ headless: !headfulMode }),
+				});
 
-			if (!response.ok) {
-				const data = await response.json();
-				throw new Error(data.error || 'Failed to start download');
+				if (!response.ok) {
+					const data = await response.json();
+					throw new Error(data.error || 'Failed to start download');
+				}
+
+				// Connect to SSE for progress updates
+				const eventSource = new EventSource(
+					`${API_BASE}/api/job/${jobId}/events`,
+				);
+
+				eventSource.onmessage = (event) => {
+					const progress: JobProgress = JSON.parse(event.data);
+					setJob((prev) => ({ ...prev, progress }));
+
+					// Browserless downloads never touch the SoundCloud account, so there
+					// is nothing to clean up afterwards.
+					if (
+						progress.stage === 'downloading' &&
+						(progress.downloadBytes || progress.totalBytes) &&
+						!progress.browserless &&
+						!cleanupToastShownRef.current
+					) {
+						showCleanupSoundcloudToast();
+						cleanupToastShownRef.current = true;
+					}
+
+					if (progress.stage === 'ready') {
+						eventSource.close();
+						fetch(`${API_BASE}/api/job/${jobId}`)
+							.then((res) => res.json())
+							.then((data) => {
+								setJob((prev) => ({
+									...prev,
+									downloadFilename: data.downloadFilename,
+									outputFilename: data.outputFilename,
+									existingMetadata: data.existingMetadata,
+									outputFormat: data.outputFormat,
+								}));
+								setStep(
+									data.outputFormat === 'original' ? 'complete' : 'metadata',
+								);
+							})
+							.catch((err) => {
+								setJob((prev) => ({
+									...prev,
+									error:
+										err instanceof Error ? err.message : 'Failed to load job',
+								}));
+							});
+					} else if (progress.stage === 'error') {
+						eventSource.close();
+						setJob((prev) => ({ ...prev, error: progress.message }));
+					}
+				};
+
+				eventSource.onerror = () => {
+					eventSource.close();
+				};
+			} catch (err) {
+				setJob((prev) => ({
+					...prev,
+					error: err instanceof Error ? err.message : 'Unknown error',
+				}));
 			}
-
-			// Connect to SSE for progress updates
-			const eventSource = new EventSource(
-				`${API_BASE}/api/job/${jobId}/events`,
-			);
-
-			eventSource.onmessage = (event) => {
-				const progress: JobProgress = JSON.parse(event.data);
-				setJob((prev) => ({ ...prev, progress }));
-
-				// Browserless downloads never touch the SoundCloud account, so there
-				// is nothing to clean up afterwards.
-				if (progress.stage === 'downloading' &&
-					(progress.downloadBytes || progress.totalBytes) &&
-					!progress.browserless &&
-					!cleanupToastShownRef.current
-				) {
-					showCleanupSoundcloudToast();
-					cleanupToastShownRef.current = true;
-				}
-
-				if (progress.stage === 'ready') {
-					eventSource.close();
-					setStep('metadata');
-				} else if (progress.stage === 'error') {
-					eventSource.close();
-					setJob((prev) => ({ ...prev, error: progress.message }));
-				}
-			};
-
-			eventSource.onerror = () => {
-				eventSource.close();
-			};
-		} catch (err) {
-			setJob((prev) => ({
-				...prev,
-				error: err instanceof Error ? err.message : 'Unknown error',
-			}));
-		}
-	}, [headfulMode, showCleanupSoundcloudToast]);
+		},
+		[headfulMode, showCleanupSoundcloudToast],
+	);
 
 	// Process metadata and finalize
-	const handleMetadataSubmit = async (e: React.FormEvent) => {
-		e.preventDefault();
+	const processMetadata = async (preserveMetadata = false) => {
 		if (!job.jobId) return;
 
 		setIsLoading(true);
@@ -316,7 +358,13 @@ export default function App() {
 		try {
 			let response: Response;
 
-			if (customArtwork) {
+			if (preserveMetadata) {
+				response = await fetch(`${API_BASE}/api/job/${job.jobId}/metadata`, {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ preserveMetadata: true }),
+				});
+			} else if (customArtwork) {
 				const formData = new FormData();
 				formData.append('title', metadata.title || '');
 				formData.append('artist', metadata.artist || '');
@@ -354,6 +402,11 @@ export default function App() {
 		}
 	};
 
+	const handleMetadataSubmit = (e: React.FormEvent) => {
+		e.preventDefault();
+		void processMetadata();
+	};
+
 	// Reset and start over
 	const handleReset = () => {
 		setSoundcloudUrl('');
@@ -365,6 +418,8 @@ export default function App() {
 			track: null,
 			hypedditUrl: null,
 			defaultMetadata: null,
+			existingMetadata: null,
+			outputFormat,
 			progress: null,
 			downloadFilename: null,
 			outputFilename: null,
@@ -377,7 +432,8 @@ export default function App() {
 
 	const handleInitializeLogins = async () => {
 		toast('Initialize logins?', {
-			description: 'This will open a browser window (non-headless) to initialize SoundCloud and Spotify logins. You may need to solve a captcha if the built-in solver fails.',
+			description:
+				'This will open a browser window (non-headless) to initialize SoundCloud and Spotify logins. You may need to solve a captcha if the built-in solver fails.',
 			closeButton: false,
 			duration: Infinity,
 			action: {
@@ -413,20 +469,6 @@ export default function App() {
 		});
 	};
 
-	// Refresh job state (for metadata step)
-	useEffect(() => {
-		if (step === 'metadata' && job.jobId) {
-			fetch(`${API_BASE}/api/job/${job.jobId}`)
-				.then((res) => res.json())
-				.then((data) => {
-					setJob((prev) => ({
-						...prev,
-						downloadFilename: data.downloadFilename,
-					}));
-				});
-		}
-	}, [step, job.jobId]);
-
 	return (
 		<div className="app">
 			<Toaster richColors closeButton theme="dark" />
@@ -435,32 +477,45 @@ export default function App() {
 					<span className="logo-icon">&#9654;</span>
 					<h1>sc-gate-dl</h1>
 				</div>
-				<p className="tagline">Download & tag SoundCloud tracks from Hypeddit, Droploud, GateRush, DownloadGater, or Bandcamp</p>
+				<p className="tagline">
+					Download & tag SoundCloud tracks from Hypeddit, Droploud, GateRush,
+					DownloadGater, or Bandcamp
+				</p>
 			</header>
 
 			{/* Step indicator */}
 			<div className="steps">
-				<div className={`step ${step === 'url' ? 'active' : ''} ${['hypeddit', 'progress', 'metadata', 'complete'].includes(step) ? 'completed' : ''}`}>
+				<div
+					className={`step ${step === 'url' ? 'active' : ''} ${['hypeddit', 'progress', 'metadata', 'complete'].includes(step) ? 'completed' : ''}`}
+				>
 					<span className="step-number">1</span>
 					<span className="step-label">SoundCloud</span>
 				</div>
 				<div className="step-connector" />
-				<div className={`step ${step === 'hypeddit' ? 'active' : ''} ${['progress', 'metadata', 'complete'].includes(step) ? 'completed' : ''}`}>
+				<div
+					className={`step ${step === 'hypeddit' ? 'active' : ''} ${['progress', 'metadata', 'complete'].includes(step) ? 'completed' : ''}`}
+				>
 					<span className="step-number">2</span>
 					<span className="step-label">Gate</span>
 				</div>
 				<div className="step-connector" />
-				<div className={`step ${step === 'progress' ? 'active' : ''} ${['metadata', 'complete'].includes(step) ? 'completed' : ''}`}>
+				<div
+					className={`step ${step === 'progress' ? 'active' : ''} ${['metadata', 'complete'].includes(step) ? 'completed' : ''}`}
+				>
 					<span className="step-number">3</span>
 					<span className="step-label">Download</span>
 				</div>
 				<div className="step-connector" />
-				<div className={`step ${step === 'metadata' ? 'active' : ''} ${step === 'complete' ? 'completed' : ''}`}>
+				<div
+					className={`step ${step === 'metadata' ? 'active' : ''} ${step === 'complete' ? 'completed' : ''}`}
+				>
 					<span className="step-number">4</span>
 					<span className="step-label">Metadata</span>
 				</div>
 				<div className="step-connector" />
-				<div className={`step ${step === 'complete' ? 'active completed' : ''}`}>
+				<div
+					className={`step ${step === 'complete' ? 'active completed' : ''}`}
+				>
 					<span className="step-number">5</span>
 					<span className="step-label">Done</span>
 				</div>
@@ -471,7 +526,10 @@ export default function App() {
 				<div className="error-banner">
 					<span className="error-icon">!</span>
 					<span>{job.error}</span>
-					<button type="button" onClick={() => setJob((prev) => ({ ...prev, error: null }))}>
+					<button
+						type="button"
+						onClick={() => setJob((prev) => ({ ...prev, error: null }))}
+					>
 						Dismiss
 					</button>
 				</div>
@@ -481,7 +539,10 @@ export default function App() {
 			{job.track && step !== 'url' && (
 				<div className="track-preview">
 					<img
-						src={(job.track.artworkUrl || job.track.user.avatarUrl).replace('large', 't300x300')}
+						src={(job.track.artworkUrl || job.track.user.avatarUrl).replace(
+							'large',
+							't300x300',
+						)}
 						alt="Track artwork"
 						className="track-artwork"
 					/>
@@ -496,7 +557,10 @@ export default function App() {
 			<div className="content">
 				{/* Step 1: SoundCloud URL */}
 				{step === 'url' && (
-					<form onSubmit={handleSoundcloudSubmit} className="form animate-slide-up">
+					<form
+						onSubmit={handleSoundcloudSubmit}
+						className="form animate-slide-up"
+					>
 						<div className="form-group">
 							<label htmlFor="soundcloud-url">SoundCloud Track URL</label>
 							<input
@@ -511,26 +575,46 @@ export default function App() {
 								disabled={isLoading}
 							/>
 						</div>
-						<label className="checkbox-row" htmlFor="skip-hypeddit-fetch">
-							<input
-								id="skip-hypeddit-fetch"
-								type="checkbox"
-								checked={skipAutomaticHypedditFetch}
-								onChange={(e) => setSkipAutomaticHypedditFetch(e.target.checked)}
-								disabled={isLoading}
-							/>
-							<span>Skip automatic gate link fetching</span>
-						</label>
-						<label className="checkbox-row" htmlFor="headful-mode">
-							<input
-								id="headful-mode"
-								type="checkbox"
-								checked={headfulMode}
-								onChange={(e) => setHeadfulMode(e.target.checked)}
-								disabled={isLoading}
-							/>
-							<span>Show browser window (headful)</span>
-						</label>
+						<div className="url-settings">
+							<div className="form-group url-settings-format">
+								<label htmlFor="output-format">Output Format</label>
+								<select
+									id="output-format"
+									value={outputFormat}
+									onChange={(e) =>
+										setOutputFormat(e.target.value as OutputFormat)
+									}
+									disabled={isLoading}
+								>
+									<option value="mp3-320">MP3 320 kbps</option>
+									<option value="original">Original file</option>
+								</select>
+							</div>
+							<div className="checkbox-settings">
+								<label className="checkbox-row" htmlFor="skip-hypeddit-fetch">
+									<input
+										id="skip-hypeddit-fetch"
+										type="checkbox"
+										checked={skipAutomaticHypedditFetch}
+										onChange={(e) =>
+											setSkipAutomaticHypedditFetch(e.target.checked)
+										}
+										disabled={isLoading}
+									/>
+									<span>Skip automatic gate link fetching</span>
+								</label>
+								<label className="checkbox-row" htmlFor="headful-mode">
+									<input
+										id="headful-mode"
+										type="checkbox"
+										checked={headfulMode}
+										onChange={(e) => setHeadfulMode(e.target.checked)}
+										disabled={isLoading}
+									/>
+									<span>Show browser window (headful)</span>
+								</label>
+							</div>
+						</div>
 						<button type="submit" className="btn-primary" disabled={isLoading}>
 							{isLoading ? (
 								<>
@@ -580,7 +664,11 @@ export default function App() {
 								/>
 								<span>Show browser window (headful)</span>
 							</label>
-							<button type="submit" className="btn-primary" disabled={isLoading}>
+							<button
+								type="submit"
+								className="btn-primary"
+								disabled={isLoading}
+							>
 								{isLoading ? (
 									<>
 										<span className="spinner" />
@@ -616,9 +704,13 @@ export default function App() {
 				{step === 'progress' && (
 					<div className="progress-container animate-slide-up">
 						<div className="progress-stage">
-							<span className="stage-label">{job.progress?.message || 'Initializing...'}</span>
+							<span className="stage-label">
+								{job.progress?.message || 'Initializing...'}
+							</span>
 							{job.progress?.currentGate && (
-								<span className="gate-badge">{job.progress.currentGate.toUpperCase()}</span>
+								<span className="gate-badge">
+									{job.progress.currentGate.toUpperCase()}
+								</span>
 							)}
 						</div>
 						<div className="progress-bar">
@@ -642,7 +734,48 @@ export default function App() {
 
 				{/* Step 4: Metadata */}
 				{step === 'metadata' && (
-					<form onSubmit={handleMetadataSubmit} className="form metadata-form animate-slide-up">
+					<form
+						onSubmit={handleMetadataSubmit}
+						className="form metadata-form animate-slide-up"
+					>
+						{job.existingMetadata && (
+							<div className="existing-metadata">
+								<div>
+									<h3>Existing MP3 Metadata</h3>
+									<p>
+										Copy these values into the form, or keep the file unchanged.
+									</p>
+								</div>
+								<dl>
+									<dt>Title</dt>
+									<dd>{job.existingMetadata.title || 'Not set'}</dd>
+									<dt>Artist</dt>
+									<dd>{job.existingMetadata.artist || 'Not set'}</dd>
+									<dt>Album</dt>
+									<dd>{job.existingMetadata.album || 'Not set'}</dd>
+									<dt>Genre</dt>
+									<dd>{job.existingMetadata.genre || 'Not set'}</dd>
+								</dl>
+								<div className="existing-metadata-actions">
+									<button
+										type="button"
+										className="btn-secondary"
+										disabled={isLoading}
+										onClick={() => setMetadata(job.existingMetadata || {})}
+									>
+										Use Existing Values
+									</button>
+									<button
+										type="button"
+										className="btn-secondary"
+										disabled={isLoading}
+										onClick={() => void processMetadata(true)}
+									>
+										Leave Metadata As-Is
+									</button>
+								</div>
+							</div>
+						)}
 						<div className="metadata-grid">
 							<div className="artwork-section">
 								<div className="artwork-preview">
@@ -664,7 +797,9 @@ export default function App() {
 									<input
 										type="file"
 										accept="image/*"
-										onChange={(e) => setCustomArtwork(e.target.files?.[0] || null)}
+										onChange={(e) =>
+											setCustomArtwork(e.target.files?.[0] || null)
+										}
 									/>
 									<span>Change Artwork</span>
 								</label>
@@ -678,7 +813,10 @@ export default function App() {
 										type="text"
 										value={metadata.title || ''}
 										onChange={(e) =>
-											setMetadata((prev) => ({ ...prev, title: e.target.value }))
+											setMetadata((prev) => ({
+												...prev,
+												title: e.target.value,
+											}))
 										}
 										placeholder="Track title"
 									/>
@@ -690,7 +828,10 @@ export default function App() {
 										type="text"
 										value={metadata.artist || ''}
 										onChange={(e) =>
-											setMetadata((prev) => ({ ...prev, artist: e.target.value }))
+											setMetadata((prev) => ({
+												...prev,
+												artist: e.target.value,
+											}))
 										}
 										placeholder="Artist name"
 									/>
@@ -702,7 +843,10 @@ export default function App() {
 										type="text"
 										value={metadata.album || ''}
 										onChange={(e) =>
-											setMetadata((prev) => ({ ...prev, album: e.target.value }))
+											setMetadata((prev) => ({
+												...prev,
+												album: e.target.value,
+											}))
 										}
 										placeholder="Album name"
 									/>
@@ -714,7 +858,10 @@ export default function App() {
 										type="text"
 										value={metadata.genre || ''}
 										onChange={(e) =>
-											setMetadata((prev) => ({ ...prev, genre: e.target.value }))
+											setMetadata((prev) => ({
+												...prev,
+												genre: e.target.value,
+											}))
 										}
 										placeholder="Genre"
 									/>
@@ -740,16 +887,24 @@ export default function App() {
 					<div className="complete-container animate-slide-up">
 						<div className="success-icon">&#10003;</div>
 						<h2>Download Ready!</h2>
-						<p className="filename mono">{job.outputFilename || job.downloadFilename}</p>
+						<p className="filename mono">
+							{job.outputFilename || job.downloadFilename}
+						</p>
 						<div className="complete-actions">
 							<a
 								href={`${API_BASE}/api/job/${job.jobId}/file`}
 								download
 								className="btn-primary"
 							>
-								Download MP3
+								{job.outputFormat === 'original'
+									? 'Download Original'
+									: 'Download MP3'}
 							</a>
-							<button type="button" onClick={handleReset} className="btn-secondary">
+							<button
+								type="button"
+								onClick={handleReset}
+								className="btn-secondary"
+							>
 								Start New Download
 							</button>
 						</div>


### PR DESCRIPTION
## Summary
- Add per-job output format selection: keep the original download or convert/retag to MP3 320 kbps
- When the download is already an MP3, show existing tags on the metadata step with options to copy them or leave metadata as-is
- Tidy the URL-step settings layout and even out step-indicator spacing

## Test plan
- [ ] Start a job with **MP3 320 kbps**, download a lossless gate file, edit metadata, confirm conversion
- [ ] Start a job with **Original file**, confirm metadata step is skipped and the original file downloads with correct MIME type
- [ ] Download an already-MP3 file with MP3 320 selected: confirm existing tags appear, **Use Existing Values** fills the form, **Leave Metadata As-Is** skips retagging
- [ ] Confirm URL-step format select + checkboxes span the full form width
- [ ] Confirm step indicator circles/dashes are evenly spaced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Choose between downloading the original audio or converting it to MP3 at 320 kbps.
  * Review existing MP3 metadata and choose whether to preserve or update it.
  * Download original files without additional metadata processing.
  * Downloaded files now use the correct detected file type.

* **Bug Fixes**
  * Artwork download failures no longer prevent processing.
  * Improved form layout, step navigation, and responsive controls.
  * Metadata options now validate MP3 compatibility.

* **Documentation**
  * Updated installation instructions and repository links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->