### PR TITLE
feat: metadata UX, userscript panel/queue, Hypeddit headless fallback, and cancel downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Download and tag SoundCloud tracks unlocked via Hypeddit, Droploud, GateRush, Do
 - 🎧 Converts Lossless (WAV/AIFF/FLAC) files to MP3 (320kbps)
 - 🏷️ Tags MP3 files with metadata and artwork from SoundCloud
 - 🧹 Optional cleanup of the SoundCloud account (unfollow, unlike, delete comments/reposts)
+- 🧩 Userscript (Violentmonkey) that opens the Web UI in a floating panel next to SoundCloud store/buy links
 
 ## Prerequisites
 
@@ -140,6 +141,37 @@ bun webui
 Wait for Astro to be started. It will then tell you the address it's available on, most likely [`http://localhost:4321`](http://localhost:4321).
 
 If it's the first time you're running it you will need to initialize the logins by clicking the button in the footer.
+
+You can deep-link a track with `?url=` (also accepted as `?soundcloudUrl=`) and optional `outputFormat` (`mp3-320` or `original`), which pre-fills the form and starts the job:
+
+```text
+http://localhost:4321/?url=https://soundcloud.com/artist/track&outputFormat=mp3-320
+```
+
+### Browser userscript
+
+Adds a download icon next to SoundCloud store/buy links (feed and track pages). Clicking it opens the **exact Web UI** in a floating, movable panel on the right (resizable from all edges) — the page behind stays usable (no dimmed overlay). Choose output format via the panel toolbar, or Violentmonkey → **Choose output format…**. Auto-close after the **browser file download** (Download MP3/Original) or **Start New Download** is on by default — toggle via **Auto-close after browser download**. Closing the panel (× / Escape) or **Cancel download** in the Web UI stops an in-progress job and exits the browser cleanly.
+
+**Recommended:** [Violentmonkey](https://violentmonkey.github.io/) (Firefox / Chrome / Edge). Tampermonkey also works.
+
+[![Install userscript](https://img.shields.io/badge/Install%20userscript-Violentmonkey-3b3b3b?style=for-the-badge&logo=firefoxbrowser&logoColor=white)](https://raw.githubusercontent.com/D3SOX/sc-gate-dl/main/userscript/sc-gate-dl.user.js)
+
+Or open the raw file: [`userscript/sc-gate-dl.user.js`](https://raw.githubusercontent.com/D3SOX/sc-gate-dl/main/userscript/sc-gate-dl.user.js)
+
+1. Install [Violentmonkey](https://violentmonkey.github.io/)
+2. Click **Install userscript** above (Violentmonkey will prompt to confirm)
+3. Start the Web UI locally: `bun webui`
+4. Browse SoundCloud — use the download icon beside the store/cart button
+
+Chrome may ask once to allow the page to access your local network (`localhost`). If the panel iframe is blocked, use **open in tab** in the panel toolbar.
+
+To point at a different Web UI origin (from the SoundCloud tab console):
+
+```js
+localStorage.setItem('sc-gate-dl-webui-base', 'http://localhost:4321')
+```
+
+Panel size/position is remembered in `localStorage` (`sc-gate-dl-panel-geom`).
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Install the [EditThisCookie (fork)](https://chromewebstore.google.com/detail/edi
 
 #### SoundCloud Cookies (Required)
 
+Used for SoundCloud API/session automation and for **yt-dlp** when downloading a SoundCloud track directly (so downloadable tracks can fetch the original upload, not only the 128k stream).
+
 **Steps:**
 
 1. Go to [soundcloud.com](https://soundcloud.com) and log in

--- a/src/audioProcessor.ts
+++ b/src/audioProcessor.ts
@@ -1,7 +1,12 @@
+import { existsSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import { confirm, input } from '@inquirer/prompts';
 import { execa } from 'execa';
 import type { SoundcloudTrack } from 'soundcloud.ts';
+import {
+	pickUniqueDownloadFilename,
+	withDownloadRenameLock,
+} from './downloadRename';
 import type { Metadata } from './types';
 import {
 	getDefaultMetadata,
@@ -11,6 +16,16 @@ import {
 	REPO_URL,
 	toMp3Filename,
 } from './utils';
+
+type FfprobeResult = {
+	format?: { tags?: Record<string, string>; bit_rate?: string };
+	streams?: Array<{
+		tags?: Record<string, string>;
+		codec_type?: string;
+		codec_name?: string;
+		bit_rate?: string;
+	}>;
+};
 
 export class AudioProcessor {
 	private ffmpegBin: string;
@@ -27,11 +42,17 @@ export class AudioProcessor {
 			return null;
 		}
 
-		const tags = probeData.format?.tags || probeData.streams?.[0]?.tags || null;
-
-		if (!tags) {
+		const streamTags = (probeData.streams ?? [])
+			.filter((stream) => stream.codec_type === 'audio')
+			.map((stream) => stream.tags)
+			.filter((value): value is Record<string, string> => Boolean(value));
+		const tagSources = [...streamTags, probeData.format?.tags].filter(
+			(value): value is Record<string, string> => Boolean(value),
+		);
+		if (tagSources.length === 0) {
 			return null;
 		}
+		const tags = Object.assign({}, ...tagSources);
 
 		// MP3 metadata can be in different cases
 		const getTag = (key: string): string | undefined => {
@@ -188,14 +209,7 @@ export class AudioProcessor {
 		}
 	}
 
-	private async runFfprobe(inputPath: string): Promise<{
-		format?: { tags?: Record<string, string>; bit_rate?: string };
-		streams?: Array<{
-			tags?: Record<string, string>;
-			codec_type?: string;
-			bit_rate?: string;
-		}>;
-	} | null> {
+	private async runFfprobe(inputPath: string): Promise<FfprobeResult | null> {
 		try {
 			const { stdout } = await execa(this.ffprobeBin, [
 				'-v',
@@ -206,14 +220,7 @@ export class AudioProcessor {
 				'-show_streams',
 				inputPath,
 			]);
-			return JSON.parse(stdout) as {
-				format?: { tags?: Record<string, string>; bit_rate?: string };
-				streams?: Array<{
-					tags?: Record<string, string>;
-					codec_type?: string;
-					bit_rate?: string;
-				}>;
-			};
+			return JSON.parse(stdout) as FfprobeResult;
 		} catch (error) {
 			console.warn(
 				`Failed to probe audio: ${error instanceof Error ? error.message : String(error)}`,
@@ -222,25 +229,33 @@ export class AudioProcessor {
 		}
 	}
 
-	/** Probe audio bitrate in kbps; null when unknown. */
-	private async probeAudioBitrateKbps(
+	private parseBitrateKbps(raw: string | undefined): number | null {
+		if (!raw) return null;
+		const bps = Number(raw);
+		if (!Number.isFinite(bps) || bps <= 0) return null;
+		return Math.round(bps / 1000);
+	}
+
+	/** Probe audio bitrate (kbps) and codec; null bitrate when unknown. */
+	private async probeAudioStream(
 		inputPath: string,
-	): Promise<number | null> {
+	): Promise<{ bitrateKbps: number | null; codecName: string | null }> {
 		const probeData = await this.runFfprobe(inputPath);
 		if (!probeData) {
-			return null;
+			return { bitrateKbps: null, codecName: null };
 		}
 
 		const audioStream = probeData.streams?.find(
 			(stream) => stream.codec_type === 'audio',
 		);
-		const raw =
-			audioStream?.bit_rate || probeData.format?.bit_rate || undefined;
-		if (!raw) return null;
+		const bitrateKbps =
+			this.parseBitrateKbps(audioStream?.bit_rate) ??
+			this.parseBitrateKbps(probeData.format?.bit_rate);
 
-		const bps = Number(raw);
-		if (!Number.isFinite(bps) || bps <= 0) return null;
-		return Math.round(bps / 1000);
+		return {
+			bitrateKbps,
+			codecName: audioStream?.codec_name ?? null,
+		};
 	}
 
 	/**
@@ -251,15 +266,42 @@ export class AudioProcessor {
 		inputPath: string,
 		filename: string,
 	): Promise<number> {
-		if (isLosslessFormat(filename)) {
+		const probed = await this.probeAudioStream(inputPath);
+		const losslessCodec = probed.codecName?.toLowerCase() === 'alac';
+		if (isLosslessFormat(filename) || losslessCodec) {
 			return 320;
 		}
 
-		const probed = await this.probeAudioBitrateKbps(inputPath);
-		if (probed == null) {
+		if (probed.bitrateKbps == null) {
 			return 192;
 		}
-		return Math.min(320, Math.max(32, probed));
+		return Math.min(320, Math.max(32, probed.bitrateKbps));
+	}
+
+	/** Pick a free MP3 destination and reserve it on disk before FFmpeg runs. */
+	private async allocateMp3OutputPath(
+		inputPath: string,
+		filename: string,
+	): Promise<string> {
+		const downloadsDir = './downloads';
+		const desiredFilename = toMp3Filename(filename);
+		const currentFilename = basename(inputPath);
+
+		return withDownloadRenameLock(async () => {
+			const finalName = pickUniqueDownloadFilename({
+				desiredFilename,
+				currentFilename,
+				jobId: crypto.randomUUID(),
+				exists: (name) => existsSync(join(downloadsDir, name)),
+				isOwnedByOtherJob: () => false,
+			});
+			const outputPath = join(downloadsDir, finalName);
+			// Reserve the name so concurrent converts cannot pick the same path.
+			if (finalName !== currentFilename && !existsSync(outputPath)) {
+				await Bun.write(outputPath, new Uint8Array());
+			}
+			return outputPath;
+		});
 	}
 
 	private async convertToMp3(
@@ -268,7 +310,7 @@ export class AudioProcessor {
 		metadata: Metadata,
 		filename: string,
 	): Promise<string> {
-		const outputPath = join('./downloads', toMp3Filename(filename));
+		const outputPath = await this.allocateMp3OutputPath(inputPath, filename);
 		const bitrateKbps = await this.resolveMp3BitrateKbps(inputPath, filename);
 
 		const args: string[] = [
@@ -310,7 +352,17 @@ export class AudioProcessor {
 		args.push('-y', outputPath);
 
 		console.log(`Converting to MP3 (${bitrateKbps}kbps)...`);
-		await execa(this.ffmpegBin, args);
+		try {
+			await execa(this.ffmpegBin, args);
+		} catch (error) {
+			// Drop the empty reservation if conversion failed.
+			if (existsSync(outputPath) && (await Bun.file(outputPath).size) === 0) {
+				await Bun.file(outputPath)
+					.unlink()
+					.catch(() => {});
+			}
+			throw error;
+		}
 		console.log(`✓ Converted to ${outputPath}`);
 		return outputPath;
 	}

--- a/src/audioProcessor.ts
+++ b/src/audioProcessor.ts
@@ -22,51 +22,28 @@ export class AudioProcessor {
 	}
 
 	async readMp3Metadata(inputPath: string): Promise<Metadata | null> {
-		try {
-			const { stdout } = await execa(this.ffprobeBin, [
-				'-v',
-				'quiet',
-				'-print_format',
-				'json',
-				'-show_format',
-				'-show_streams',
-				inputPath,
-			]);
-
-			const probeData = JSON.parse(stdout) as {
-				format?: {
-					tags?: Record<string, string>;
-				};
-				streams?: Array<{
-					tags?: Record<string, string>;
-				}>;
-			};
-
-			const tags =
-				probeData.format?.tags || probeData.streams?.[0]?.tags || null;
-
-			if (!tags) {
-				return null;
-			}
-
-			// MP3 metadata can be in different cases
-			const getTag = (key: string): string | undefined => {
-				return tags[key] || tags[key.toUpperCase()];
-			};
-
-			return {
-				title: getTag('title'),
-				artist: getTag('artist'),
-				album: getTag('album'),
-				genre: getTag('genre'),
-			};
-		} catch (error) {
-			// If ffprobe is not found or fails, return null to fall back to normal behavior
-			console.warn(
-				`Failed to read MP3 metadata: ${error instanceof Error ? error.message : String(error)}`,
-			);
+		const probeData = await this.runFfprobe(inputPath);
+		if (!probeData) {
 			return null;
 		}
+
+		const tags = probeData.format?.tags || probeData.streams?.[0]?.tags || null;
+
+		if (!tags) {
+			return null;
+		}
+
+		// MP3 metadata can be in different cases
+		const getTag = (key: string): string | undefined => {
+			return tags[key] || tags[key.toUpperCase()];
+		};
+
+		return {
+			title: getTag('title'),
+			artist: getTag('artist'),
+			album: getTag('album'),
+			genre: getTag('genre'),
+		};
 	}
 
 	async promptForMetadata(
@@ -213,10 +190,14 @@ export class AudioProcessor {
 		}
 	}
 
-	/** Probe audio bitrate in kbps; null when unknown. */
-	private async probeAudioBitrateKbps(
-		inputPath: string,
-	): Promise<number | null> {
+	private async runFfprobe(inputPath: string): Promise<{
+		format?: { tags?: Record<string, string>; bit_rate?: string };
+		streams?: Array<{
+			tags?: Record<string, string>;
+			codec_type?: string;
+			bit_rate?: string;
+		}>;
+	} | null> {
 		try {
 			const { stdout } = await execa(this.ffprobeBin, [
 				'-v',
@@ -227,28 +208,41 @@ export class AudioProcessor {
 				'-show_streams',
 				inputPath,
 			]);
-
-			const probeData = JSON.parse(stdout) as {
-				format?: { bit_rate?: string };
-				streams?: Array<{ codec_type?: string; bit_rate?: string }>;
+			return JSON.parse(stdout) as {
+				format?: { tags?: Record<string, string>; bit_rate?: string };
+				streams?: Array<{
+					tags?: Record<string, string>;
+					codec_type?: string;
+					bit_rate?: string;
+				}>;
 			};
-
-			const audioStream = probeData.streams?.find(
-				(stream) => stream.codec_type === 'audio',
-			);
-			const raw =
-				audioStream?.bit_rate || probeData.format?.bit_rate || undefined;
-			if (!raw) return null;
-
-			const bps = Number(raw);
-			if (!Number.isFinite(bps) || bps <= 0) return null;
-			return Math.round(bps / 1000);
 		} catch (error) {
 			console.warn(
-				`Failed to probe audio bitrate: ${error instanceof Error ? error.message : String(error)}`,
+				`Failed to probe audio: ${error instanceof Error ? error.message : String(error)}`,
 			);
 			return null;
 		}
+	}
+
+	/** Probe audio bitrate in kbps; null when unknown. */
+	private async probeAudioBitrateKbps(
+		inputPath: string,
+	): Promise<number | null> {
+		const probeData = await this.runFfprobe(inputPath);
+		if (!probeData) {
+			return null;
+		}
+
+		const audioStream = probeData.streams?.find(
+			(stream) => stream.codec_type === 'audio',
+		);
+		const raw =
+			audioStream?.bit_rate || probeData.format?.bit_rate || undefined;
+		if (!raw) return null;
+
+		const bps = Number(raw);
+		if (!Number.isFinite(bps) || bps <= 0) return null;
+		return Math.round(bps / 1000);
 	}
 
 	/**

--- a/src/audioProcessor.ts
+++ b/src/audioProcessor.ts
@@ -145,19 +145,17 @@ export class AudioProcessor {
 					filename,
 				);
 
-				// ask if you want to remove the source file (only prompt for lossless)
+				// ask if you want to remove the source file
 				let removeSourceFile = true;
-				if (isLosslessFormat(filename)) {
-					if (losslessHandling === 'prompt') {
-						removeSourceFile = await confirm({
-							message: 'Do you want to remove the lossless file now?',
-							default: true,
-						});
-					} else if (losslessHandling === 'always') {
-						removeSourceFile = true;
-					} else if (losslessHandling === 'never') {
-						removeSourceFile = false;
-					}
+				if (losslessHandling === 'prompt') {
+					removeSourceFile = await confirm({
+						message: `Do you want to remove the ${isLosslessFormat(filename) ? 'lossless' : 'source'} file now?`,
+						default: true,
+					});
+				} else if (losslessHandling === 'always') {
+					removeSourceFile = true;
+				} else if (losslessHandling === 'never') {
+					removeSourceFile = false;
 				}
 				if (removeSourceFile) {
 					await Bun.file(inputPath).unlink();

--- a/src/audioProcessor.ts
+++ b/src/audioProcessor.ts
@@ -7,8 +7,9 @@ import {
 	getDefaultMetadata,
 	isLosslessFormat,
 	isMp3Format,
-	losslessToMp3Filename,
+	needsMp3Conversion,
 	REPO_URL,
+	toMp3Filename,
 } from './utils';
 
 export class AudioProcessor {
@@ -158,28 +159,30 @@ export class AudioProcessor {
 		}
 
 		try {
-			// if it is a WAV, AIFF, or FLAC, we convert it to MP3
-			if (isLosslessFormat(filename)) {
-				const outputPath = await this.convertLosslessToMp3(
+			// Convert non-MP3 audio (lossless or lossy containers like m4a) to MP3.
+			if (needsMp3Conversion(filename)) {
+				const outputPath = await this.convertToMp3(
 					inputPath,
 					artworkPath,
 					metadata,
 					filename,
 				);
 
-				// ask if you want to remove the lossless file
-				let removeLosslessFile = true;
-				if (losslessHandling === 'prompt') {
-					removeLosslessFile = await confirm({
-						message: 'Do you want to remove the lossless file now?',
-						default: true,
-					});
-				} else if (losslessHandling === 'always') {
-					removeLosslessFile = true;
-				} else if (losslessHandling === 'never') {
-					removeLosslessFile = false;
+				// ask if you want to remove the source file (only prompt for lossless)
+				let removeSourceFile = true;
+				if (isLosslessFormat(filename)) {
+					if (losslessHandling === 'prompt') {
+						removeSourceFile = await confirm({
+							message: 'Do you want to remove the lossless file now?',
+							default: true,
+						});
+					} else if (losslessHandling === 'always') {
+						removeSourceFile = true;
+					} else if (losslessHandling === 'never') {
+						removeSourceFile = false;
+					}
 				}
-				if (removeLosslessFile) {
+				if (removeSourceFile) {
 					await Bun.file(inputPath).unlink();
 					console.log(`✓ Removed ${inputPath}`);
 				}
@@ -210,13 +213,71 @@ export class AudioProcessor {
 		}
 	}
 
-	private async convertLosslessToMp3(
+	/** Probe audio bitrate in kbps; null when unknown. */
+	private async probeAudioBitrateKbps(
+		inputPath: string,
+	): Promise<number | null> {
+		try {
+			const { stdout } = await execa(this.ffprobeBin, [
+				'-v',
+				'quiet',
+				'-print_format',
+				'json',
+				'-show_format',
+				'-show_streams',
+				inputPath,
+			]);
+
+			const probeData = JSON.parse(stdout) as {
+				format?: { bit_rate?: string };
+				streams?: Array<{ codec_type?: string; bit_rate?: string }>;
+			};
+
+			const audioStream = probeData.streams?.find(
+				(stream) => stream.codec_type === 'audio',
+			);
+			const raw =
+				audioStream?.bit_rate || probeData.format?.bit_rate || undefined;
+			if (!raw) return null;
+
+			const bps = Number(raw);
+			if (!Number.isFinite(bps) || bps <= 0) return null;
+			return Math.round(bps / 1000);
+		} catch (error) {
+			console.warn(
+				`Failed to probe audio bitrate: ${error instanceof Error ? error.message : String(error)}`,
+			);
+			return null;
+		}
+	}
+
+	/**
+	 * Target MP3 bitrate: lossless → 320; lossy → source rate (capped at 320).
+	 * Never upscales a 128k stream to fake 320.
+	 */
+	private async resolveMp3BitrateKbps(
+		inputPath: string,
+		filename: string,
+	): Promise<number> {
+		if (isLosslessFormat(filename)) {
+			return 320;
+		}
+
+		const probed = await this.probeAudioBitrateKbps(inputPath);
+		if (probed == null) {
+			return 192;
+		}
+		return Math.min(320, Math.max(32, probed));
+	}
+
+	private async convertToMp3(
 		inputPath: string,
 		artworkPath: string,
 		metadata: Metadata,
 		filename: string,
 	): Promise<string> {
-		const outputPath = join('./downloads', losslessToMp3Filename(filename));
+		const outputPath = join('./downloads', toMp3Filename(filename));
+		const bitrateKbps = await this.resolveMp3BitrateKbps(inputPath, filename);
 
 		const args: string[] = [
 			'-i',
@@ -228,7 +289,7 @@ export class AudioProcessor {
 			'-c:a',
 			'libmp3lame',
 			'-b:a',
-			'320k',
+			`${bitrateKbps}k`,
 			'-id3v2_version',
 			'3',
 			'-map',
@@ -256,7 +317,7 @@ export class AudioProcessor {
 
 		args.push('-y', outputPath);
 
-		console.log('Converting Lossless to MP3 (320kbps)...');
+		console.log(`Converting to MP3 (${bitrateKbps}kbps)...`);
 		await execa(this.ffmpegBin, args);
 		console.log(`✓ Converted to ${outputPath}`);
 		return outputPath;

--- a/src/downloadRename.test.ts
+++ b/src/downloadRename.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	pickUniqueDownloadFilename,
+	withDownloadRenameLock,
+} from './downloadRename';
+
+describe('pickUniqueDownloadFilename', () => {
+	test('returns desired name when free', () => {
+		expect(
+			pickUniqueDownloadFilename({
+				desiredFilename: 'Artist - Title.mp3',
+				currentFilename: 'download.mp3',
+				jobId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+				exists: () => false,
+				isOwnedByOtherJob: () => false,
+			}),
+		).toBe('Artist - Title.mp3');
+	});
+
+	test('suffixes with job id when destination is taken', () => {
+		expect(
+			pickUniqueDownloadFilename({
+				desiredFilename: 'Artist - Title.mp3',
+				currentFilename: 'download.mp3',
+				jobId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+				exists: (filename) => filename === 'Artist - Title.mp3',
+				isOwnedByOtherJob: () => false,
+			}),
+		).toBe('Artist - Title [aaaaaaaa].mp3');
+	});
+});
+
+describe('withDownloadRenameLock', () => {
+	test('serializes concurrent renames that want the same name', async () => {
+		const owned = new Set<string>();
+		const onDisk = new Set<string>();
+
+		const claim = async (jobId: string, current: string) =>
+			withDownloadRenameLock(async () => {
+				const finalName = pickUniqueDownloadFilename({
+					desiredFilename: 'Artist - Title.mp3',
+					currentFilename: current,
+					jobId,
+					exists: (filename) => onDisk.has(filename),
+					isOwnedByOtherJob: (filename) => owned.has(filename),
+				});
+				onDisk.delete(current);
+				onDisk.add(finalName);
+				owned.add(finalName);
+				return finalName;
+			});
+
+		onDisk.add('a.mp3');
+		onDisk.add('b.mp3');
+
+		const [first, second] = await Promise.all([
+			claim('11111111-1111-1111-1111-111111111111', 'a.mp3'),
+			claim('22222222-2222-2222-2222-222222222222', 'b.mp3'),
+		]);
+
+		expect(first).not.toBe(second);
+		expect(new Set([first, second]).has('Artist - Title.mp3')).toBe(true);
+		expect(owned.has(first)).toBe(true);
+		expect(owned.has(second)).toBe(true);
+	});
+});

--- a/src/downloadRename.test.ts
+++ b/src/downloadRename.test.ts
@@ -44,6 +44,7 @@ describe('withDownloadRenameLock', () => {
 					exists: (filename) => onDisk.has(filename),
 					isOwnedByOtherJob: (filename) => owned.has(filename),
 				});
+				await Promise.resolve();
 				onDisk.delete(current);
 				onDisk.add(finalName);
 				owned.add(finalName);

--- a/src/downloadRename.ts
+++ b/src/downloadRename.ts
@@ -1,0 +1,95 @@
+import { existsSync } from 'node:fs';
+import { rename } from 'node:fs/promises';
+import { basename, extname, join } from 'node:path';
+
+/** Serialize destination allocation + rename + ownership claim. */
+let renameChain: Promise<unknown> = Promise.resolve();
+
+export function withDownloadRenameLock<T>(fn: () => Promise<T>): Promise<T> {
+	const run = renameChain.then(fn, fn);
+	renameChain = run.then(
+		() => undefined,
+		() => undefined,
+	);
+	return run;
+}
+
+/** Choose a downloads/ filename that is free on disk and not owned by another job. */
+export function pickUniqueDownloadFilename(options: {
+	desiredFilename: string;
+	currentFilename: string;
+	jobId: string;
+	exists: (filename: string) => boolean;
+	isOwnedByOtherJob: (filename: string, jobId: string) => boolean;
+}): string {
+	const { desiredFilename, currentFilename, jobId, exists, isOwnedByOtherJob } =
+		options;
+
+	if (desiredFilename === currentFilename) {
+		return currentFilename;
+	}
+
+	let finalName = desiredFilename;
+	const blocked =
+		isOwnedByOtherJob(finalName, jobId) ||
+		(exists(finalName) && finalName !== currentFilename);
+
+	if (!blocked) {
+		return finalName;
+	}
+
+	const ext = extname(desiredFilename);
+	const stem = basename(desiredFilename, ext);
+	const shortId = jobId.slice(0, 8);
+	finalName = `${stem} [${shortId}]${ext}`;
+	let n = 2;
+	while (exists(finalName) || isOwnedByOtherJob(finalName, jobId)) {
+		finalName = `${stem} [${shortId}] (${n})${ext}`;
+		n += 1;
+	}
+	return finalName;
+}
+
+/**
+ * Atomically allocate a destination, rename the file, and claim it on the job.
+ * Concurrent callers are serialized so two jobs cannot race onto the same name.
+ */
+export async function renameDownloadFileExclusive(options: {
+	downloadsDir: string;
+	jobId: string;
+	currentFilename: string;
+	desiredFilename: string;
+	isOwnedByOtherJob: (filename: string, jobId: string) => boolean;
+	claimFilenames: (jobId: string, filename: string) => void;
+}): Promise<string> {
+	const {
+		downloadsDir,
+		jobId,
+		currentFilename,
+		desiredFilename,
+		isOwnedByOtherJob,
+		claimFilenames,
+	} = options;
+
+	return withDownloadRenameLock(async () => {
+		if (currentFilename === desiredFilename) {
+			claimFilenames(jobId, currentFilename);
+			return currentFilename;
+		}
+
+		const finalName = pickUniqueDownloadFilename({
+			desiredFilename,
+			currentFilename,
+			jobId,
+			exists: (filename) => existsSync(join(downloadsDir, filename)),
+			isOwnedByOtherJob,
+		});
+
+		await rename(
+			join(downloadsDir, currentFilename),
+			join(downloadsDir, finalName),
+		);
+		claimFilenames(jobId, finalName);
+		return finalName;
+	});
+}

--- a/src/hypedditHttp.ts
+++ b/src/hypedditHttp.ts
@@ -1,3 +1,4 @@
+import { rename, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { ProgressCallback } from './hypeddit';
 import type { HypedditConfig } from './types';
@@ -265,35 +266,51 @@ export class HypedditHttpDownloader {
 			'download';
 
 		const totalBytes = Number(response.headers.get('content-length')) || 0;
-		const writer = Bun.file(join('./downloads', filename)).writer();
+		const destPath = join('./downloads', filename);
+		const tempPath = `${destPath}.${crypto.randomUUID()}.part`;
+		const writer = Bun.file(tempPath).writer();
 		let receivedBytes = 0;
 		let lastEmit = 0;
+		let succeeded = false;
 
-		if (response.body) {
-			const reader = response.body.getReader();
-			while (true) {
-				const { done, value: chunk } = await reader.read();
-				if (done) {
-					break;
-				}
-				writer.write(chunk);
-				receivedBytes += chunk.byteLength;
+		try {
+			if (response.body) {
+				const reader = response.body.getReader();
+				while (true) {
+					const { done, value: chunk } = await reader.read();
+					if (done) {
+						break;
+					}
+					writer.write(chunk);
+					receivedBytes += chunk.byteLength;
 
-				// throttle progress events to avoid flooding the SSE stream
-				const now = Date.now();
-				if (now - lastEmit > 250 && totalBytes > 0) {
-					lastEmit = now;
-					const downloadPercent = receivedBytes / totalBytes;
-					this.progressCallback?.(
-						'downloading',
-						`Downloading... ${(receivedBytes / 1024 / 1024).toFixed(1)} / ${(totalBytes / 1024 / 1024).toFixed(1)} MB`,
-						76 + downloadPercent * 8,
-						{ downloadBytes: receivedBytes, totalBytes, browserless: true },
-					);
+					// throttle progress events to avoid flooding the SSE stream
+					const now = Date.now();
+					if (now - lastEmit > 250 && totalBytes > 0) {
+						lastEmit = now;
+						const downloadPercent = receivedBytes / totalBytes;
+						this.progressCallback?.(
+							'downloading',
+							`Downloading... ${(receivedBytes / 1024 / 1024).toFixed(1)} / ${(totalBytes / 1024 / 1024).toFixed(1)} MB`,
+							76 + downloadPercent * 8,
+							{ downloadBytes: receivedBytes, totalBytes, browserless: true },
+						);
+					}
 				}
 			}
+			await writer.end();
+			await rename(tempPath, destPath);
+			succeeded = true;
+		} finally {
+			if (!succeeded) {
+				try {
+					await writer.end();
+				} catch {
+					// Writer may already be closed or never flushed.
+				}
+				await rm(tempPath, { force: true }).catch(() => {});
+			}
 		}
-		await writer.end();
 
 		console.log(`Browserless: downloaded ${filename}`);
 		this.progressCallback?.('downloading', 'Download complete', 85);

--- a/src/hypedditHttp.ts
+++ b/src/hypedditHttp.ts
@@ -115,10 +115,15 @@ export class HypedditHttpDownloader {
 	private readonly progressCallback: ProgressCallback | null;
 	private cookies = new Map<string, string>();
 	private csrfToken = '';
+	private abortController = new AbortController();
 
 	constructor(config: HypedditConfig, progressCallback?: ProgressCallback) {
 		this.config = config;
 		this.progressCallback = progressCallback ?? null;
+	}
+
+	async close(): Promise<void> {
+		this.abortController.abort();
 	}
 
 	// Attempts to download the file without a browser. Returns the saved filename,
@@ -185,6 +190,9 @@ export class HypedditHttpDownloader {
 
 			return await this.saveFile(downloadUrl);
 		} catch (error) {
+			if (this.abortController.signal.aborted) {
+				throw new Error('Download cancelled');
+			}
 			if (error instanceof BrowserlessConfigError) {
 				throw error;
 			}
@@ -238,7 +246,9 @@ export class HypedditHttpDownloader {
 
 	private async saveFile(downloadUrl: string): Promise<string> {
 		this.progressCallback?.('downloading', 'Downloading file...', 76);
-		const response = await fetch(downloadUrl);
+		const response = await fetch(downloadUrl, {
+			signal: this.abortController.signal,
+		});
 		if (!response.ok) {
 			throw new Error(`Download request failed: ${response.status}`);
 		}
@@ -314,6 +324,7 @@ export class HypedditHttpDownloader {
 		const response = await fetch(url, {
 			headers: { 'User-Agent': USER_AGENT },
 			redirect: 'follow',
+			signal: this.abortController.signal,
 		});
 		this.storeCookies(response);
 		return await response.text();
@@ -339,6 +350,7 @@ export class HypedditHttpDownloader {
 				Cookie: this.cookieHeader(),
 			},
 			body: params.toString(),
+			signal: this.abortController.signal,
 		});
 		this.storeCookies(response);
 		return response;

--- a/src/hypedditHttp.ts
+++ b/src/hypedditHttp.ts
@@ -299,6 +299,9 @@ export class HypedditHttpDownloader {
 				}
 			}
 			await writer.end();
+			if (this.abortController.signal.aborted) {
+				throw new Error('Download cancelled');
+			}
 			await rename(tempPath, destPath);
 			succeeded = true;
 		} finally {

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,8 +115,7 @@ try {
 		: config
 			? config.headless
 			: await confirm({
-					message:
-						'Run headless? (no browser window). Headless also skips the Hypeddit browser fallback — gates that need Spotify/etc. will fail unless you turn headless off.',
+					message: 'Run headless? (no browser window)',
 					default: true,
 				});
 
@@ -200,8 +199,8 @@ try {
 		const httpDownloader = new HypedditHttpDownloader(gateConfig);
 		downloadFilename = await httpDownloader.tryDownload(gateUrl);
 
-		// HTTP first. Browser fallback only when not headless (user wants a window).
-		if (!downloadFilename && !gateConfig.headless) {
+		// HTTP first. Fall back to the browser (headless or headful) when needed.
+		if (!downloadFilename) {
 			usedBrowser = true;
 			const hypedditDownloader = new HypedditDownloader(gateConfig);
 			try {
@@ -219,10 +218,6 @@ try {
 			} finally {
 				await hypedditDownloader.close();
 			}
-		} else if (!downloadFilename && gateConfig.headless) {
-			throw new Error(
-				'This Hypeddit gate needs a browser (e.g. Spotify). Re-run with headless disabled to allow a browser fallback.',
-			);
 		}
 	}
 

--- a/src/jobStore.ts
+++ b/src/jobStore.ts
@@ -48,6 +48,20 @@ class JobStore {
 		return this.jobs.get(id);
 	}
 
+	/** True when another job already claims this downloads/ filename. */
+	isFilenameOwnedByOtherJob(filename: string, excludeJobId: string): boolean {
+		for (const job of this.jobs.values()) {
+			if (job.id === excludeJobId) continue;
+			if (
+				job.downloadFilename === filename ||
+				job.outputFilename === filename
+			) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	/**
 	 * Updates a job and notifies listeners
 	 */

--- a/src/jobStore.ts
+++ b/src/jobStore.ts
@@ -21,6 +21,7 @@ class JobStore {
 			hypedditUrl: null,
 			headless: process.env.BROWSER_HEADLESS !== 'false',
 			outputFormat,
+			cancelled: false,
 			track: null,
 			defaultMetadata: null,
 			existingMetadata: null,
@@ -122,6 +123,37 @@ class JobStore {
 		job.updatedAt = new Date();
 
 		this.notifyListeners(id, job.progress);
+	}
+
+	isCancelled(id: string): boolean {
+		return this.jobs.get(id)?.cancelled === true;
+	}
+
+	/**
+	 * Mark a job cancelled and notify listeners. Caller closes the browser.
+	 */
+	cancel(id: string, message = 'Download cancelled'): Job | undefined {
+		const job = this.jobs.get(id);
+		if (!job) return undefined;
+
+		job.cancelled = true;
+		job.error = null;
+		job.progress = {
+			stage: 'cancelled',
+			message,
+			percent: job.progress.percent,
+		};
+		job.updatedAt = new Date();
+		this.notifyListeners(id, job.progress);
+		return job;
+	}
+
+	/**
+	 * Clear cancelled flag when restarting a job (e.g. after error).
+	 */
+	clearCancelled(id: string): void {
+		const job = this.jobs.get(id);
+		if (job) job.cancelled = false;
 	}
 
 	/**

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
 import { cp, mkdir, rename, rm } from 'node:fs/promises';
-import { basename, join } from 'node:path';
+import { basename, extname, join } from 'node:path';
 import type { SoundcloudTrack } from 'soundcloud.ts';
 import { AudioProcessor } from './audioProcessor';
 import { DownloadgaterDownloader } from './downloadgater';
@@ -53,6 +53,7 @@ const soundcloudClient = new SoundcloudClient();
 const audioProcessor = new AudioProcessor(ffmpegBin, ffprobeBin);
 
 async function renameDownloadFile(
+	jobId: string,
 	currentFilename: string,
 	desiredFilename: string,
 ): Promise<string> {
@@ -61,14 +62,29 @@ async function renameDownloadFile(
 	}
 
 	const fromPath = join('./downloads', currentFilename);
-	const toPath = join('./downloads', desiredFilename);
+	let finalName = desiredFilename;
+	let toPath = join('./downloads', finalName);
 
-	if (await Bun.file(toPath).exists()) {
-		await rm(toPath, { force: true });
+	const destinationBlocked =
+		jobStore.isFilenameOwnedByOtherJob(finalName, jobId) ||
+		((await Bun.file(toPath).exists()) && finalName !== currentFilename);
+
+	if (destinationBlocked) {
+		const ext = extname(desiredFilename);
+		const stem = basename(desiredFilename, ext);
+		const shortId = jobId.slice(0, 8);
+		finalName = `${stem} [${shortId}]${ext}`;
+		toPath = join('./downloads', finalName);
+		let n = 2;
+		while (await Bun.file(toPath).exists()) {
+			finalName = `${stem} [${shortId}] (${n})${ext}`;
+			toPath = join('./downloads', finalName);
+			n += 1;
+		}
 	}
 
 	await rename(fromPath, toPath);
-	return desiredFilename;
+	return finalName;
 }
 
 type AnyDownloader = {
@@ -837,7 +853,7 @@ const server = Bun.serve({
 						return jsonResponse({ error: 'Job not found' }, { status: 404 });
 					}
 
-					if (!job.downloadFilename) {
+					if (!job.downloadFilename && !job.outputFilename) {
 						return jsonResponse(
 							{ error: 'No downloaded file available' },
 							{ status: 400 },
@@ -884,7 +900,16 @@ const server = Bun.serve({
 						nameAsArtistTitle = body.nameAsArtistTitle === true;
 					}
 
-					if (preserveMetadata && !isMp3Format(job.downloadFilename)) {
+					const sourceFilename =
+						job.outputFilename || job.downloadFilename || '';
+					if (!sourceFilename) {
+						return jsonResponse(
+							{ error: 'No downloaded file available' },
+							{ status: 400 },
+						);
+					}
+
+					if (preserveMetadata && !isMp3Format(sourceFilename)) {
 						return jsonResponse(
 							{
 								error: 'Existing metadata can only be preserved for MP3 files',
@@ -894,14 +919,22 @@ const server = Bun.serve({
 					}
 
 					if (job.outputFormat === 'original' || preserveMetadata) {
-						let outputFilename = job.downloadFilename;
+						let outputFilename = sourceFilename;
 						if (nameAsArtistTitle) {
 							outputFilename = await renameDownloadFile(
-								job.downloadFilename,
-								artistTitleFilename(metadata.artist, metadata.title),
+								jobId,
+								sourceFilename,
+								artistTitleFilename(
+									metadata.artist,
+									metadata.title,
+									extname(sourceFilename) || '.mp3',
+								),
 							);
 						}
-						jobStore.update(jobId, { outputFilename });
+						jobStore.update(jobId, {
+							outputFilename,
+							downloadFilename: outputFilename,
+						});
 						jobStore.updateProgress(
 							jobId,
 							'ready',
@@ -940,7 +973,7 @@ const server = Bun.serve({
 					}
 
 					const outputPath = await audioProcessor.processAudio(
-						job.downloadFilename,
+						sourceFilename,
 						metadata,
 						artwork,
 						'always',
@@ -949,11 +982,15 @@ const server = Bun.serve({
 					let outputFilename = basename(outputPath);
 					if (nameAsArtistTitle) {
 						outputFilename = await renameDownloadFile(
+							jobId,
 							outputFilename,
-							artistTitleFilename(metadata.artist, metadata.title),
+							artistTitleFilename(metadata.artist, metadata.title, '.mp3'),
 						);
 					}
-					jobStore.update(jobId, { outputFilename });
+					jobStore.update(jobId, {
+						outputFilename,
+						downloadFilename: outputFilename,
+					});
 
 					jobStore.updateProgress(
 						jobId,

--- a/src/server.ts
+++ b/src/server.ts
@@ -236,6 +236,7 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 				{ browserless: true },
 			);
 			const ytDlpDownloader = new YtDlpDownloader(sourceLabel);
+			activeDownloaders.set(jobId, ytDlpDownloader);
 			ytDlpDownloader.setProgressCallback(emitProgress);
 			downloadFilename = await ytDlpDownloader.downloadAudio(
 				downloadSourceUrl,
@@ -325,6 +326,7 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 				gateConfigBase,
 				emitProgress,
 			);
+			activeDownloaders.set(jobId, httpDownloader);
 			downloadFilename = await httpDownloader.tryDownload(downloadSourceUrl);
 			throwIfCancelled();
 
@@ -823,90 +825,98 @@ const server = Bun.serve({
 
 		'/api/job/:id/events': {
 			GET: (req) => {
-				const jobId = req.params.id;
-				const job = jobStore.get(jobId);
+				try {
+					const jobId = req.params.id;
+					const job = jobStore.get(jobId);
 
-				if (!job) {
-					return jsonResponse({ error: 'Job not found' }, { status: 404 });
-				}
+					if (!job) {
+						return jsonResponse({ error: 'Job not found' }, { status: 404 });
+					}
 
-				const stream = new ReadableStream({
-					start(controller) {
-						const encoder = new TextEncoder();
-						let cleanedUp = false;
-						let unsubscribe: (() => void) | null = null;
-						let heartbeat: ReturnType<typeof setInterval> | null = null;
+					const stream = new ReadableStream({
+						start(controller) {
+							const encoder = new TextEncoder();
+							let cleanedUp = false;
+							let unsubscribe: (() => void) | null = null;
+							let heartbeat: ReturnType<typeof setInterval> | null = null;
 
-						const cleanup = () => {
-							if (cleanedUp) return;
-							cleanedUp = true;
-							if (heartbeat !== null) {
-								clearInterval(heartbeat);
-								heartbeat = null;
-							}
-							unsubscribe?.();
-							unsubscribe = null;
-						};
+							const cleanup = () => {
+								if (cleanedUp) return;
+								cleanedUp = true;
+								if (heartbeat !== null) {
+									clearInterval(heartbeat);
+									heartbeat = null;
+								}
+								unsubscribe?.();
+								unsubscribe = null;
+							};
 
-						const closeStream = () => {
-							cleanup();
-							try {
-								controller.close();
-							} catch {
-								// Already closed
-							}
-						};
-
-						const safeEnqueue = (chunk: string): boolean => {
-							if (cleanedUp) return false;
-							try {
-								controller.enqueue(encoder.encode(chunk));
-								return true;
-							} catch {
+							const closeStream = () => {
 								cleanup();
-								return false;
-							}
-						};
+								try {
+									controller.close();
+								} catch {
+									// Already closed
+								}
+							};
 
-						if (!safeEnqueue(`data: ${JSON.stringify(job.progress)}\n\n`)) {
-							return;
-						}
+							const safeEnqueue = (chunk: string): boolean => {
+								if (cleanedUp) return false;
+								try {
+									controller.enqueue(encoder.encode(chunk));
+									return true;
+								} catch {
+									cleanup();
+									return false;
+								}
+							};
 
-						// Keep the SSE connection alive during long silent stretches
-						// (e.g. yt-dlp downloads up to 10 minutes with no progress events).
-						// Bun closes idle connections after idleTimeout (~255s).
-						heartbeat = setInterval(() => {
-							safeEnqueue(': keepalive\n\n');
-						}, 30_000);
-
-						unsubscribe = jobStore.subscribe(jobId, (progress) => {
-							if (!safeEnqueue(`data: ${JSON.stringify(progress)}\n\n`)) {
+							if (!safeEnqueue(`data: ${JSON.stringify(job.progress)}\n\n`)) {
 								return;
 							}
 
+							// Keep the SSE connection alive during long silent stretches
+							// (e.g. yt-dlp downloads up to 10 minutes with no progress events).
+							// Bun closes idle connections after idleTimeout (~255s).
+							heartbeat = setInterval(() => {
+								safeEnqueue(': keepalive\n\n');
+							}, 30_000);
+
+							unsubscribe = jobStore.subscribe(jobId, (progress) => {
+								if (!safeEnqueue(`data: ${JSON.stringify(progress)}\n\n`)) {
+									return;
+								}
+
+								if (
+									progress.stage === 'ready' ||
+									progress.stage === 'error' ||
+									progress.stage === 'cancelled'
+								) {
+									setTimeout(closeStream, 100);
+								}
+							});
+
+							// subscribe() does not replay — close if the job is already done.
 							if (
-								progress.stage === 'ready' ||
-								progress.stage === 'error' ||
-								progress.stage === 'cancelled'
+								job.progress.stage === 'ready' ||
+								job.progress.stage === 'error' ||
+								job.progress.stage === 'cancelled'
 							) {
 								setTimeout(closeStream, 100);
 							}
-						});
 
-						// subscribe() does not replay — close if the job is already done.
-						if (
-							job.progress.stage === 'ready' ||
-							job.progress.stage === 'error' ||
-							job.progress.stage === 'cancelled'
-						) {
-							setTimeout(closeStream, 100);
-						}
+							req.signal.addEventListener('abort', closeStream);
+						},
+					});
 
-						req.signal.addEventListener('abort', closeStream);
-					},
-				});
-
-				return sseResponse(stream);
+					return sseResponse(stream);
+				} catch (error) {
+					console.error('SSE setup failed:', error);
+					return jsonResponse(
+						{ error: 'Failed to open event stream' },
+						{ status: 500 },
+					);
+				}
 			},
 		},
 
@@ -1160,10 +1170,17 @@ const server = Bun.serve({
 			},
 		},
 	}),
-	error: async (err) => {
+	error: ((err: Error, request?: Request) => {
 		console.error('Server error:', err);
-		return jsonResponse({ error: 'Internal Server Error' }, { status: 500 });
-	},
+		const respond = () =>
+			jsonResponse({ error: 'Internal Server Error' }, { status: 500 });
+		// Bun may pass Request as a second runtime arg (typed API is 1-arg).
+		// Restore ALS so CORS uses the request Origin instead of *.
+		if (request instanceof Request) {
+			return requestAls.run(request, respond);
+		}
+		return respond();
+	}) as (err: Error) => Response | Promise<Response>,
 });
 
 let shuttingDown = false;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,4 @@
-import { cp, mkdir, rm } from 'node:fs/promises';
+import { cp, mkdir, rename, rm } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 import type { SoundcloudTrack } from 'soundcloud.ts';
 import { AudioProcessor } from './audioProcessor';
@@ -11,6 +11,7 @@ import { jobStore } from './jobStore';
 import { SoundcloudClient } from './soundcloud';
 import type { Job, Metadata, OutputFormat } from './types';
 import {
+	artistTitleFilename,
 	extractGateUrl,
 	getDefaultMetadata,
 	getFfmpegBin,
@@ -50,6 +51,25 @@ const HYPEDDIT_EMAIL = getOptionalEnv('HYPEDDIT_EMAIL');
 
 const soundcloudClient = new SoundcloudClient();
 const audioProcessor = new AudioProcessor(ffmpegBin, ffprobeBin);
+
+async function renameDownloadFile(
+	currentFilename: string,
+	desiredFilename: string,
+): Promise<string> {
+	if (currentFilename === desiredFilename) {
+		return currentFilename;
+	}
+
+	const fromPath = join('./downloads', currentFilename);
+	const toPath = join('./downloads', desiredFilename);
+
+	if (await Bun.file(toPath).exists()) {
+		await rm(toPath, { force: true });
+	}
+
+	await rename(fromPath, toPath);
+	return desiredFilename;
+}
 
 type AnyDownloader = {
 	close(): Promise<void>;
@@ -827,6 +847,7 @@ const server = Bun.serve({
 					const contentType = req.headers.get('content-type') || '';
 					let metadata: Metadata;
 					let preserveMetadata = false;
+					let nameAsArtistTitle = false;
 					let customArtwork: { buffer: ArrayBuffer; fileName: string } | null =
 						null;
 
@@ -839,6 +860,7 @@ const server = Bun.serve({
 							genre: formData.get('genre')?.toString() || undefined,
 						};
 						preserveMetadata = formData.get('preserveMetadata') === 'true';
+						nameAsArtistTitle = formData.get('nameAsArtistTitle') === 'true';
 
 						const artworkFile = formData.get('artwork');
 						if (artworkFile instanceof File) {
@@ -850,6 +872,7 @@ const server = Bun.serve({
 					} else {
 						const body = (await req.json()) as Metadata & {
 							preserveMetadata?: boolean;
+							nameAsArtistTitle?: boolean;
 						};
 						metadata = {
 							title: body.title,
@@ -858,6 +881,7 @@ const server = Bun.serve({
 							genre: body.genre,
 						};
 						preserveMetadata = body.preserveMetadata === true;
+						nameAsArtistTitle = body.nameAsArtistTitle === true;
 					}
 
 					if (preserveMetadata && !isMp3Format(job.downloadFilename)) {
@@ -870,9 +894,14 @@ const server = Bun.serve({
 					}
 
 					if (job.outputFormat === 'original' || preserveMetadata) {
-						jobStore.update(jobId, {
-							outputFilename: job.downloadFilename,
-						});
+						let outputFilename = job.downloadFilename;
+						if (nameAsArtistTitle) {
+							outputFilename = await renameDownloadFile(
+								job.downloadFilename,
+								artistTitleFilename(metadata.artist, metadata.title),
+							);
+						}
+						jobStore.update(jobId, { outputFilename });
 						jobStore.updateProgress(
 							jobId,
 							'ready',
@@ -883,7 +912,7 @@ const server = Bun.serve({
 						);
 						return jsonResponse({
 							success: true,
-							outputFilename: job.downloadFilename,
+							outputFilename,
 						});
 					}
 
@@ -917,7 +946,13 @@ const server = Bun.serve({
 						'always',
 					);
 
-					const outputFilename = outputPath.split('/').pop() || outputPath;
+					let outputFilename = basename(outputPath);
+					if (nameAsArtistTitle) {
+						outputFilename = await renameDownloadFile(
+							outputFilename,
+							artistTitleFilename(metadata.artist, metadata.title),
+						);
+					}
 					jobStore.update(jobId, { outputFilename });
 
 					jobStore.updateProgress(

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,8 +1,9 @@
-import { cp, mkdir, rename, rm } from 'node:fs/promises';
+import { cp, mkdir, rm } from 'node:fs/promises';
 import { basename, extname, join } from 'node:path';
 import type { SoundcloudTrack } from 'soundcloud.ts';
 import { AudioProcessor } from './audioProcessor';
 import { DownloadgaterDownloader } from './downloadgater';
+import { renameDownloadFileExclusive } from './downloadRename';
 import { DroploudDownloader } from './droploud';
 import { GaterushDownloader } from './gaterush';
 import { HypedditDownloader } from './hypeddit';
@@ -57,34 +58,20 @@ async function renameDownloadFile(
 	currentFilename: string,
 	desiredFilename: string,
 ): Promise<string> {
-	if (currentFilename === desiredFilename) {
-		return currentFilename;
-	}
-
-	const fromPath = join('./downloads', currentFilename);
-	let finalName = desiredFilename;
-	let toPath = join('./downloads', finalName);
-
-	const destinationBlocked =
-		jobStore.isFilenameOwnedByOtherJob(finalName, jobId) ||
-		((await Bun.file(toPath).exists()) && finalName !== currentFilename);
-
-	if (destinationBlocked) {
-		const ext = extname(desiredFilename);
-		const stem = basename(desiredFilename, ext);
-		const shortId = jobId.slice(0, 8);
-		finalName = `${stem} [${shortId}]${ext}`;
-		toPath = join('./downloads', finalName);
-		let n = 2;
-		while (await Bun.file(toPath).exists()) {
-			finalName = `${stem} [${shortId}] (${n})${ext}`;
-			toPath = join('./downloads', finalName);
-			n += 1;
-		}
-	}
-
-	await rename(fromPath, toPath);
-	return finalName;
+	return renameDownloadFileExclusive({
+		downloadsDir: './downloads',
+		jobId,
+		currentFilename,
+		desiredFilename,
+		isOwnedByOtherJob: (filename, excludeJobId) =>
+			jobStore.isFilenameOwnedByOtherJob(filename, excludeJobId),
+		claimFilenames: (id, filename) => {
+			jobStore.update(id, {
+				outputFilename: filename,
+				downloadFilename: filename,
+			});
+		},
+	});
 }
 
 type AnyDownloader = {

--- a/src/server.ts
+++ b/src/server.ts
@@ -187,13 +187,22 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 	}
 	const { url: downloadSourceUrl, provider } = resolved;
 
+	const throwIfCancelled = () => {
+		if (jobStore.isCancelled(jobId)) {
+			throw new Error('Download cancelled');
+		}
+	};
+
 	try {
 		const emitProgress = (
 			stage: Job['progress']['stage'],
 			message: string,
 			percent: number,
 			extra?: Partial<Job['progress']>,
-		) => jobStore.updateProgress(jobId, stage, message, percent, extra);
+		) => {
+			if (jobStore.isCancelled(jobId)) return;
+			jobStore.updateProgress(jobId, stage, message, percent, extra);
+		};
 
 		const gateConfigBase = {
 			name: HYPEDDIT_NAME,
@@ -203,6 +212,7 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 		};
 
 		const prepareBrowserConfig = async () => {
+			throwIfCancelled();
 			const userDataDir = await prepareJobUserDataDir(jobId);
 			jobProfileDirs.set(jobId, userDataDir);
 			return { ...gateConfigBase, userDataDir };
@@ -227,6 +237,7 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 					matchTitle: job.track?.title,
 				},
 			);
+			throwIfCancelled();
 		} else if (provider === 'droploud') {
 			jobStore.updateProgress(
 				jobId,
@@ -240,6 +251,7 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 			activeDownloaders.set(jobId, droploudDownloader);
 			droploudDownloader.setProgressCallback(emitProgress);
 			await droploudDownloader.initialize();
+			throwIfCancelled();
 			jobStore.updateProgress(
 				jobId,
 				'handling_gates',
@@ -248,7 +260,7 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 			);
 			downloadFilename =
 				await droploudDownloader.downloadAudio(downloadSourceUrl);
-			await closeJobDownloader(jobId);
+			throwIfCancelled();
 		} else if (provider === 'gaterush') {
 			jobStore.updateProgress(
 				jobId,
@@ -262,6 +274,7 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 			activeDownloaders.set(jobId, gaterushDownloader);
 			gaterushDownloader.setProgressCallback(emitProgress);
 			await gaterushDownloader.initialize();
+			throwIfCancelled();
 			jobStore.updateProgress(
 				jobId,
 				'handling_gates',
@@ -270,7 +283,7 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 			);
 			downloadFilename =
 				await gaterushDownloader.downloadAudio(downloadSourceUrl);
-			await closeJobDownloader(jobId);
+			throwIfCancelled();
 		} else if (provider === 'downloadgater') {
 			jobStore.updateProgress(
 				jobId,
@@ -284,6 +297,7 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 			activeDownloaders.set(jobId, downloadgaterDownloader);
 			downloadgaterDownloader.setProgressCallback(emitProgress);
 			await downloadgaterDownloader.initialize();
+			throwIfCancelled();
 			jobStore.updateProgress(
 				jobId,
 				'handling_gates',
@@ -292,7 +306,7 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 			);
 			downloadFilename =
 				await downloadgaterDownloader.downloadAudio(downloadSourceUrl);
-			await closeJobDownloader(jobId);
+			throwIfCancelled();
 		} else {
 			// Hypeddit: always try plain HTTP first (email + social skip gates).
 			jobStore.updateProgress(
@@ -306,6 +320,7 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 				emitProgress,
 			);
 			downloadFilename = await httpDownloader.tryDownload(downloadSourceUrl);
+			throwIfCancelled();
 
 			// Always try HTTP first. Fall back to the browser (headless or
 			// headful per job setting) when the gate needs real verification
@@ -324,6 +339,7 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 				activeDownloaders.set(jobId, hypedditDownloader);
 				hypedditDownloader.setProgressCallback(emitProgress);
 				await hypedditDownloader.initialize();
+				throwIfCancelled();
 
 				jobStore.updateProgress(
 					jobId,
@@ -334,8 +350,12 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 
 				downloadFilename =
 					await hypedditDownloader.downloadAudio(downloadSourceUrl);
-				await closeJobDownloader(jobId);
+				throwIfCancelled();
 			}
+		}
+
+		if (jobStore.isCancelled(jobId)) {
+			return;
 		}
 
 		if (!downloadFilename) {
@@ -357,6 +377,8 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 			);
 			jobStore.update(jobId, { existingMetadata: existingMetadata ?? {} });
 		}
+
+		throwIfCancelled();
 
 		jobStore.updateProgress(
 			jobId,
@@ -380,19 +402,38 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 			}
 		}
 
+		if (jobStore.isCancelled(jobId)) {
+			return;
+		}
+
 		jobStore.updateProgress(jobId, 'ready', 'Ready for metadata editing', 100);
 	} catch (error) {
-		await closeJobDownloader(jobId);
+		if (jobStore.isCancelled(jobId)) {
+			// Progress already set to cancelled by the cancel endpoint (or below).
+			if (jobStore.get(jobId)?.progress.stage !== 'cancelled') {
+				jobStore.cancel(jobId);
+			}
+			return;
+		}
 		const message =
 			error instanceof Error ? error.message : 'Unknown error occurred';
+		if (/cancel|target closed|session closed|browser.*closed/i.test(message)) {
+			jobStore.cancel(jobId, 'Download cancelled');
+			return;
+		}
 		jobStore.setError(jobId, message);
+	} finally {
+		await closeJobDownloader(jobId);
 	}
 }
 
 const corsHeaders: Record<string, string> = {
 	'Access-Control-Allow-Origin': '*',
 	'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
-	'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+	'Access-Control-Allow-Headers':
+		'Content-Type, Authorization, Access-Control-Request-Private-Network',
+	// Chrome Private Network Access: allow soundcloud.com → localhost:3000 (userscript)
+	'Access-Control-Allow-Private-Network': 'true',
 };
 
 function jsonResponse(data: unknown, options?: { status?: number }): Response {
@@ -663,13 +704,16 @@ const server = Bun.serve({
 					if (
 						job.progress.stage !== 'pending' &&
 						job.progress.stage !== 'waiting_hypeddit' &&
-						job.progress.stage !== 'error'
+						job.progress.stage !== 'error' &&
+						job.progress.stage !== 'cancelled'
 					) {
 						return jsonResponse(
 							{ error: 'Job is already in progress or completed' },
 							{ status: 400 },
 						);
 					}
+
+					jobStore.clearCancelled(jobId);
 
 					try {
 						const body = (await req.json()) as { headless?: boolean };
@@ -683,6 +727,40 @@ const server = Bun.serve({
 					runDownloadProcess(jobId);
 
 					return jsonResponse({ success: true, message: 'Download started' });
+				} catch (error) {
+					return jsonResponse(
+						{
+							error: error instanceof Error ? error.message : 'Unknown error',
+						},
+						{ status: 500 },
+					);
+				}
+			},
+		},
+
+		'/api/job/:id/cancel': {
+			POST: async (req) => {
+				try {
+					const jobId = req.params.id;
+					const job = jobStore.get(jobId);
+
+					if (!job) {
+						return jsonResponse({ error: 'Job not found' }, { status: 404 });
+					}
+
+					const stage = job.progress.stage;
+					if (stage === 'ready' || stage === 'cancelled') {
+						jobStore.cancel(jobId);
+						await closeJobDownloader(jobId);
+						return jsonResponse({ success: true, message: 'Cancelled' });
+					}
+
+					jobStore.cancel(jobId, 'Cancelling download…');
+					// Close CloakBrowser / job profile so Chromium exits cleanly
+					await closeJobDownloader(jobId);
+					jobStore.cancel(jobId, 'Download cancelled');
+
+					return jsonResponse({ success: true, message: 'Download cancelled' });
 				} catch (error) {
 					return jsonResponse(
 						{
@@ -757,7 +835,11 @@ const server = Bun.serve({
 								return;
 							}
 
-							if (progress.stage === 'ready' || progress.stage === 'error') {
+							if (
+								progress.stage === 'ready' ||
+								progress.stage === 'error' ||
+								progress.stage === 'cancelled'
+							) {
 								setTimeout(closeStream, 100);
 							}
 						});
@@ -765,7 +847,8 @@ const server = Bun.serve({
 						// subscribe() does not replay — close if the job is already done.
 						if (
 							job.progress.stage === 'ready' ||
-							job.progress.stage === 'error'
+							job.progress.stage === 'error' ||
+							job.progress.stage === 'cancelled'
 						) {
 							setTimeout(closeStream, 100);
 						}

--- a/src/server.ts
+++ b/src/server.ts
@@ -284,10 +284,10 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 			);
 			downloadFilename = await httpDownloader.tryDownload(downloadSourceUrl);
 
-			// Always try HTTP first. Open a browser only when the user checked
-			// “Show browser window” (headful) and the gate needs real verification
-			// (e.g. Spotify). Headless stays fully browserless for Hypeddit.
-			if (!downloadFilename && !job.headless) {
+			// Always try HTTP first. Fall back to the browser (headless or
+			// headful per job setting) when the gate needs real verification
+			// (e.g. Spotify).
+			if (!downloadFilename) {
 				jobStore.updateProgress(
 					jobId,
 					'initializing_browser',
@@ -312,12 +312,6 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 				downloadFilename =
 					await hypedditDownloader.downloadAudio(downloadSourceUrl);
 				await closeJobDownloader(jobId);
-			} else if (!downloadFilename && job.headless) {
-				jobStore.setError(
-					jobId,
-					'This Hypeddit gate needs a browser (e.g. Spotify). Enable “Show browser window (headful)” and retry.',
-				);
-				return;
 			}
 		}
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { cp, mkdir, rm } from 'node:fs/promises';
 import { basename, extname, join } from 'node:path';
 import type { SoundcloudTrack } from 'soundcloud.ts';
@@ -215,6 +216,11 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 			throwIfCancelled();
 			const userDataDir = await prepareJobUserDataDir(jobId);
 			jobProfileDirs.set(jobId, userDataDir);
+			if (jobStore.isCancelled(jobId)) {
+				jobProfileDirs.delete(jobId);
+				await rm(userDataDir, { recursive: true, force: true });
+				throw new Error('Download cancelled');
+			}
 			return { ...gateConfigBase, userDataDir };
 		};
 
@@ -417,29 +423,45 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 		}
 		const message =
 			error instanceof Error ? error.message : 'Unknown error occurred';
-		if (/cancel|target closed|session closed|browser.*closed/i.test(message)) {
-			jobStore.cancel(jobId, 'Download cancelled');
-			return;
-		}
 		jobStore.setError(jobId, message);
 	} finally {
 		await closeJobDownloader(jobId);
 	}
 }
 
-const corsHeaders: Record<string, string> = {
-	'Access-Control-Allow-Origin': '*',
-	'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
-	'Access-Control-Allow-Headers':
-		'Content-Type, Authorization, Access-Control-Request-Private-Network',
-	// Chrome Private Network Access: allow soundcloud.com → localhost:3000 (userscript)
-	'Access-Control-Allow-Private-Network': 'true',
-};
+const ALLOWED_ORIGINS = new Set([
+	'https://soundcloud.com',
+	'https://www.soundcloud.com',
+	'https://m.soundcloud.com',
+	'http://localhost:4321',
+	'http://127.0.0.1:4321',
+	'http://localhost:3000',
+	'http://127.0.0.1:3000',
+]);
+
+const requestAls = new AsyncLocalStorage<Request>();
+
+function corsHeaders(): Record<string, string> {
+	const req = requestAls.getStore();
+	const origin = req?.headers.get('Origin');
+	const headers: Record<string, string> = {
+		'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+		'Access-Control-Allow-Headers':
+			'Content-Type, Authorization, Access-Control-Request-Private-Network',
+		// Chrome Private Network Access: allow soundcloud.com → localhost:3000 (userscript)
+		'Access-Control-Allow-Private-Network': 'true',
+		Vary: 'Origin',
+	};
+	if (origin && ALLOWED_ORIGINS.has(origin)) {
+		headers['Access-Control-Allow-Origin'] = origin;
+	}
+	return headers;
+}
 
 function jsonResponse(data: unknown, options?: { status?: number }): Response {
 	return Response.json(data, {
 		status: options?.status || 200,
-		headers: corsHeaders,
+		headers: corsHeaders(),
 	});
 }
 
@@ -448,14 +470,14 @@ function fileResponse(
 	headers: Record<string, string>,
 ): Response {
 	return new Response(body, {
-		headers: { ...corsHeaders, ...headers },
+		headers: { ...corsHeaders(), ...headers },
 	});
 }
 
 function sseResponse(stream: ReadableStream): Response {
 	return new Response(stream, {
 		headers: {
-			...corsHeaders,
+			...corsHeaders(),
 			'Content-Type': 'text/event-stream',
 			'Cache-Control': 'no-cache',
 			Connection: 'keep-alive',
@@ -463,22 +485,49 @@ function sseResponse(stream: ReadableStream): Response {
 	});
 }
 
+type RouteHandler = (req: Request) => Response | Promise<Response>;
+
+function wrapRouteHandler(handler: RouteHandler): RouteHandler {
+	return (req) => requestAls.run(req, () => handler(req));
+}
+
+function wrapRoutes<T extends Record<string, unknown>>(routes: T): T {
+	const wrapped: Record<string, unknown> = {};
+	for (const [path, handler] of Object.entries(routes)) {
+		if (typeof handler === 'function') {
+			wrapped[path] = wrapRouteHandler(handler as RouteHandler);
+		} else if (handler && typeof handler === 'object') {
+			const methodHandlers: Record<string, unknown> = {};
+			for (const [method, fn] of Object.entries(
+				handler as Record<string, unknown>,
+			)) {
+				methodHandlers[method] =
+					typeof fn === 'function' ? wrapRouteHandler(fn as RouteHandler) : fn;
+			}
+			wrapped[path] = methodHandlers;
+		} else {
+			wrapped[path] = handler;
+		}
+	}
+	return wrapped as T;
+}
+
 const server = Bun.serve({
 	port: 3000,
 	// Increase idle timeout for long-running operations (browser automation, downloads)
 	idleTimeout: 255, // ~4 minutes (max allowed)
-	routes: {
+	routes: wrapRoutes({
 		// CORS preflight handler for all routes
 		'/*': {
 			OPTIONS: () =>
 				new Response(null, {
 					status: 204,
-					headers: corsHeaders,
+					headers: corsHeaders(),
 				}),
 		},
 		'/': () =>
 			new Response('sc-gate-dl API is running!', {
-				headers: corsHeaders,
+				headers: corsHeaders(),
 			}),
 
 		'/api/soundcloud/cleanup': {
@@ -1103,14 +1152,14 @@ const server = Bun.serve({
 
 				return new Response(file, {
 					headers: {
-						...corsHeaders,
+						...corsHeaders(),
 						'Content-Type': file.type || 'application/octet-stream',
 						'Content-Disposition': `attachment; filename="${filename}"`,
 					},
 				});
 			},
 		},
-	},
+	}),
 	error: async (err) => {
 		console.error('Server error:', err);
 		return jsonResponse({ error: 'Internal Server Error' }, { status: 500 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,7 +40,8 @@ export type JobStage =
 	| 'downloading'
 	| 'processing_audio'
 	| 'ready'
-	| 'error';
+	| 'error'
+	| 'cancelled';
 
 export interface JobProgress {
 	stage: JobStage;
@@ -61,6 +62,8 @@ export interface Job {
 	/** Whether browser automation runs headless. Defaults to true. */
 	headless: boolean;
 	outputFormat: OutputFormat;
+	/** Set when the user cancels; download loop should stop and close the browser. */
+	cancelled: boolean;
 	track: {
 		title: string;
 		artworkUrl: string | null;

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import {
 	artistTitleFilename,
+	cookiesToNetscape,
 	previewProcessedFilename,
 	resolveGateProviderUrl,
 	sanitizeFilenamePart,
@@ -45,6 +46,33 @@ describe('resolveGateProviderUrl', () => {
 			url: 'https://hypeddit.com/foo',
 			provider: 'hypeddit',
 		});
+	});
+});
+
+describe('cookiesToNetscape', () => {
+	test('emits Netscape rows with subdomain flag from leading dot', () => {
+		const text = cookiesToNetscape([
+			{
+				name: 'oauth_token',
+				value: 'tok',
+				domain: 'soundcloud.com',
+				path: '/',
+				secure: true,
+				expirationDate: 1700000000.5,
+			},
+			{
+				name: 'datadome',
+				value: 'dd',
+				domain: '.soundcloud.com',
+				path: '/',
+				secure: false,
+			},
+		]);
+		expect(text.startsWith('# Netscape HTTP Cookie File\n')).toBe(true);
+		expect(text).toContain(
+			'soundcloud.com\tFALSE\t/\tTRUE\t1700000000\toauth_token\ttok',
+		);
+		expect(text).toContain('.soundcloud.com\tTRUE\t/\tFALSE\t0\tdatadome\tdd');
 	});
 });
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -64,6 +64,21 @@ describe('writeSoundcloudNetscapeCookies', () => {
 			await rm(dir, { recursive: true, force: true });
 		}
 	});
+
+	test('returns null when every cookie record is malformed', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'sc-gate-dl-test-'));
+		const jsonPath = join(dir, 'cookies.json');
+		try {
+			await writeFile(
+				jsonPath,
+				JSON.stringify([null, {}, { name: 'x' }]),
+				'utf8',
+			);
+			expect(await writeSoundcloudNetscapeCookies(jsonPath)).toBeNull();
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
 });
 
 describe('cookiesToNetscape', () => {
@@ -85,11 +100,23 @@ describe('cookiesToNetscape', () => {
 				secure: false,
 			},
 		]);
-		expect(text.startsWith('# Netscape HTTP Cookie File\n')).toBe(true);
+		expect(text).not.toBeNull();
+		expect(text?.startsWith('# Netscape HTTP Cookie File\n')).toBe(true);
 		expect(text).toContain(
 			'soundcloud.com\tFALSE\t/\tTRUE\t1700000000\toauth_token\ttok',
 		);
 		expect(text).toContain('.soundcloud.com\tTRUE\t/\tFALSE\t0\tdatadome\tdd');
+	});
+
+	test('returns null for null entries and empty objects', () => {
+		expect(cookiesToNetscape([null, {}])).toBeNull();
+		expect(
+			cookiesToNetscape([
+				null,
+				{},
+				{ name: 'oauth_token', value: 'tok', domain: 'soundcloud.com' },
+			]),
+		).toContain('oauth_token\ttok');
 	});
 });
 
@@ -112,6 +139,12 @@ describe('artistTitleFilename', () => {
 			'Unknown Artist - Unknown Title.wav',
 		);
 		expect(artistTitleFilename('A', 'B', 'flac')).toBe('A - B.flac');
+	});
+
+	test('falls back when artist/title are only invalid filename characters', () => {
+		expect(artistTitleFilename('<>:"/\\|?*', '<>:"/\\|?*')).toBe(
+			'Unknown Artist - Unknown Title.mp3',
+		);
 	});
 });
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, test } from 'bun:test';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
 	artistTitleFilename,
 	cookiesToNetscape,
 	previewProcessedFilename,
 	resolveGateProviderUrl,
 	sanitizeFilenamePart,
+	writeSoundcloudNetscapeCookies,
 } from './utils';
 
 describe('resolveGateProviderUrl', () => {
@@ -46,6 +50,19 @@ describe('resolveGateProviderUrl', () => {
 			url: 'https://hypeddit.com/foo',
 			provider: 'hypeddit',
 		});
+	});
+});
+
+describe('writeSoundcloudNetscapeCookies', () => {
+	test('returns null for malformed JSON', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'sc-gate-dl-test-'));
+		const jsonPath = join(dir, 'cookies.json');
+		try {
+			await writeFile(jsonPath, 'not valid json{{{', 'utf8');
+			expect(await writeSoundcloudNetscapeCookies(jsonPath)).toBeNull();
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -126,16 +126,19 @@ describe('previewProcessedFilename', () => {
 		).toBe('Artist - Title.mp3');
 	});
 
-	test('converts lossless extensions to mp3 when not renaming', () => {
+	test('converts lossless and lossy containers to mp3 when not renaming', () => {
 		expect(
 			previewProcessedFilename('song.flac', { nameAsArtistTitle: false }),
 		).toBe('song.mp3');
 		expect(
 			previewProcessedFilename('song.aiff', { nameAsArtistTitle: false }),
 		).toBe('song.mp3');
+		expect(
+			previewProcessedFilename('song.m4a', { nameAsArtistTitle: false }),
+		).toBe('song.mp3');
 	});
 
-	test('keeps non-lossless filenames unchanged when not renaming', () => {
+	test('keeps mp3 filenames unchanged when not renaming', () => {
 		expect(
 			previewProcessedFilename('song.mp3', { nameAsArtistTitle: false }),
 		).toBe('song.mp3');

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'bun:test';
-import { resolveGateProviderUrl } from './utils';
+import {
+	artistTitleFilename,
+	previewProcessedFilename,
+	resolveGateProviderUrl,
+	sanitizeFilenamePart,
+} from './utils';
 
 describe('resolveGateProviderUrl', () => {
 	test('extracts Bandcamp track URLs from surrounding prose', () => {
@@ -40,5 +45,54 @@ describe('resolveGateProviderUrl', () => {
 			url: 'https://hypeddit.com/foo',
 			provider: 'hypeddit',
 		});
+	});
+});
+
+describe('sanitizeFilenamePart', () => {
+	test('strips unsafe filename characters and collapses whitespace', () => {
+		expect(sanitizeFilenamePart('  a/b:c*d?e  ')).toBe('abcde');
+		expect(sanitizeFilenamePart('foo   bar')).toBe('foo bar');
+	});
+});
+
+describe('artistTitleFilename', () => {
+	test('builds Artist - Title with default mp3 extension', () => {
+		expect(artistTitleFilename('Wax Thief', 'When I grow up')).toBe(
+			'Wax Thief - When I grow up.mp3',
+		);
+	});
+
+	test('falls back for empty artist/title and preserves custom extension', () => {
+		expect(artistTitleFilename('  ', '', '.wav')).toBe(
+			'Unknown Artist - Unknown Title.wav',
+		);
+		expect(artistTitleFilename('A', 'B', 'flac')).toBe('A - B.flac');
+	});
+});
+
+describe('previewProcessedFilename', () => {
+	test('prefers artist-title naming when requested', () => {
+		expect(
+			previewProcessedFilename('track.wav', {
+				nameAsArtistTitle: true,
+				artist: 'Artist',
+				title: 'Title',
+			}),
+		).toBe('Artist - Title.mp3');
+	});
+
+	test('converts lossless extensions to mp3 when not renaming', () => {
+		expect(
+			previewProcessedFilename('song.flac', { nameAsArtistTitle: false }),
+		).toBe('song.mp3');
+		expect(
+			previewProcessedFilename('song.aiff', { nameAsArtistTitle: false }),
+		).toBe('song.mp3');
+	});
+
+	test('keeps non-lossless filenames unchanged when not renaming', () => {
+		expect(
+			previewProcessedFilename('song.mp3', { nameAsArtistTitle: false }),
+		).toBe('song.mp3');
 	});
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -123,15 +123,23 @@ export async function loadCookies(filename: string): Promise<CookieData[]> {
 /**
  * Convert EditThisCookie-style JSON cookies to Netscape/Mozilla cookie file
  * text (required by yt-dlp `--cookies`).
+ * Returns null when no usable cookie records remain.
  */
-export function cookiesToNetscape(cookies: LocalCookieData[]): string {
+export function cookiesToNetscape(cookies: unknown): string | null {
+	if (!Array.isArray(cookies) || cookies.length === 0) {
+		return null;
+	}
+
 	const lines = ['# Netscape HTTP Cookie File'];
-	for (const cookie of cookies) {
-		const domain = cookie.domain || '';
+	for (const entry of cookies) {
+		if (!isValidLocalCookie(entry)) {
+			continue;
+		}
+		const domain = entry.domain;
 		const includeSubdomains = domain.startsWith('.') ? 'TRUE' : 'FALSE';
-		const path = cookie.path || '/';
-		const secure = cookie.secure ? 'TRUE' : 'FALSE';
-		const expires = Math.floor(cookie.expirationDate ?? 0);
+		const path = entry.path || '/';
+		const secure = entry.secure ? 'TRUE' : 'FALSE';
+		const expires = Math.floor(entry.expirationDate ?? 0);
 		lines.push(
 			[
 				domain,
@@ -139,12 +147,31 @@ export function cookiesToNetscape(cookies: LocalCookieData[]): string {
 				path,
 				secure,
 				String(expires),
-				cookie.name,
-				cookie.value,
+				entry.name,
+				entry.value,
 			].join('\t'),
 		);
 	}
+
+	// Header only — nothing valid to serialize.
+	if (lines.length === 1) {
+		return null;
+	}
 	return `${lines.join('\n')}\n`;
+}
+
+function isValidLocalCookie(entry: unknown): entry is LocalCookieData {
+	if (entry === null || typeof entry !== 'object') {
+		return false;
+	}
+	const cookie = entry as Record<string, unknown>;
+	return (
+		typeof cookie.domain === 'string' &&
+		cookie.domain.length > 0 &&
+		typeof cookie.name === 'string' &&
+		cookie.name.length > 0 &&
+		typeof cookie.value === 'string'
+	);
 }
 
 /** Write `soundcloud-cookies.json` as a Netscape cookie file for yt-dlp. */
@@ -156,14 +183,14 @@ export async function writeSoundcloudNetscapeCookies(
 	if (!(await file.exists())) {
 		return null;
 	}
-	let cookies: LocalCookieData[];
+	let parsed: unknown;
 	try {
-		const parsed: unknown = JSON.parse(await file.text());
-		if (!Array.isArray(parsed) || parsed.length === 0) {
-			return null;
-		}
-		cookies = parsed as LocalCookieData[];
+		parsed = JSON.parse(await file.text());
 	} catch {
+		return null;
+	}
+	const netscape = cookiesToNetscape(parsed);
+	if (!netscape) {
 		return null;
 	}
 	const dest =
@@ -172,7 +199,7 @@ export async function writeSoundcloudNetscapeCookies(
 			tmpdir(),
 			`sc-gate-dl-cookies-${process.pid}-${crypto.randomUUID()}.txt`,
 		);
-	await Bun.write(dest, cookiesToNetscape(cookies), { mode: 0o600 });
+	await Bun.write(dest, netscape, { mode: 0o600 });
 	return dest;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { lookpath } from 'find-bin';
 import type { CookieData } from 'puppeteer';
 import type { SoundcloudTrack } from 'soundcloud.ts';
@@ -115,6 +117,52 @@ export async function loadCookies(filename: string): Promise<CookieData[]> {
 
 		return puppeteerCookie;
 	});
+}
+
+/**
+ * Convert EditThisCookie-style JSON cookies to Netscape/Mozilla cookie file
+ * text (required by yt-dlp `--cookies`).
+ */
+export function cookiesToNetscape(cookies: LocalCookieData[]): string {
+	const lines = ['# Netscape HTTP Cookie File'];
+	for (const cookie of cookies) {
+		const domain = cookie.domain || '';
+		const includeSubdomains = domain.startsWith('.') ? 'TRUE' : 'FALSE';
+		const path = cookie.path || '/';
+		const secure = cookie.secure ? 'TRUE' : 'FALSE';
+		const expires = Math.floor(cookie.expirationDate ?? 0);
+		lines.push(
+			[
+				domain,
+				includeSubdomains,
+				path,
+				secure,
+				String(expires),
+				cookie.name,
+				cookie.value,
+			].join('\t'),
+		);
+	}
+	return `${lines.join('\n')}\n`;
+}
+
+/** Write `soundcloud-cookies.json` as a Netscape cookie file for yt-dlp. */
+export async function writeSoundcloudNetscapeCookies(
+	jsonPath = 'soundcloud-cookies.json',
+	outPath?: string,
+): Promise<string | null> {
+	const file = Bun.file(jsonPath);
+	if (!(await file.exists())) {
+		return null;
+	}
+	const cookies: LocalCookieData[] = JSON.parse(await file.text());
+	if (!Array.isArray(cookies) || cookies.length === 0) {
+		return null;
+	}
+	const dest =
+		outPath ?? join(tmpdir(), `sc-gate-dl-cookies-${process.pid}.txt`);
+	await Bun.write(dest, cookiesToNetscape(cookies));
+	return dest;
 }
 
 export function isSoundcloudUrl(value: string): boolean {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -360,3 +360,36 @@ export function losslessToMp3Filename(filename: string): string {
 		.replace(/\.aif$/i, '.mp3')
 		.replace(/\.flac$/i, '.mp3');
 }
+
+/** Strip characters that are unsafe or awkward in filenames. */
+export function sanitizeFilenamePart(value: string): string {
+	return value
+		.replace(/[<>:"/\\|?*]/g, '')
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+/** `Artist - Title.mp3` from metadata fields. */
+export function artistTitleFilename(artist?: string, title?: string): string {
+	const safeArtist = sanitizeFilenamePart(artist || '') || 'Unknown Artist';
+	const safeTitle = sanitizeFilenamePart(title || '') || 'Unknown Title';
+	return `${safeArtist} - ${safeTitle}.mp3`;
+}
+
+/** Predicted output name for the metadata step (always ends as MP3). */
+export function previewProcessedFilename(
+	downloadFilename: string,
+	options: {
+		nameAsArtistTitle: boolean;
+		artist?: string;
+		title?: string;
+	},
+): string {
+	if (options.nameAsArtistTitle) {
+		return artistTitleFilename(options.artist, options.title);
+	}
+	if (isLosslessFormat(downloadFilename)) {
+		return losslessToMp3Filename(downloadFilename);
+	}
+	return downloadFilename;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -398,26 +398,50 @@ export function getDefaultMetadata(track: SoundcloudTrack): Metadata {
 	};
 }
 
-export function isLosslessFormat(filename: string): boolean {
+const LOSSLESS_EXTENSIONS = ['.wav', '.aiff', '.aif', '.flac'] as const;
+/** Lossy containers we still re-encode to MP3 when output is mp3-320. */
+const LOSSY_TO_MP3_EXTENSIONS = [
+	'.m4a',
+	'.aac',
+	'.ogg',
+	'.opus',
+	'.webm',
+] as const;
+
+function hasExtension(
+	filename: string,
+	extensions: readonly string[],
+): boolean {
 	const lower = filename.toLowerCase();
-	return (
-		lower.endsWith('.wav') ||
-		lower.endsWith('.aiff') ||
-		lower.endsWith('.aif') ||
-		lower.endsWith('.flac')
-	);
+	return extensions.some((ext) => lower.endsWith(ext));
+}
+
+export function isLosslessFormat(filename: string): boolean {
+	return hasExtension(filename, LOSSLESS_EXTENSIONS);
 }
 
 export function isMp3Format(filename: string): boolean {
 	return filename.toLowerCase().endsWith('.mp3');
 }
 
+/** True when the file must be re-encoded to MP3 for the mp3-320 output path. */
+export function needsMp3Conversion(filename: string): boolean {
+	return (
+		isLosslessFormat(filename) ||
+		hasExtension(filename, LOSSY_TO_MP3_EXTENSIONS)
+	);
+}
+
+export function toMp3Filename(filename: string): string {
+	return filename.replace(
+		/\.(wav|aiff|aif|flac|m4a|aac|ogg|opus|webm)$/i,
+		'.mp3',
+	);
+}
+
+/** @deprecated Prefer toMp3Filename */
 export function losslessToMp3Filename(filename: string): string {
-	return filename
-		.replace(/\.wav$/i, '.mp3')
-		.replace(/\.aiff$/i, '.mp3')
-		.replace(/\.aif$/i, '.mp3')
-		.replace(/\.flac$/i, '.mp3');
+	return toMp3Filename(filename);
 }
 
 /** Strip characters that are unsafe or awkward in filenames. */
@@ -452,8 +476,8 @@ export function previewProcessedFilename(
 	if (options.nameAsArtistTitle) {
 		return artistTitleFilename(options.artist, options.title, '.mp3');
 	}
-	if (isLosslessFormat(downloadFilename)) {
-		return losslessToMp3Filename(downloadFilename);
+	if (needsMp3Conversion(downloadFilename)) {
+		return toMp3Filename(downloadFilename);
 	}
 	return downloadFilename;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { lookpath } from 'find-bin';
@@ -155,13 +156,23 @@ export async function writeSoundcloudNetscapeCookies(
 	if (!(await file.exists())) {
 		return null;
 	}
-	const cookies: LocalCookieData[] = JSON.parse(await file.text());
-	if (!Array.isArray(cookies) || cookies.length === 0) {
+	let cookies: LocalCookieData[];
+	try {
+		const parsed: unknown = JSON.parse(await file.text());
+		if (!Array.isArray(parsed) || parsed.length === 0) {
+			return null;
+		}
+		cookies = parsed as LocalCookieData[];
+	} catch {
 		return null;
 	}
 	const dest =
-		outPath ?? join(tmpdir(), `sc-gate-dl-cookies-${process.pid}.txt`);
-	await Bun.write(dest, cookiesToNetscape(cookies));
+		outPath ??
+		join(
+			tmpdir(),
+			`sc-gate-dl-cookies-${process.pid}-${crypto.randomUUID()}.txt`,
+		);
+	await Bun.write(dest, cookiesToNetscape(cookies), { mode: 0o600 });
 	return dest;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -369,11 +369,16 @@ export function sanitizeFilenamePart(value: string): string {
 		.trim();
 }
 
-/** `Artist - Title.mp3` from metadata fields. */
-export function artistTitleFilename(artist?: string, title?: string): string {
+/** `Artist - Title` (+ extension) from metadata fields. */
+export function artistTitleFilename(
+	artist?: string,
+	title?: string,
+	extension = '.mp3',
+): string {
 	const safeArtist = sanitizeFilenamePart(artist || '') || 'Unknown Artist';
 	const safeTitle = sanitizeFilenamePart(title || '') || 'Unknown Title';
-	return `${safeArtist} - ${safeTitle}.mp3`;
+	const ext = extension.startsWith('.') ? extension : `.${extension}`;
+	return `${safeArtist} - ${safeTitle}${ext}`;
 }
 
 /** Predicted output name for the metadata step (always ends as MP3). */
@@ -386,7 +391,7 @@ export function previewProcessedFilename(
 	},
 ): string {
 	if (options.nameAsArtistTitle) {
-		return artistTitleFilename(options.artist, options.title);
+		return artistTitleFilename(options.artist, options.title, '.mp3');
 	}
 	if (isLosslessFormat(downloadFilename)) {
 		return losslessToMp3Filename(downloadFilename);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -399,7 +399,7 @@ export function getDefaultMetadata(track: SoundcloudTrack): Metadata {
 }
 
 const LOSSLESS_EXTENSIONS = ['.wav', '.aiff', '.aif', '.flac'] as const;
-/** Lossy containers we still re-encode to MP3 when output is mp3-320. */
+/** Lossy containers we still re-encode to MP3 (bitrate chosen from the source). */
 const LOSSY_TO_MP3_EXTENSIONS = [
 	'.m4a',
 	'.aac',
@@ -407,6 +407,14 @@ const LOSSY_TO_MP3_EXTENSIONS = [
 	'.opus',
 	'.webm',
 ] as const;
+const MP3_CONVERTIBLE_EXTENSIONS = [
+	...LOSSLESS_EXTENSIONS,
+	...LOSSY_TO_MP3_EXTENSIONS,
+] as const;
+const MP3_CONVERTIBLE_EXT_PATTERN = new RegExp(
+	`\\.(${MP3_CONVERTIBLE_EXTENSIONS.map((ext) => ext.slice(1)).join('|')})$`,
+	'i',
+);
 
 function hasExtension(
 	filename: string,
@@ -424,7 +432,7 @@ export function isMp3Format(filename: string): boolean {
 	return filename.toLowerCase().endsWith('.mp3');
 }
 
-/** True when the file must be re-encoded to MP3 for the mp3-320 output path. */
+/** True when the file must be re-encoded to MP3 for the MP3 output path. */
 export function needsMp3Conversion(filename: string): boolean {
 	return (
 		isLosslessFormat(filename) ||
@@ -433,10 +441,7 @@ export function needsMp3Conversion(filename: string): boolean {
 }
 
 export function toMp3Filename(filename: string): string {
-	return filename.replace(
-		/\.(wav|aiff|aif|flac|m4a|aac|ogg|opus|webm)$/i,
-		'.mp3',
-	);
+	return filename.replace(MP3_CONVERTIBLE_EXT_PATTERN, '.mp3');
 }
 
 /** @deprecated Prefer toMp3Filename */

--- a/src/ytdlp.ts
+++ b/src/ytdlp.ts
@@ -85,6 +85,7 @@ export function titleMatchScore(candidate: string, wanted: string): number {
 export class YtDlpDownloader {
 	private progressCallback: ProgressCallback | null = null;
 	private sourceLabel: string;
+	private activeProcess: ReturnType<typeof execa> | null = null;
 
 	constructor(sourceLabel = 'yt-dlp') {
 		this.sourceLabel = sourceLabel;
@@ -92,6 +93,32 @@ export class YtDlpDownloader {
 
 	setProgressCallback(callback: ProgressCallback) {
 		this.progressCallback = callback;
+	}
+
+	async close(): Promise<void> {
+		const running = this.activeProcess;
+		this.activeProcess = null;
+		running?.kill('SIGTERM');
+	}
+
+	private async runYtDlp(
+		ytDlpBin: string,
+		args: string[],
+		timeout: number,
+	): Promise<string> {
+		const process = execa(ytDlpBin, args, {
+			timeout,
+			killSignal: 'SIGTERM',
+		});
+		this.activeProcess = process;
+		try {
+			const { stdout } = await process;
+			return stdout;
+		} finally {
+			if (this.activeProcess === process) {
+				this.activeProcess = null;
+			}
+		}
 	}
 
 	async downloadAudio(
@@ -159,10 +186,7 @@ export class YtDlpDownloader {
 
 		let stdout: string;
 		try {
-			({ stdout } = await execa(ytDlpBin, args, {
-				timeout: YTDLP_DOWNLOAD_TIMEOUT_MS,
-				killSignal: 'SIGTERM',
-			}));
+			stdout = await this.runYtDlp(ytDlpBin, args, YTDLP_DOWNLOAD_TIMEOUT_MS);
 		} finally {
 			if (cookiesPath) await rm(cookiesPath, { force: true });
 		}
@@ -227,10 +251,10 @@ export class YtDlpDownloader {
 			`${this.sourceLabel}: album URL — matching track “${matchTitle}”…`,
 		);
 
-		const { stdout } = await execa(
+		const stdout = await this.runYtDlp(
 			ytDlpBin,
 			['--flat-playlist', '-J', '--no-warnings', albumUrl],
-			{ timeout: YTDLP_METADATA_TIMEOUT_MS, killSignal: 'SIGTERM' },
+			YTDLP_METADATA_TIMEOUT_MS,
 		);
 
 		const data = JSON.parse(stdout) as {

--- a/src/ytdlp.ts
+++ b/src/ytdlp.ts
@@ -1,4 +1,4 @@
-import { mkdir } from 'node:fs/promises';
+import { mkdir, rm } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 import { execa } from 'execa';
 import { lookpath } from 'find-bin';
@@ -140,8 +140,9 @@ export class YtDlpDownloader {
 			'--no-warnings',
 		];
 
+		let cookiesPath: string | null = null;
 		if (soundcloud) {
-			const cookiesPath = await writeSoundcloudNetscapeCookies();
+			cookiesPath = await writeSoundcloudNetscapeCookies();
 			if (cookiesPath) {
 				args.push('--cookies', cookiesPath);
 				console.log(
@@ -156,10 +157,15 @@ export class YtDlpDownloader {
 
 		args.push(downloadUrl);
 
-		const { stdout } = await execa(ytDlpBin, args, {
-			timeout: YTDLP_DOWNLOAD_TIMEOUT_MS,
-			killSignal: 'SIGTERM',
-		});
+		let stdout: string;
+		try {
+			({ stdout } = await execa(ytDlpBin, args, {
+				timeout: YTDLP_DOWNLOAD_TIMEOUT_MS,
+				killSignal: 'SIGTERM',
+			}));
+		} finally {
+			if (cookiesPath) await rm(cookiesPath, { force: true });
+		}
 
 		const filepaths = stdout
 			.trim()

--- a/src/ytdlp.ts
+++ b/src/ytdlp.ts
@@ -3,7 +3,11 @@ import { basename, join } from 'node:path';
 import { execa } from 'execa';
 import { lookpath } from 'find-bin';
 import type { JobProgress } from './types';
-import { isBandcampAlbumUrl } from './utils';
+import {
+	isBandcampAlbumUrl,
+	isSoundcloudUrl,
+	writeSoundcloudNetscapeCookies,
+} from './utils';
 
 type ProgressCallback = (
 	stage: JobProgress['stage'],
@@ -71,6 +75,9 @@ export function titleMatchScore(candidate: string, wanted: string): number {
  * Downloads audio via yt-dlp into ./downloads (Bandcamp, SoundCloud, …).
  * Browserless — no gate browser / SoundCloud session automation.
  *
+ * SoundCloud: when `soundcloud-cookies.json` is present, cookies are passed to
+ * yt-dlp so downloadable tracks can fetch the original upload (not just 128k).
+ *
  * Bandcamp album URLs: when `matchTitle` is set, resolves the best-matching
  * track on the album and downloads only that entry (avoids grabbing the whole
  * album and offering the wrong file).
@@ -117,23 +124,42 @@ export class YtDlpDownloader {
 		await mkdir(DOWNLOADS_DIR, { recursive: true });
 
 		const outputTemplate = join(DOWNLOADS_DIR, '%(title)s [%(id)s].%(ext)s');
+		const soundcloud = isSoundcloudUrl(downloadUrl);
+		// Prefer SoundCloud's original upload (`download`) when the track allows it.
+		// That format is only listed for registered users — pass cookies when available.
+		const format = soundcloud ? 'download/bestaudio/best' : 'bestaudio/best';
+		const args = [
+			'--no-mtime',
+			'--no-playlist',
+			'-f',
+			format,
+			'-o',
+			outputTemplate,
+			'--print',
+			'after_move:filepath',
+			'--no-warnings',
+		];
 
-		const { stdout } = await execa(
-			ytDlpBin,
-			[
-				'--no-mtime',
-				'--no-playlist',
-				'-f',
-				'bestaudio/best',
-				'-o',
-				outputTemplate,
-				'--print',
-				'after_move:filepath',
-				'--no-warnings',
-				downloadUrl,
-			],
-			{ timeout: YTDLP_DOWNLOAD_TIMEOUT_MS, killSignal: 'SIGTERM' },
-		);
+		if (soundcloud) {
+			const cookiesPath = await writeSoundcloudNetscapeCookies();
+			if (cookiesPath) {
+				args.push('--cookies', cookiesPath);
+				console.log(
+					`${this.sourceLabel}: using soundcloud-cookies.json for yt-dlp (original download if available)`,
+				);
+			} else {
+				console.warn(
+					`${this.sourceLabel}: no soundcloud-cookies.json — original SoundCloud downloads may be unavailable`,
+				);
+			}
+		}
+
+		args.push(downloadUrl);
+
+		const { stdout } = await execa(ytDlpBin, args, {
+			timeout: YTDLP_DOWNLOAD_TIMEOUT_MS,
+			killSignal: 'SIGTERM',
+		});
 
 		const filepaths = stdout
 			.trim()

--- a/src/ytdlp.ts
+++ b/src/ytdlp.ts
@@ -86,6 +86,7 @@ export class YtDlpDownloader {
 	private progressCallback: ProgressCallback | null = null;
 	private sourceLabel: string;
 	private activeProcess: ReturnType<typeof execa> | null = null;
+	private closed = false;
 
 	constructor(sourceLabel = 'yt-dlp') {
 		this.sourceLabel = sourceLabel;
@@ -96,6 +97,7 @@ export class YtDlpDownloader {
 	}
 
 	async close(): Promise<void> {
+		this.closed = true;
 		const running = this.activeProcess;
 		this.activeProcess = null;
 		running?.kill('SIGTERM');
@@ -106,16 +108,19 @@ export class YtDlpDownloader {
 		args: string[],
 		timeout: number,
 	): Promise<string> {
-		const process = execa(ytDlpBin, args, {
+		if (this.closed) {
+			throw new Error('yt-dlp downloader is closed');
+		}
+		const subprocess = execa(ytDlpBin, args, {
 			timeout,
 			killSignal: 'SIGTERM',
 		});
-		this.activeProcess = process;
+		this.activeProcess = subprocess;
 		try {
-			const { stdout } = await process;
+			const { stdout } = await subprocess;
 			return stdout;
 		} finally {
-			if (this.activeProcess === process) {
+			if (this.activeProcess === subprocess) {
 				this.activeProcess = null;
 			}
 		}

--- a/userscript/sc-gate-dl.user.js
+++ b/userscript/sc-gate-dl.user.js
@@ -1,0 +1,1190 @@
+// ==UserScript==
+// @name         sc-gate-dl
+// @namespace    https://github.com/D3SOX/sc-gate-dl
+// @version      1.6.0
+// @description  Open the sc-gate-dl Web UI in a floating panel next to SoundCloud store/buy links
+// @author       D3SOX
+// @match        https://soundcloud.com/*
+// @match        https://www.soundcloud.com/*
+// @icon         https://soundcloud.com/favicon.ico
+// @grant        GM_registerMenuCommand
+// @grant        GM_unregisterMenuCommand
+// @grant        GM_getValue
+// @grant        GM_setValue
+// @connect      localhost
+// @connect      127.0.0.1
+// @run-at       document-idle
+// @homepageURL  https://github.com/D3SOX/sc-gate-dl
+// @supportURL   https://github.com/D3SOX/sc-gate-dl/issues
+// @downloadURL  https://raw.githubusercontent.com/D3SOX/sc-gate-dl/main/userscript/sc-gate-dl.user.js
+// @updateURL    https://raw.githubusercontent.com/D3SOX/sc-gate-dl/main/userscript/sc-gate-dl.user.js
+// ==/UserScript==
+
+(() => {
+	'use strict';
+
+	const WEBUI_BASE_KEY = 'sc-gate-dl-webui-base';
+	const PANEL_GEOM_KEY = 'sc-gate-dl-panel-geom';
+	const OUTPUT_FORMAT_KEY = 'sc-gate-dl-output-format';
+	const AUTO_CLOSE_KEY = 'sc-gate-dl-auto-close';
+	const DEFAULT_WEBUI_BASE = 'http://localhost:4321';
+	const BUTTON_ATTR = 'data-sc-gate-dl-btn';
+	const WRAP_ATTR = 'data-sc-gate-dl-wrap';
+	const PANEL_ID = 'sc-gate-dl-panel';
+	const STYLE_ID = 'sc-gate-dl-styles';
+	const TOOLTIP_ID = 'sc-gate-dl-tooltip';
+	const TOOLTIP_LABEL = 'Download with sc-gate-dl';
+	const MIN_PANEL_W = 280;
+	const MIN_PANEL_H = 240;
+
+	const DEFAULT_GEOM = {
+		width: 400,
+		height: 0, // filled from viewport
+		right: 12,
+		top: 72,
+	};
+
+	const RESERVED_FIRST = new Set([
+		'you',
+		'discover',
+		'stream',
+		'library',
+		'messages',
+		'notifications',
+		'settings',
+		'pages',
+		'charts',
+		'jobs',
+		'pro',
+		'upload',
+		'search',
+		'login',
+		'signup',
+		'about',
+		'stations',
+		'feed',
+	]);
+
+	const TRAILING_SEGMENTS = new Set([
+		'likes',
+		'reposts',
+		'comments',
+		'recommended',
+		'sets',
+		'popular-tracks',
+		'albums',
+		'tracks',
+		'followers',
+		'following',
+	]);
+
+	const DOWNLOAD_ICON_16 = `
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="16" height="16">
+  <path fill="currentColor" d="M8 1.25a.75.75 0 0 1 .75.75v7.19l2.22-2.22a.75.75 0 1 1 1.06 1.06l-3.5 3.5a.75.75 0 0 1-1.06 0l-3.5-3.5a.75.75 0 0 1 1.06-1.06l2.22 2.22V2A.75.75 0 0 1 8 1.25Z"/>
+  <path fill="currentColor" d="M2.5 11.25a.75.75 0 0 1 .75.75v1.25h9.5V12a.75.75 0 0 1 1.5 0v1.5A1.25 1.25 0 0 1 13 14.75H3A1.25 1.25 0 0 1 1.75 13.5V12a.75.75 0 0 1 .75-.75Z"/>
+</svg>`;
+
+	const DOWNLOAD_ICON_24 = `
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="24" height="24">
+  <path fill="currentColor" d="M12 3.25a.75.75 0 0 1 .75.75v9.19l3.22-3.22a.75.75 0 1 1 1.06 1.06l-4.5 4.5a.75.75 0 0 1-1.06 0l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.22 3.22V4A.75.75 0 0 1 12 3.25Z"/>
+  <path fill="currentColor" d="M4.5 15.25a.75.75 0 0 1 .75.75v2.25h13.5V16a.75.75 0 0 1 1.5 0v2.5A1.75 1.75 0 0 1 18.5 20.25h-13A1.75 1.75 0 0 1 3.75 18.5V16a.75.75 0 0 1 .75-.75Z"/>
+</svg>`;
+
+	function getAutoClose() {
+		try {
+			if (typeof GM_getValue === 'function') {
+				const gm = GM_getValue(AUTO_CLOSE_KEY, null);
+				if (typeof gm === 'boolean') return gm;
+			}
+		} catch {
+			// ignore
+		}
+		try {
+			const v = localStorage.getItem(AUTO_CLOSE_KEY);
+			if (v === '0' || v === 'false') return false;
+			if (v === '1' || v === 'true') return true;
+		} catch {
+			// ignore
+		}
+		return true; // default on
+	}
+
+	function setAutoClose(value) {
+		const on = Boolean(value);
+		try {
+			if (typeof GM_setValue === 'function') GM_setValue(AUTO_CLOSE_KEY, on);
+		} catch {
+			// ignore
+		}
+		try {
+			localStorage.setItem(AUTO_CLOSE_KEY, on ? '1' : '0');
+		} catch {
+			// ignore
+		}
+	}
+
+	function getOutputFormat() {
+		try {
+			if (typeof GM_getValue === 'function') {
+				const gm = GM_getValue(OUTPUT_FORMAT_KEY, null);
+				if (gm === 'original' || gm === 'mp3-320') return gm;
+			}
+		} catch {
+			// ignore
+		}
+		try {
+			const v = localStorage.getItem(OUTPUT_FORMAT_KEY);
+			if (v === 'original' || v === 'mp3-320') return v;
+		} catch {
+			// ignore
+		}
+		return 'mp3-320';
+	}
+
+	function syncFormatSelect(value) {
+		const select = document.querySelector(`#${PANEL_ID} .sc-gate-dl-format`);
+		if (select instanceof HTMLSelectElement) select.value = value;
+	}
+
+	function setOutputFormat(value) {
+		if (value !== 'original' && value !== 'mp3-320') return;
+		try {
+			if (typeof GM_setValue === 'function') GM_setValue(OUTPUT_FORMAT_KEY, value);
+		} catch {
+			// ignore
+		}
+		try {
+			localStorage.setItem(OUTPUT_FORMAT_KEY, value);
+		} catch {
+			// ignore
+		}
+		syncFormatSelect(value);
+		const panel = document.getElementById(PANEL_ID);
+		if (panel && !panel.hidden && panel.dataset.trackUrl) {
+			loadTrackIntoPanel(panel, panel.dataset.trackUrl);
+		}
+	}
+
+	let autoCloseMenuId;
+
+	function refreshAutoCloseMenu() {
+		if (typeof GM_registerMenuCommand !== 'function') return;
+		if (
+			typeof GM_unregisterMenuCommand === 'function' &&
+			autoCloseMenuId != null
+		) {
+			try {
+				GM_unregisterMenuCommand(autoCloseMenuId);
+			} catch {
+				// ignore
+			}
+		}
+		const on = getAutoClose();
+		autoCloseMenuId = GM_registerMenuCommand(
+			`Auto-close after browser download: ${on ? 'ON' : 'OFF'}`,
+			() => {
+				setAutoClose(!getAutoClose());
+				refreshAutoCloseMenu();
+			},
+		);
+	}
+
+	function registerMenuCommands() {
+		if (typeof GM_registerMenuCommand !== 'function') return;
+		GM_registerMenuCommand('Choose output format…', () => {
+			openFormatDialog();
+		});
+		refreshAutoCloseMenu();
+	}
+
+	function currentHref() {
+		try {
+			// document.location is the browsing document (reliable with GM sandbox)
+			return document.location.href;
+		} catch {
+			try {
+				return window.location.href;
+			} catch {
+				return document.URL || '';
+			}
+		}
+	}
+
+	function normalizeTrackUrl(href) {
+		try {
+			const url = new URL(href, currentHref() || 'https://soundcloud.com/');
+			const host = url.hostname.replace(/^www\./i, '').toLowerCase();
+			if (
+				host !== 'soundcloud.com' &&
+				host !== 'm.soundcloud.com' &&
+				host !== 'on.soundcloud.com'
+			) {
+				return null;
+			}
+			let parts = url.pathname.split('/').filter(Boolean);
+			// New logged-in listen layout uses /n/artist/track
+			if (parts[0]?.toLowerCase() === 'n' && parts.length >= 3) {
+				parts = parts.slice(1);
+			}
+			while (
+				parts.length > 2 &&
+				TRAILING_SEGMENTS.has(parts[parts.length - 1].toLowerCase())
+			) {
+				parts = parts.slice(0, -1);
+			}
+			if (parts.length === 3 && parts[2].toLowerCase().startsWith('s-')) {
+				parts = parts.slice(0, 2);
+			}
+			if (parts.length < 2) return null;
+			if (RESERVED_FIRST.has(parts[0].toLowerCase())) return null;
+			if (TRAILING_SEGMENTS.has(parts[1].toLowerCase())) return null;
+			return `https://soundcloud.com/${parts[0]}/${parts[1]}`;
+		} catch {
+			return null;
+		}
+	}
+
+	function pageTrackUrl() {
+		// Only the real page location — meta tags / embeds can be /n/... or wrong
+		const href = currentHref();
+		if (href) {
+			const normalized = normalizeTrackUrl(href);
+			if (normalized) return normalized;
+		}
+		try {
+			const pathUrl = `https://soundcloud.com${document.location.pathname}`;
+			return normalizeTrackUrl(pathUrl);
+		} catch {
+			return null;
+		}
+	}
+
+	/** Feed/search cards only — track pages use the current URL. */
+	function trackUrlFromCard(el) {
+		const sound = el?.closest?.(
+			'.sound, .soundList__item, .searchItem__trackItem, .listenContext',
+		);
+		if (!sound) return null;
+		const titleLink = sound.querySelector(
+			'a.soundTitle__title, a[href][class*="soundTitle"]',
+		);
+		if (titleLink?.href) {
+			const fromTitle = normalizeTrackUrl(titleLink.href);
+			if (fromTitle) return fromTitle;
+		}
+		for (const a of sound.querySelectorAll('a[href]')) {
+			const fromA = normalizeTrackUrl(a.href);
+			if (fromA) return fromA;
+		}
+		return null;
+	}
+
+	function resolveTrackUrl(el) {
+		// Listen page (classic or MUI): always prefer the address bar URL
+		const fromPage = pageTrackUrl();
+		if (fromPage) return fromPage;
+		return trackUrlFromCard(el);
+	}
+
+	function getWebuiBase() {
+		try {
+			return (
+				localStorage.getItem(WEBUI_BASE_KEY)?.replace(/\/$/, '') ||
+				DEFAULT_WEBUI_BASE
+			);
+		} catch {
+			return DEFAULT_WEBUI_BASE;
+		}
+	}
+
+	function loadGeom() {
+		try {
+			const raw = localStorage.getItem(PANEL_GEOM_KEY);
+			if (!raw) return null;
+			const parsed = JSON.parse(raw);
+			if (
+				typeof parsed?.width === 'number' &&
+				typeof parsed?.height === 'number' &&
+				typeof parsed?.left === 'number' &&
+				typeof parsed?.top === 'number'
+			) {
+				return parsed;
+			}
+		} catch {
+			// ignore
+		}
+		return null;
+	}
+
+	function saveGeom(panel) {
+		try {
+			const rect = panel.getBoundingClientRect();
+			localStorage.setItem(
+				PANEL_GEOM_KEY,
+				JSON.stringify({
+					width: Math.round(rect.width),
+					height: Math.round(rect.height),
+					left: Math.round(rect.left),
+					top: Math.round(rect.top),
+				}),
+			);
+		} catch {
+			// ignore
+		}
+	}
+
+	function hideTooltip() {
+		document.getElementById(TOOLTIP_ID)?.remove();
+	}
+
+	function showTooltip(anchor) {
+		hideTooltip();
+		const tip = document.createElement('div');
+		tip.id = TOOLTIP_ID;
+		tip.setAttribute('role', 'tooltip');
+		tip.innerHTML = `<div class="sc-gate-dl-tip-arrow"></div><div class="sc-gate-dl-tip-content"></div>`;
+		const content = tip.querySelector('.sc-gate-dl-tip-content');
+		if (content) content.textContent = TOOLTIP_LABEL;
+		document.documentElement.appendChild(tip);
+
+		// Anchor to the visible icon button, not a wide wrapper
+		const icon =
+			anchor.querySelector?.(`[${BUTTON_ATTR}]`) ||
+			(anchor.hasAttribute?.(BUTTON_ATTR) ? anchor : null) ||
+			anchor;
+		const ar = icon.getBoundingClientRect();
+		const tr = tip.getBoundingClientRect();
+		let top = ar.top - tr.height - 8;
+		let left = ar.left + ar.width / 2 - tr.width / 2;
+		if (top < 4) top = ar.bottom + 8;
+		left = Math.min(Math.max(8, left), window.innerWidth - tr.width - 8);
+		tip.style.top = `${Math.round(top)}px`;
+		tip.style.left = `${Math.round(left)}px`;
+		const arrow = tip.querySelector('.sc-gate-dl-tip-arrow');
+		if (arrow instanceof HTMLElement) {
+			const tipRect = tip.getBoundingClientRect();
+			const arrowLeft = ar.left + ar.width / 2 - tipRect.left - 5;
+			arrow.style.left = `${Math.round(Math.min(Math.max(6, arrowLeft), tipRect.width - 14))}px`;
+			if (top > ar.top) tip.classList.add('sc-gate-dl-tip-below');
+		}
+	}
+
+	function openFormatDialog() {
+		ensureStyles();
+		document.getElementById('sc-gate-dl-format-dialog')?.remove();
+		const current = getOutputFormat();
+		const dialog = document.createElement('div');
+		dialog.id = 'sc-gate-dl-format-dialog';
+		dialog.innerHTML = `
+			<div class="sc-gate-dl-format-card" role="dialog" aria-label="Output format">
+				<div class="sc-gate-dl-format-title">Output format</div>
+				<label class="sc-gate-dl-format-option">
+					<input type="radio" name="sc-gate-dl-fmt" value="mp3-320"${current === 'mp3-320' ? ' checked' : ''}/>
+					<span>MP3 320kbps</span>
+				</label>
+				<label class="sc-gate-dl-format-option">
+					<input type="radio" name="sc-gate-dl-fmt" value="original"${current === 'original' ? ' checked' : ''}/>
+					<span>Original file</span>
+				</label>
+				<div class="sc-gate-dl-format-actions">
+					<button type="button" class="sc-gate-dl-format-cancel">Cancel</button>
+					<button type="button" class="sc-gate-dl-format-save">Save</button>
+				</div>
+			</div>
+		`;
+		const close = () => dialog.remove();
+		dialog.addEventListener('click', (e) => {
+			if (e.target === dialog) close();
+		});
+		dialog.querySelector('.sc-gate-dl-format-cancel')?.addEventListener('click', close);
+		dialog.querySelector('.sc-gate-dl-format-save')?.addEventListener('click', () => {
+			const selected = dialog.querySelector(
+				'input[name="sc-gate-dl-fmt"]:checked',
+			);
+			if (selected instanceof HTMLInputElement) setOutputFormat(selected.value);
+			close();
+		});
+		document.documentElement.appendChild(dialog);
+	}
+
+	function bindTooltip(anchor) {
+		let showTimer = 0;
+		const onEnter = () => {
+			window.clearTimeout(showTimer);
+			showTimer = window.setTimeout(() => showTooltip(anchor), 60);
+		};
+		const onLeave = () => {
+			window.clearTimeout(showTimer);
+			hideTooltip();
+		};
+		anchor.addEventListener('mouseenter', onEnter);
+		anchor.addEventListener('mouseleave', onLeave);
+		anchor.addEventListener('focus', onEnter);
+		anchor.addEventListener('blur', onLeave);
+	}
+
+	function isOurNode(el) {
+		return (
+			el instanceof Element &&
+			(el.hasAttribute(BUTTON_ATTR) ||
+				el.hasAttribute(WRAP_ATTR) ||
+				!!el.closest(`[${BUTTON_ATTR}], [${WRAP_ATTR}], #${PANEL_ID}`) )
+		);
+	}
+
+	function alreadyInjectedNear(anchorPoint) {
+		if (!anchorPoint) return true;
+		const scope =
+			anchorPoint.closest('.soundActions, .sound__soundActions') ||
+			anchorPoint.parentElement;
+		if (scope?.querySelector(`[${WRAP_ATTR}]`)) return true;
+		const next = anchorPoint.nextElementSibling;
+		return !!(
+			next?.hasAttribute?.(WRAP_ATTR) || next?.hasAttribute?.(BUTTON_ATTR)
+		);
+	}
+
+	function ensureStyles() {
+		if (document.getElementById(STYLE_ID)) return;
+		const style = document.createElement('style');
+		style.id = STYLE_ID;
+		style.textContent = `
+#${PANEL_ID} {
+	position: fixed;
+	z-index: 2147483646;
+	display: flex;
+	flex-direction: column;
+	box-sizing: border-box;
+	min-width: ${MIN_PANEL_W}px;
+	min-height: ${MIN_PANEL_H}px;
+	max-width: calc(100vw - 8px);
+	max-height: calc(100vh - 8px);
+	background: #0f0f12;
+	border-radius: 10px;
+	overflow: hidden;
+	box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
+	border: 1px solid rgba(255, 255, 255, 0.12);
+}
+#${PANEL_ID}[hidden] { display: none !important; }
+#${PANEL_ID} .sc-gate-dl-toolbar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	padding: 6px 8px 6px 10px;
+	background: #16161c;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+	color: #eee;
+	font: 600 12px/1.2 Interstate, "Lucida Grande", Arial, sans-serif;
+	cursor: move;
+	user-select: none;
+	flex-shrink: 0;
+	touch-action: none;
+}
+#${PANEL_ID} .sc-gate-dl-toolbar a {
+	color: #f50;
+	text-decoration: none;
+	cursor: pointer;
+}
+#${PANEL_ID} .sc-gate-dl-toolbar .sc-gate-dl-actions {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	flex-shrink: 0;
+}
+#${PANEL_ID} .sc-gate-dl-format {
+	appearance: none;
+	background: #0f0f12;
+	color: #ddd;
+	border: 1px solid rgba(255,255,255,0.14);
+	border-radius: 6px;
+	font: 500 11px/1.2 Interstate, "Lucida Grande", Arial, sans-serif;
+	padding: 4px 6px;
+	cursor: pointer;
+	max-width: 118px;
+}
+#${PANEL_ID} .sc-gate-dl-toolbar button.sc-gate-dl-close {
+	appearance: none;
+	border: 0;
+	background: transparent;
+	color: #ccc;
+	font-size: 18px;
+	line-height: 1;
+	cursor: pointer;
+	padding: 2px 6px;
+}
+#${PANEL_ID} .sc-gate-dl-toolbar button.sc-gate-dl-close:hover { color: #fff; }
+#${PANEL_ID} iframe {
+	flex: 1;
+	width: 100%;
+	border: 0;
+	background: #0f0f12;
+	min-height: 0;
+}
+
+/* Resize handles — all edges + corners */
+#${PANEL_ID} .sc-gate-dl-rh {
+	position: absolute;
+	z-index: 3;
+	background: transparent;
+}
+#${PANEL_ID} .sc-gate-dl-rh[data-dir="n"] { top: 0; left: 8px; right: 8px; height: 6px; cursor: n-resize; }
+#${PANEL_ID} .sc-gate-dl-rh[data-dir="s"] { bottom: 0; left: 8px; right: 8px; height: 6px; cursor: s-resize; }
+#${PANEL_ID} .sc-gate-dl-rh[data-dir="e"] { top: 8px; right: 0; bottom: 8px; width: 6px; cursor: e-resize; }
+#${PANEL_ID} .sc-gate-dl-rh[data-dir="w"] { top: 8px; left: 0; bottom: 8px; width: 6px; cursor: w-resize; }
+#${PANEL_ID} .sc-gate-dl-rh[data-dir="ne"] { top: 0; right: 0; width: 10px; height: 10px; cursor: ne-resize; }
+#${PANEL_ID} .sc-gate-dl-rh[data-dir="nw"] { top: 0; left: 0; width: 10px; height: 10px; cursor: nw-resize; }
+#${PANEL_ID} .sc-gate-dl-rh[data-dir="se"] { bottom: 0; right: 0; width: 10px; height: 10px; cursor: se-resize; }
+#${PANEL_ID} .sc-gate-dl-rh[data-dir="sw"] { bottom: 0; left: 0; width: 10px; height: 10px; cursor: sw-resize; }
+
+/* Match SoundCloud .tooltip (rgb(48,48,48) / #303030) */
+#${TOOLTIP_ID} {
+	position: fixed !important;
+	z-index: 2147483647 !important;
+	pointer-events: none;
+	background: #303030;
+	color: #fff;
+	border-radius: 4px;
+	padding: 4px 8px;
+	font: 500 12px/1.3 Söhne, Interstate, "Lucida Grande", Arial, sans-serif;
+	box-shadow: none;
+	border: 0;
+	white-space: nowrap;
+	max-width: min(280px, calc(100vw - 16px));
+}
+#${TOOLTIP_ID} .sc-gate-dl-tip-content { position: relative; z-index: 1; }
+#${TOOLTIP_ID} .sc-gate-dl-tip-arrow {
+	position: absolute;
+	bottom: -5px;
+	width: 10px;
+	height: 10px;
+	background: #303030;
+	border: 0;
+	transform: rotate(45deg);
+}
+#${TOOLTIP_ID}.sc-gate-dl-tip-below .sc-gate-dl-tip-arrow {
+	bottom: auto;
+	top: -5px;
+}
+
+/* Format chooser (Violentmonkey menu) */
+#sc-gate-dl-format-dialog {
+	position: fixed;
+	inset: 0;
+	z-index: 2147483647;
+	display: flex;
+	align-items: flex-start;
+	justify-content: flex-end;
+	padding: 72px 16px 16px;
+	pointer-events: none;
+}
+#sc-gate-dl-format-dialog .sc-gate-dl-format-card {
+	pointer-events: auto;
+	width: min(280px, calc(100vw - 32px));
+	background: #16161c;
+	color: #eee;
+	border: 1px solid rgba(255,255,255,0.12);
+	border-radius: 10px;
+	box-shadow: 0 12px 40px rgba(0,0,0,0.45);
+	padding: 14px;
+	font: 500 13px/1.35 Interstate, "Lucida Grande", Arial, sans-serif;
+}
+#sc-gate-dl-format-dialog .sc-gate-dl-format-title {
+	font-weight: 700;
+	margin-bottom: 10px;
+}
+#sc-gate-dl-format-dialog .sc-gate-dl-format-option {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 8px 4px;
+	cursor: pointer;
+}
+#sc-gate-dl-format-dialog .sc-gate-dl-format-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+	margin-top: 12px;
+}
+#sc-gate-dl-format-dialog button {
+	appearance: none;
+	border: 1px solid rgba(255,255,255,0.14);
+	background: #0f0f12;
+	color: #ddd;
+	border-radius: 6px;
+	padding: 6px 10px;
+	cursor: pointer;
+	font: inherit;
+}
+#sc-gate-dl-format-dialog .sc-gate-dl-format-save {
+	background: #f50;
+	border-color: #f50;
+	color: #fff;
+}
+
+/* Classic SC — sibling of cart in .soundActions (cart wrapper is ~16px and clips) */
+div[${WRAP_ATTR}="classic"] {
+	display: inline-flex !important;
+	align-items: center;
+	justify-content: center;
+	vertical-align: middle;
+	margin-left: 2px !important;
+	width: 32px;
+	height: 32px;
+	overflow: visible !important;
+	line-height: 0;
+	flex-shrink: 0;
+}
+a[${BUTTON_ATTR}="classic"] {
+	display: inline-flex !important;
+	align-items: center;
+	justify-content: center;
+	width: 32px !important;
+	height: 32px !important;
+	min-width: 32px !important;
+	min-height: 32px !important;
+	padding: 0 !important;
+	box-sizing: border-box;
+	vertical-align: middle;
+	overflow: visible !important;
+}
+a[${BUTTON_ATTR}="classic"] .sc-button-label {
+	display: flex !important;
+	align-items: center;
+	justify-content: center;
+	padding: 0 !important;
+	width: 100%;
+}
+a[${BUTTON_ATTR}="classic"] svg {
+	display: block;
+	width: 16px;
+	height: 16px;
+}
+
+/* MUI listen page */
+div[${WRAP_ATTR}="mui"] {
+	display: inline-flex;
+	vertical-align: middle;
+}
+button[${BUTTON_ATTR}="mui"] svg {
+	display: block;
+	width: 24px;
+	height: 24px;
+}
+`;
+		document.documentElement.appendChild(style);
+	}
+
+	function applyDefaultGeom(panel) {
+		const saved = loadGeom();
+		if (saved) {
+			panel.style.width = `${saved.width}px`;
+			panel.style.height = `${saved.height}px`;
+			panel.style.left = `${saved.left}px`;
+			panel.style.top = `${saved.top}px`;
+			panel.style.right = 'auto';
+			return;
+		}
+		const height = Math.min(
+			Math.max(window.innerHeight - DEFAULT_GEOM.top - 12, 360),
+			window.innerHeight - 24,
+		);
+		panel.style.width = `${DEFAULT_GEOM.width}px`;
+		panel.style.height = `${height}px`;
+		panel.style.top = `${DEFAULT_GEOM.top}px`;
+		panel.style.right = `${DEFAULT_GEOM.right}px`;
+		panel.style.left = 'auto';
+	}
+
+	function clampPanel(panel) {
+		const rect = panel.getBoundingClientRect();
+		const maxLeft = window.innerWidth - Math.min(rect.width, window.innerWidth);
+		const maxTop = window.innerHeight - Math.min(rect.height, window.innerHeight);
+		const left = Math.min(Math.max(0, rect.left), Math.max(0, maxLeft));
+		const top = Math.min(Math.max(0, rect.top), Math.max(0, maxTop));
+		panel.style.left = `${left}px`;
+		panel.style.top = `${top}px`;
+		panel.style.right = 'auto';
+	}
+
+	function enableDrag(panel) {
+		const toolbar = panel.querySelector('.sc-gate-dl-toolbar');
+		if (!toolbar || toolbar.dataset.dragBound) return;
+		toolbar.dataset.dragBound = '1';
+
+		let dragging = false;
+		let startX = 0;
+		let startY = 0;
+		let origLeft = 0;
+		let origTop = 0;
+
+		toolbar.addEventListener('pointerdown', (e) => {
+			if (e.button !== 0) return;
+			if (e.target.closest('a, button, select, label')) return;
+			dragging = true;
+			const rect = panel.getBoundingClientRect();
+			startX = e.clientX;
+			startY = e.clientY;
+			origLeft = rect.left;
+			origTop = rect.top;
+			panel.style.left = `${origLeft}px`;
+			panel.style.top = `${origTop}px`;
+			panel.style.right = 'auto';
+			toolbar.setPointerCapture(e.pointerId);
+			e.preventDefault();
+		});
+
+		toolbar.addEventListener('pointermove', (e) => {
+			if (!dragging) return;
+			panel.style.left = `${origLeft + (e.clientX - startX)}px`;
+			panel.style.top = `${origTop + (e.clientY - startY)}px`;
+		});
+
+		const endDrag = (e) => {
+			if (!dragging) return;
+			dragging = false;
+			try {
+				toolbar.releasePointerCapture(e.pointerId);
+			} catch {
+				// ignore
+			}
+			clampPanel(panel);
+			saveGeom(panel);
+		};
+
+		toolbar.addEventListener('pointerup', endDrag);
+		toolbar.addEventListener('pointercancel', endDrag);
+	}
+
+	function enableEdgeResize(panel) {
+		if (panel.dataset.resizeBound) return;
+		panel.dataset.resizeBound = '1';
+
+		for (const dir of ['n', 's', 'e', 'w', 'ne', 'nw', 'se', 'sw']) {
+			const handle = document.createElement('div');
+			handle.className = 'sc-gate-dl-rh';
+			handle.dataset.dir = dir;
+			panel.appendChild(handle);
+		}
+
+		let resizing = false;
+		let dir = '';
+		let startX = 0;
+		let startY = 0;
+		let startLeft = 0;
+		let startTop = 0;
+		let startW = 0;
+		let startH = 0;
+
+		panel.addEventListener('pointerdown', (e) => {
+			const handle = e.target.closest?.('.sc-gate-dl-rh');
+			if (!(handle instanceof HTMLElement) || e.button !== 0) return;
+			e.preventDefault();
+			e.stopPropagation();
+			resizing = true;
+			dir = handle.dataset.dir || '';
+			const rect = panel.getBoundingClientRect();
+			startX = e.clientX;
+			startY = e.clientY;
+			startLeft = rect.left;
+			startTop = rect.top;
+			startW = rect.width;
+			startH = rect.height;
+			panel.style.left = `${startLeft}px`;
+			panel.style.top = `${startTop}px`;
+			panel.style.right = 'auto';
+			handle.setPointerCapture(e.pointerId);
+		});
+
+		panel.addEventListener('pointermove', (e) => {
+			if (!resizing) return;
+			const dx = e.clientX - startX;
+			const dy = e.clientY - startY;
+			let left = startLeft;
+			let top = startTop;
+			let width = startW;
+			let height = startH;
+
+			if (dir.includes('e')) width = startW + dx;
+			if (dir.includes('s')) height = startH + dy;
+			if (dir.includes('w')) {
+				width = startW - dx;
+				left = startLeft + dx;
+			}
+			if (dir.includes('n')) {
+				height = startH - dy;
+				top = startTop + dy;
+			}
+
+			if (width < MIN_PANEL_W) {
+				if (dir.includes('w')) left = startLeft + startW - MIN_PANEL_W;
+				width = MIN_PANEL_W;
+			}
+			if (height < MIN_PANEL_H) {
+				if (dir.includes('n')) top = startTop + startH - MIN_PANEL_H;
+				height = MIN_PANEL_H;
+			}
+
+			width = Math.min(width, window.innerWidth - 8);
+			height = Math.min(height, window.innerHeight - 8);
+			left = Math.min(Math.max(0, left), window.innerWidth - width);
+			top = Math.min(Math.max(0, top), window.innerHeight - height);
+
+			panel.style.left = `${left}px`;
+			panel.style.top = `${top}px`;
+			panel.style.width = `${width}px`;
+			panel.style.height = `${height}px`;
+		});
+
+		const endResize = (e) => {
+			if (!resizing) return;
+			resizing = false;
+			try {
+				e.target.releasePointerCapture?.(e.pointerId);
+			} catch {
+				// ignore
+			}
+			clampPanel(panel);
+			saveGeom(panel);
+		};
+
+		panel.addEventListener('pointerup', endResize);
+		panel.addEventListener('pointercancel', endResize);
+	}
+
+	function buildWebuiSrc(trackUrl) {
+		const params = new URLSearchParams({
+			url: trackUrl,
+			outputFormat: getOutputFormat(),
+		});
+		return `${getWebuiBase()}/?${params.toString()}`;
+	}
+
+	function loadTrackIntoPanel(panel, trackUrl) {
+		// Switching tracks cancels any in-flight job for the previous one
+		if (panel.dataset.jobId) {
+			void cancelActiveJob(panel);
+		}
+		panel.dataset.trackUrl = trackUrl;
+		const src = buildWebuiSrc(trackUrl);
+		const iframe = panel.querySelector('iframe');
+		const openTab = panel.querySelector('.sc-gate-dl-open-tab');
+		if (iframe) iframe.src = src;
+		if (openTab instanceof HTMLAnchorElement) openTab.href = src;
+	}
+
+	function getApiBase() {
+		try {
+			const webui = getWebuiBase();
+			const u = new URL(webui);
+			if (u.port === '4321') u.port = '3000';
+			return u.origin;
+		} catch {
+			return 'http://localhost:3000';
+		}
+	}
+
+	async function cancelActiveJob(panel) {
+		if (!panel) return;
+		const jobId = panel.dataset.jobId;
+		if (!jobId) return;
+
+		const iframe = panel.querySelector('iframe');
+		if (iframe?.contentWindow) {
+			try {
+				iframe.contentWindow.postMessage(
+					{ source: 'sc-gate-dl-host', type: 'cancel' },
+					'*',
+				);
+			} catch {
+				// ignore
+			}
+		}
+		try {
+			await fetch(`${getApiBase()}/api/job/${encodeURIComponent(jobId)}/cancel`, {
+				method: 'POST',
+			});
+		} catch {
+			// ignore — panel still closes
+		}
+		delete panel.dataset.jobId;
+	}
+
+	async function closePanel() {
+		window.clearTimeout(autoCloseTimer);
+		const panel = document.getElementById(PANEL_ID);
+		if (!panel) return;
+		await cancelActiveJob(panel);
+		const iframe = panel.querySelector('iframe');
+		if (iframe) iframe.src = 'about:blank';
+		panel.hidden = true;
+	}
+
+	let autoCloseTimer = 0;
+
+	window.addEventListener('message', (event) => {
+		const data = event.data;
+		if (!data || data.source !== 'sc-gate-dl') return;
+		const panel = document.getElementById(PANEL_ID);
+
+		if (data.type === 'job' && data.jobId && panel) {
+			panel.dataset.jobId = String(data.jobId);
+			return;
+		}
+		if ((data.type === 'cancelled' || data.type === 'ready') && panel) {
+			delete panel.dataset.jobId;
+			return;
+		}
+
+		if (!getAutoClose()) return;
+		if (data.type === 'file-download') {
+			if (panel) delete panel.dataset.jobId;
+			window.clearTimeout(autoCloseTimer);
+			autoCloseTimer = window.setTimeout(() => {
+				void closePanel();
+			}, 600);
+		} else if (data.type === 'new-download') {
+			if (panel) delete panel.dataset.jobId;
+			void closePanel();
+		}
+	});
+
+	function openPanel(trackUrl) {
+		window.clearTimeout(autoCloseTimer);
+		ensureStyles();
+		let panel = document.getElementById(PANEL_ID);
+		if (!panel) {
+			panel = document.createElement('div');
+			panel.id = PANEL_ID;
+			panel.hidden = true;
+			panel.setAttribute('role', 'dialog');
+			panel.setAttribute('aria-modal', 'false');
+			panel.setAttribute('aria-label', 'sc-gate-dl');
+			const format = getOutputFormat();
+			panel.innerHTML = `
+				<div class="sc-gate-dl-toolbar">
+					<span>sc-gate-dl · <a class="sc-gate-dl-open-tab" href="#" target="_blank" rel="noopener">open in tab</a></span>
+					<span class="sc-gate-dl-actions">
+						<label>
+							<select class="sc-gate-dl-format" aria-label="Output format" title="Output format">
+								<option value="mp3-320"${format === 'mp3-320' ? ' selected' : ''}>MP3 320</option>
+								<option value="original"${format === 'original' ? ' selected' : ''}>Original</option>
+							</select>
+						</label>
+						<button type="button" class="sc-gate-dl-close" aria-label="Close" title="Close">×</button>
+					</span>
+				</div>
+				<iframe title="sc-gate-dl" allow="clipboard-read; clipboard-write"></iframe>
+			`;
+			panel
+				.querySelector('.sc-gate-dl-close')
+				?.addEventListener('click', () => {
+					void closePanel();
+				});
+			panel
+				.querySelector('.sc-gate-dl-format')
+				?.addEventListener('change', (e) => {
+					const select = e.target;
+					if (!(select instanceof HTMLSelectElement)) return;
+					setOutputFormat(select.value);
+					const current = panel.dataset.trackUrl;
+					if (current) loadTrackIntoPanel(panel, current);
+				});
+			document.addEventListener('keydown', (e) => {
+				if (e.key === 'Escape' && !panel.hidden) void closePanel();
+			});
+			document.documentElement.appendChild(panel);
+			applyDefaultGeom(panel);
+			enableDrag(panel);
+			enableEdgeResize(panel);
+		} else if (panel.hidden) {
+			clampPanel(panel);
+		}
+
+		loadTrackIntoPanel(panel, trackUrl);
+		panel.hidden = false;
+		clampPanel(panel);
+	}
+
+	function bindClick(el, trackUrl) {
+		el.addEventListener('click', (e) => {
+			e.preventDefault();
+			e.stopPropagation();
+			hideTooltip();
+			const url = resolveTrackUrl(el) || trackUrl;
+			if (!url) {
+				alert('sc-gate-dl: could not resolve a SoundCloud track URL here.');
+				return;
+			}
+			openPanel(url);
+		});
+	}
+
+	function makeClassicControl(trackUrl) {
+		// Mirror purchaseLink__container: SC tooltips key off aria-describedby + hover
+		const wrap = document.createElement('div');
+		wrap.setAttribute(WRAP_ATTR, 'classic');
+		wrap.className = 'purchaseLink__container';
+		wrap.setAttribute('aria-describedby', TOOLTIP_ID);
+		wrap.setAttribute('aria-label', TOOLTIP_LABEL);
+
+		const btn = document.createElement('a');
+		btn.href = '#';
+		btn.setAttribute(BUTTON_ATTR, 'classic');
+		btn.className =
+			'soundActions__purchaseLink sc-button sc-button-tertiary sc-button-responsive';
+		btn.setAttribute('aria-label', TOOLTIP_LABEL);
+		btn.setAttribute('aria-describedby', TOOLTIP_ID);
+		btn.innerHTML = `<span class="sc-button-label"><div>${DOWNLOAD_ICON_16}</div></span>`;
+		bindClick(btn, trackUrl);
+		wrap.appendChild(btn);
+		bindTooltip(wrap);
+		return wrap;
+	}
+
+	function makeMuiControl(trackUrl, templateBtn) {
+		const wrap = document.createElement('div');
+		wrap.setAttribute(WRAP_ATTR, 'mui');
+		wrap.className = 'MuiBox-root mui-0';
+		wrap.setAttribute('aria-label', TOOLTIP_LABEL);
+
+		const btn = document.createElement('button');
+		btn.type = 'button';
+		btn.setAttribute(BUTTON_ATTR, 'mui');
+		btn.setAttribute('aria-label', TOOLTIP_LABEL);
+		btn.className =
+			templateBtn?.className ||
+			'MuiButtonBase-root MuiIconButton-root MuiIconButton-colorContrast MuiIconButton-sizeMedium';
+		btn.innerHTML = DOWNLOAD_ICON_24;
+		bindClick(btn, trackUrl);
+		wrap.appendChild(btn);
+		bindTooltip(wrap);
+		return wrap;
+	}
+
+	/**
+	 * Classic: cart sits in a 40px `.purchaseLink__container` inside an anonymous
+	 * wrapper under `.soundActions` (flex row). Insert AFTER that wrapper.
+	 */
+	function classicAnchorPoint(el) {
+		const container =
+			el.closest?.('.purchaseLink__container') ||
+			(el.classList?.contains('purchaseLink__container') ? el : null);
+		if (!container) {
+			return el.closest?.('a.soundActions__purchaseLink, a.sc-button-buy') || el;
+		}
+		const actions = container.closest('.soundActions');
+		const wrap = container.parentElement;
+		if (actions && wrap && wrap.parentElement === actions && wrap !== actions) {
+			return wrap;
+		}
+		// Container is already a direct child of .soundActions
+		if (actions && container.parentElement === actions) return container;
+		return container;
+	}
+
+	function injectClassic(el) {
+		if (isOurNode(el)) return;
+		const trackUrl = resolveTrackUrl(el);
+		// Insert as sibling AFTER the cart cluster inside .soundActions.
+		// Do not append inside the cart wrapper — it is ~16px tall and clips the icon.
+		const anchorPoint = classicAnchorPoint(el);
+		if (isOurNode(anchorPoint) || alreadyInjectedNear(anchorPoint)) return;
+		const actions = anchorPoint.closest?.('.soundActions') || anchorPoint.parentElement;
+		if (actions instanceof HTMLElement) {
+			actions.style.overflow = 'visible';
+			actions.style.alignItems = 'center';
+		}
+		anchorPoint.insertAdjacentElement('afterend', makeClassicControl(trackUrl));
+	}
+
+	function isMuiBuyAnchor(el) {
+		if (!(el instanceof HTMLAnchorElement)) return false;
+		if (isOurNode(el)) return false;
+		// Never treat classic SC purchase links as MUI (caused duplicate under-cart inject)
+		if (el.closest('.purchaseLink__container, .soundActions, .sound__soundActions')) {
+			return false;
+		}
+		if (el.classList.contains('soundActions__purchaseLink')) return false;
+		const label = el.getAttribute('aria-label') || '';
+		if (!/buy|store|purchase|free\s*download/i.test(label)) return false;
+		return !!el.querySelector('button.MuiIconButton-root, svg');
+	}
+
+	function injectMui(buyAnchor) {
+		if (!isMuiBuyAnchor(buyAnchor)) return;
+		if (alreadyInjectedNear(buyAnchor)) return;
+		const templateBtn = buyAnchor.querySelector('button.MuiIconButton-root');
+		const trackUrl = resolveTrackUrl(buyAnchor);
+		buyAnchor.insertAdjacentElement(
+			'afterend',
+			makeMuiControl(trackUrl, templateBtn),
+		);
+	}
+
+	function isClassicPurchase(el) {
+		if (!(el instanceof Element) || isOurNode(el)) return false;
+		if (el.classList.contains('purchaseLink__container')) return true;
+		if (el.classList.contains('soundActions__purchaseLink')) return true;
+		if (el.classList.contains('sc-button-buy')) return true;
+		return false;
+	}
+
+	function scan(root = document) {
+		const scope = root instanceof Element || root === document ? root : document;
+
+		// Classic layout only — one control per purchaseLink__container
+		const containers = scope.querySelectorAll?.('.purchaseLink__container') || [];
+		for (const el of containers) {
+			if (isOurNode(el)) continue;
+			injectClassic(el);
+		}
+		// Orphan classic purchase anchors without container (rare)
+		for (const el of scope.querySelectorAll?.(
+			'a.soundActions__purchaseLink, a.sc-button-buy',
+		) || []) {
+			if (isOurNode(el)) continue;
+			if (el.closest('.purchaseLink__container')) continue;
+			if (isClassicPurchase(el)) injectClassic(el);
+		}
+
+		// MUI logged-in listen page only
+		for (const el of scope.querySelectorAll?.(
+			'a[aria-label="Buy This Track"], a[target="_blank"][aria-label]',
+		) || []) {
+			injectMui(el);
+		}
+	}
+
+	ensureStyles();
+	scan();
+
+	const observer = new MutationObserver((mutations) => {
+		let shouldScan = false;
+		for (const m of mutations) {
+			for (const node of m.addedNodes) {
+				if (!(node instanceof Element)) continue;
+				if (isOurNode(node)) continue;
+				shouldScan = true;
+				break;
+			}
+			if (shouldScan) break;
+		}
+		if (shouldScan) scan();
+	});
+	observer.observe(document.documentElement, { childList: true, subtree: true });
+
+	let lastHref = location.href;
+	setInterval(() => {
+		if (location.href !== lastHref) {
+			lastHref = location.href;
+			scan();
+		}
+	}, 1000);
+
+	registerMenuCommands();
+
+	console.info(
+		`[sc-gate-dl] ready — Web UI: ${getWebuiBase()} (run \`bun webui\`). Override with localStorage key "${WEBUI_BASE_KEY}".`,
+	);
+})();

--- a/userscript/sc-gate-dl.user.js
+++ b/userscript/sc-gate-dl.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         sc-gate-dl
 // @namespace    https://github.com/D3SOX/sc-gate-dl
-// @version      1.6.0
+// @version      1.6.1
 // @description  Open the sc-gate-dl Web UI in a floating panel next to SoundCloud store/buy links
 // @author       D3SOX
 // @match        https://soundcloud.com/*
@@ -237,6 +237,8 @@
 			}
 			if (parts.length < 2) return null;
 			if (RESERVED_FIRST.has(parts[0].toLowerCase())) return null;
+			// Playlists / albums: /artist/sets/slug — not a single track
+			if (parts[1].toLowerCase() === 'sets') return null;
 			if (TRAILING_SEGMENTS.has(parts[1].toLowerCase())) return null;
 			return `https://soundcloud.com/${parts[0]}/${parts[1]}`;
 		} catch {
@@ -284,6 +286,41 @@
 		const fromPage = pageTrackUrl();
 		if (fromPage) return fromPage;
 		return trackUrlFromCard(el);
+	}
+
+	/** Playlists/albums aren't single-track downloads — skip injection there. */
+	function isPlaylistOrAlbumContext(el) {
+		if (!(el instanceof Element)) return false;
+		if (el.closest('.sound.playlist')) return true;
+		if (
+			el.closest(
+				'.l-listen-hero.playlist, .fullHero.playlist, .listenContext.playlist',
+			)
+		) {
+			return true;
+		}
+		const sound = el.closest(
+			'.sound, .soundList__item, .activity, [role="group"]',
+		);
+		if (sound?.classList?.contains('playlist')) return true;
+		if (
+			sound?.querySelector(
+				'a.soundTitle__title[href*="/sets/"], a.sound__coverArt[href*="/sets/"]',
+			)
+		) {
+			return true;
+		}
+		const buy =
+			(el.closest('.purchaseLink__container') || el).querySelector?.(
+				'a[aria-label], a[title]',
+			) || el;
+		const label = (
+			buy.getAttribute?.('aria-label') ||
+			buy.getAttribute?.('title') ||
+			''
+		).toLowerCase();
+		if (/\bbuy all\b/.test(label)) return true;
+		return false;
 	}
 
 	function getWebuiBase() {
@@ -1085,6 +1122,7 @@ button[${BUTTON_ATTR}="mui"] svg {
 
 	function injectClassic(el) {
 		if (isOurNode(el)) return;
+		if (isPlaylistOrAlbumContext(el)) return;
 		const trackUrl = resolveTrackUrl(el);
 		// Insert as sibling AFTER the cart cluster inside .soundActions.
 		// Do not append inside the cart wrapper — it is ~16px tall and clips the icon.
@@ -1113,6 +1151,7 @@ button[${BUTTON_ATTR}="mui"] svg {
 
 	function injectMui(buyAnchor) {
 		if (!isMuiBuyAnchor(buyAnchor)) return;
+		if (isPlaylistOrAlbumContext(buyAnchor)) return;
 		if (alreadyInjectedNear(buyAnchor)) return;
 		const templateBtn = buyAnchor.querySelector('button.MuiIconButton-root');
 		const trackUrl = resolveTrackUrl(buyAnchor);
@@ -1132,6 +1171,11 @@ button[${BUTTON_ATTR}="mui"] svg {
 
 	function scan(root = document) {
 		const scope = root instanceof Element || root === document ? root : document;
+
+		// Drop buttons that landed on playlist/album cards (e.g. before class hydrated)
+		for (const wrap of scope.querySelectorAll?.(`[${WRAP_ATTR}]`) || []) {
+			if (isPlaylistOrAlbumContext(wrap)) wrap.remove();
+		}
 
 		// Classic layout only — one control per purchaseLink__container
 		const containers = scope.querySelectorAll?.('.purchaseLink__container') || [];

--- a/userscript/sc-gate-dl.user.js
+++ b/userscript/sc-gate-dl.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         sc-gate-dl
 // @namespace    https://github.com/D3SOX/sc-gate-dl
-// @version      1.6.1
+// @version      1.7.0
 // @description  Open the sc-gate-dl Web UI in a floating panel next to SoundCloud store/buy links
 // @author       D3SOX
 // @match        https://soundcloud.com/*
@@ -26,12 +26,14 @@
 	const WEBUI_BASE_KEY = 'sc-gate-dl-webui-base';
 	const API_BASE_KEY = 'sc-gate-dl-api-base';
 	const PANEL_GEOM_KEY = 'sc-gate-dl-panel-geom';
+	const QUEUE_GEOM_KEY = 'sc-gate-dl-queue-geom';
 	const OUTPUT_FORMAT_KEY = 'sc-gate-dl-output-format';
 	const AUTO_CLOSE_KEY = 'sc-gate-dl-auto-close';
 	const DEFAULT_WEBUI_BASE = 'http://localhost:4321';
 	const BUTTON_ATTR = 'data-sc-gate-dl-btn';
 	const WRAP_ATTR = 'data-sc-gate-dl-wrap';
 	const PANEL_ID = 'sc-gate-dl-panel';
+	const QUEUE_ID = 'sc-gate-dl-queue';
 	const STYLE_ID = 'sc-gate-dl-styles';
 	const TOOLTIP_ID = 'sc-gate-dl-tooltip';
 	const TOOLTIP_LABEL = 'Download with sc-gate-dl';
@@ -44,6 +46,15 @@
 		right: 12,
 		top: 72,
 	};
+
+	const DEFAULT_QUEUE_GEOM = {
+		width: 280,
+		left: 12,
+		top: 12,
+	};
+
+	/** @type {{ url: string, label: string }[]} */
+	const downloadQueue = [];
 
 	const RESERVED_FIRST = new Set([
 		'you',
@@ -371,6 +382,59 @@
 		}
 	}
 
+	function loadQueueGeom() {
+		try {
+			const raw = localStorage.getItem(QUEUE_GEOM_KEY);
+			if (!raw) return null;
+			const parsed = JSON.parse(raw);
+			if (
+				typeof parsed?.left === 'number' &&
+				typeof parsed?.top === 'number' &&
+				typeof parsed?.width === 'number'
+			) {
+				return parsed;
+			}
+		} catch {
+			// ignore
+		}
+		return null;
+	}
+
+	function saveQueueGeom(el) {
+		try {
+			const rect = el.getBoundingClientRect();
+			localStorage.setItem(
+				QUEUE_GEOM_KEY,
+				JSON.stringify({
+					width: Math.round(rect.width),
+					left: Math.round(rect.left),
+					top: Math.round(rect.top),
+				}),
+			);
+		} catch {
+			// ignore
+		}
+	}
+
+	function trackLabelFromUrl(url) {
+		try {
+			const parts = new URL(url).pathname.split('/').filter(Boolean);
+			if (parts.length >= 2) {
+				const artist = decodeURIComponent(parts[0]).replace(/-/g, ' ');
+				const track = decodeURIComponent(parts[1]).replace(/-/g, ' ');
+				return `${artist} — ${track}`;
+			}
+		} catch {
+			// ignore
+		}
+		return url;
+	}
+
+	function isPanelBusy() {
+		const panel = document.getElementById(PANEL_ID);
+		return Boolean(panel && !panel.hidden);
+	}
+
 	function hideTooltip() {
 		document.getElementById(TOOLTIP_ID)?.remove();
 	}
@@ -559,6 +623,96 @@
 	background: #0f0f12;
 	min-height: 0;
 }
+
+/* Download queue — smaller floating window (default top-left) */
+#${QUEUE_ID} {
+	position: fixed;
+	z-index: 2147483645;
+	display: flex;
+	flex-direction: column;
+	box-sizing: border-box;
+	width: ${DEFAULT_QUEUE_GEOM.width}px;
+	max-width: calc(100vw - 16px);
+	max-height: min(360px, calc(100vh - 24px));
+	background: #0f0f12;
+	border-radius: 8px;
+	overflow: hidden;
+	box-shadow: 0 8px 28px rgba(0, 0, 0, 0.4);
+	border: 1px solid rgba(255, 255, 255, 0.12);
+}
+#${QUEUE_ID}[hidden] { display: none !important; }
+#${QUEUE_ID} .sc-gate-dl-toolbar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	padding: 5px 6px 5px 10px;
+	background: #16161c;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+	color: #eee;
+	font: 600 11px/1.2 Interstate, "Lucida Grande", Arial, sans-serif;
+	cursor: move;
+	user-select: none;
+	flex-shrink: 0;
+	touch-action: none;
+}
+#${QUEUE_ID} .sc-gate-dl-toolbar button.sc-gate-dl-close {
+	appearance: none;
+	border: 0;
+	background: transparent;
+	color: #ccc;
+	font-size: 16px;
+	line-height: 1;
+	cursor: pointer;
+	padding: 2px 6px;
+}
+#${QUEUE_ID} .sc-gate-dl-toolbar button.sc-gate-dl-close:hover { color: #fff; }
+#${QUEUE_ID} .sc-gate-dl-queue-list {
+	list-style: none;
+	margin: 0;
+	padding: 4px 0;
+	overflow-y: auto;
+	flex: 1;
+	min-height: 0;
+}
+#${QUEUE_ID} .sc-gate-dl-queue-item {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 6px 8px 6px 10px;
+	color: #ddd;
+	font: 500 11px/1.3 Interstate, "Lucida Grande", Arial, sans-serif;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+#${QUEUE_ID} .sc-gate-dl-queue-item:last-child { border-bottom: 0; }
+#${QUEUE_ID} .sc-gate-dl-queue-label {
+	flex: 1;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	appearance: none;
+	border: 0;
+	background: transparent;
+	color: inherit;
+	font: inherit;
+	text-align: left;
+	cursor: pointer;
+	padding: 0;
+}
+#${QUEUE_ID} .sc-gate-dl-queue-label:hover { color: #f50; }
+#${QUEUE_ID} .sc-gate-dl-queue-remove {
+	appearance: none;
+	border: 0;
+	background: transparent;
+	color: #888;
+	font-size: 14px;
+	line-height: 1;
+	cursor: pointer;
+	padding: 2px 4px;
+	flex-shrink: 0;
+}
+#${QUEUE_ID} .sc-gate-dl-queue-remove:hover { color: #fff; }
 
 /* Resize handles — all edges + corners */
 #${PANEL_ID} .sc-gate-dl-rh {
@@ -971,7 +1125,203 @@ button[${BUTTON_ATTR}="mui"] svg {
 		await cancelActiveJob(panel);
 		const iframe = panel.querySelector('iframe');
 		if (iframe) iframe.src = 'about:blank';
+		delete panel.dataset.trackUrl;
 		panel.hidden = true;
+	}
+
+	function applyQueueGeom(el) {
+		const saved = loadQueueGeom();
+		if (saved) {
+			el.style.width = `${saved.width}px`;
+			el.style.left = `${saved.left}px`;
+			el.style.top = `${saved.top}px`;
+			return;
+		}
+		el.style.width = `${DEFAULT_QUEUE_GEOM.width}px`;
+		el.style.left = `${DEFAULT_QUEUE_GEOM.left}px`;
+		el.style.top = `${DEFAULT_QUEUE_GEOM.top}px`;
+	}
+
+	function clampQueue(el) {
+		const rect = el.getBoundingClientRect();
+		const maxLeft = window.innerWidth - Math.min(rect.width, window.innerWidth);
+		const maxTop = window.innerHeight - Math.min(rect.height, window.innerHeight);
+		const left = Math.min(Math.max(0, rect.left), Math.max(0, maxLeft));
+		const top = Math.min(Math.max(0, rect.top), Math.max(0, maxTop));
+		el.style.left = `${left}px`;
+		el.style.top = `${top}px`;
+	}
+
+	function enableQueueDrag(el) {
+		const toolbar = el.querySelector('.sc-gate-dl-toolbar');
+		if (!toolbar || toolbar.dataset.dragBound) return;
+		toolbar.dataset.dragBound = '1';
+
+		let dragging = false;
+		let startX = 0;
+		let startY = 0;
+		let origLeft = 0;
+		let origTop = 0;
+
+		toolbar.addEventListener('pointerdown', (e) => {
+			if (e.button !== 0) return;
+			if (e.target.closest('button')) return;
+			dragging = true;
+			const rect = el.getBoundingClientRect();
+			startX = e.clientX;
+			startY = e.clientY;
+			origLeft = rect.left;
+			origTop = rect.top;
+			toolbar.setPointerCapture(e.pointerId);
+			e.preventDefault();
+		});
+
+		toolbar.addEventListener('pointermove', (e) => {
+			if (!dragging) return;
+			el.style.left = `${origLeft + (e.clientX - startX)}px`;
+			el.style.top = `${origTop + (e.clientY - startY)}px`;
+		});
+
+		const endDrag = (e) => {
+			if (!dragging) return;
+			dragging = false;
+			try {
+				toolbar.releasePointerCapture(e.pointerId);
+			} catch {
+				// ignore
+			}
+			clampQueue(el);
+			saveQueueGeom(el);
+		};
+
+		toolbar.addEventListener('pointerup', endDrag);
+		toolbar.addEventListener('pointercancel', endDrag);
+	}
+
+	function clearQueue() {
+		downloadQueue.length = 0;
+		renderQueue();
+	}
+
+	function removeFromQueue(index) {
+		if (index < 0 || index >= downloadQueue.length) return;
+		downloadQueue.splice(index, 1);
+		renderQueue();
+	}
+
+	function enqueueDownload(trackUrl) {
+		if (downloadQueue.some((item) => item.url === trackUrl)) return;
+		const panel = document.getElementById(PANEL_ID);
+		if (panel && !panel.hidden && panel.dataset.trackUrl === trackUrl) return;
+		downloadQueue.push({
+			url: trackUrl,
+			label: trackLabelFromUrl(trackUrl),
+		});
+		renderQueue();
+	}
+
+	function startNextFromQueue() {
+		window.clearTimeout(autoCloseTimer);
+		const next = downloadQueue.shift();
+		renderQueue();
+		if (next) {
+			openPanel(next.url);
+			return true;
+		}
+		return false;
+	}
+
+	function startQueuedAt(index) {
+		if (index < 0 || index >= downloadQueue.length) return;
+		const [item] = downloadQueue.splice(index, 1);
+		renderQueue();
+		if (!item) return;
+		const panel = document.getElementById(PANEL_ID);
+		// Active job in progress — only promote to next in line
+		if (panel && !panel.hidden && panel.dataset.jobId) {
+			downloadQueue.unshift(item);
+			renderQueue();
+			return;
+		}
+		openPanel(item.url);
+	}
+
+	function renderQueue() {
+		ensureStyles();
+		let el = document.getElementById(QUEUE_ID);
+		if (downloadQueue.length === 0) {
+			if (el) el.hidden = true;
+			return;
+		}
+
+		if (!el) {
+			el = document.createElement('div');
+			el.id = QUEUE_ID;
+			el.setAttribute('role', 'dialog');
+			el.setAttribute('aria-modal', 'false');
+			el.setAttribute('aria-label', 'sc-gate-dl download queue');
+			el.innerHTML = `
+				<div class="sc-gate-dl-toolbar">
+					<span class="sc-gate-dl-queue-title">Queue</span>
+					<button type="button" class="sc-gate-dl-close" aria-label="Clear queue" title="Clear queue">×</button>
+				</div>
+				<ul class="sc-gate-dl-queue-list"></ul>
+			`;
+			el.querySelector('.sc-gate-dl-close')?.addEventListener('click', () => {
+				clearQueue();
+			});
+			document.documentElement.appendChild(el);
+			applyQueueGeom(el);
+			enableQueueDrag(el);
+		}
+
+		const title = el.querySelector('.sc-gate-dl-queue-title');
+		if (title) title.textContent = `Queue (${downloadQueue.length})`;
+
+		const list = el.querySelector('.sc-gate-dl-queue-list');
+		if (!(list instanceof HTMLElement)) return;
+		list.replaceChildren();
+		downloadQueue.forEach((item, index) => {
+			const li = document.createElement('li');
+			li.className = 'sc-gate-dl-queue-item';
+
+			const labelBtn = document.createElement('button');
+			labelBtn.type = 'button';
+			labelBtn.className = 'sc-gate-dl-queue-label';
+			labelBtn.title = item.url;
+			labelBtn.textContent = item.label;
+			labelBtn.addEventListener('click', () => startQueuedAt(index));
+
+			const removeBtn = document.createElement('button');
+			removeBtn.type = 'button';
+			removeBtn.className = 'sc-gate-dl-queue-remove';
+			removeBtn.setAttribute('aria-label', 'Remove from queue');
+			removeBtn.title = 'Remove';
+			removeBtn.textContent = '×';
+			removeBtn.addEventListener('click', () => removeFromQueue(index));
+
+			li.append(labelBtn, removeBtn);
+			list.appendChild(li);
+		});
+
+		el.hidden = false;
+		clampQueue(el);
+	}
+
+	function requestDownload(trackUrl) {
+		if (isPanelBusy()) {
+			enqueueDownload(trackUrl);
+			return;
+		}
+		openPanel(trackUrl);
+	}
+
+	function finishCurrentAndAdvance() {
+		if (downloadQueue.length > 0) {
+			startNextFromQueue();
+			return;
+		}
+		void closePanel();
 	}
 
 	let autoCloseTimer = 0;
@@ -998,16 +1348,20 @@ button[${BUTTON_ATTR}="mui"] svg {
 			return;
 		}
 
-		if (!getAutoClose()) return;
 		if (data.type === 'file-download') {
 			if (panel) delete panel.dataset.jobId;
+			if (!getAutoClose()) return;
 			window.clearTimeout(autoCloseTimer);
 			autoCloseTimer = window.setTimeout(() => {
-				void closePanel();
+				finishCurrentAndAdvance();
 			}, 600);
 		} else if (data.type === 'new-download') {
 			if (panel) delete panel.dataset.jobId;
-			void closePanel();
+			if (downloadQueue.length > 0) {
+				startNextFromQueue();
+				return;
+			}
+			if (getAutoClose()) void closePanel();
 		}
 	});
 
@@ -1076,7 +1430,7 @@ button[${BUTTON_ATTR}="mui"] svg {
 				alert('sc-gate-dl: could not resolve a SoundCloud track URL here.');
 				return;
 			}
-			openPanel(url);
+			requestDownload(url);
 		});
 	}
 

--- a/userscript/sc-gate-dl.user.js
+++ b/userscript/sc-gate-dl.user.js
@@ -24,6 +24,7 @@
 	'use strict';
 
 	const WEBUI_BASE_KEY = 'sc-gate-dl-webui-base';
+	const API_BASE_KEY = 'sc-gate-dl-api-base';
 	const PANEL_GEOM_KEY = 'sc-gate-dl-panel-geom';
 	const OUTPUT_FORMAT_KEY = 'sc-gate-dl-output-format';
 	const AUTO_CLOSE_KEY = 'sc-gate-dl-auto-close';
@@ -912,6 +913,22 @@ button[${BUTTON_ATTR}="mui"] svg {
 
 	function getApiBase() {
 		try {
+			if (typeof GM_getValue === 'function') {
+				const gm = GM_getValue(API_BASE_KEY, null);
+				if (typeof gm === 'string' && gm.trim()) {
+					return gm.replace(/\/$/, '');
+				}
+			}
+		} catch {
+			// ignore
+		}
+		try {
+			const stored = localStorage.getItem(API_BASE_KEY)?.replace(/\/$/, '');
+			if (stored) return stored;
+		} catch {
+			// ignore
+		}
+		try {
 			const webui = getWebuiBase();
 			const u = new URL(webui);
 			if (u.port === '4321') u.port = '3000';
@@ -931,7 +948,7 @@ button[${BUTTON_ATTR}="mui"] svg {
 			try {
 				iframe.contentWindow.postMessage(
 					{ source: 'sc-gate-dl-host', type: 'cancel' },
-					'*',
+					new URL(getWebuiBase()).origin,
 				);
 			} catch {
 				// ignore
@@ -963,6 +980,14 @@ button[${BUTTON_ATTR}="mui"] svg {
 		const data = event.data;
 		if (!data || data.source !== 'sc-gate-dl') return;
 		const panel = document.getElementById(PANEL_ID);
+		let webuiOrigin;
+		try {
+			webuiOrigin = new URL(getWebuiBase()).origin;
+		} catch {
+			return;
+		}
+		if (event.origin !== webuiOrigin) return;
+		if (event.source !== panel?.querySelector('iframe')?.contentWindow) return;
 
 		if (data.type === 'job' && data.jobId && panel) {
 			panel.dataset.jobId = String(data.jobId);
@@ -1024,8 +1049,6 @@ button[${BUTTON_ATTR}="mui"] svg {
 					const select = e.target;
 					if (!(select instanceof HTMLSelectElement)) return;
 					setOutputFormat(select.value);
-					const current = panel.dataset.trackUrl;
-					if (current) loadTrackIntoPanel(panel, current);
 				});
 			document.addEventListener('keydown', (e) => {
 				if (e.key === 'Escape' && !panel.hidden) void closePanel();

--- a/userscript/sc-gate-dl.user.js
+++ b/userscript/sc-gate-dl.user.js
@@ -889,7 +889,10 @@ button[${BUTTON_ATTR}="mui"] svg {
 	}
 
 	function clampPanel(panel) {
+		// display:none → zero rect; clamping then would snap to (0,0) and wipe position
+		if (panel.hidden) return;
 		const rect = panel.getBoundingClientRect();
+		if (rect.width <= 0 || rect.height <= 0) return;
 		const maxLeft = window.innerWidth - Math.min(rect.width, window.innerWidth);
 		const maxTop = window.innerHeight - Math.min(rect.height, window.innerHeight);
 		const left = Math.min(Math.max(0, rect.left), Math.max(0, maxLeft));
@@ -1143,7 +1146,9 @@ button[${BUTTON_ATTR}="mui"] svg {
 	}
 
 	function clampQueue(el) {
+		if (el.hidden) return;
 		const rect = el.getBoundingClientRect();
+		if (rect.width <= 0 || rect.height <= 0) return;
 		const maxLeft = window.innerWidth - Math.min(rect.width, window.innerWidth);
 		const maxTop = window.innerHeight - Math.min(rect.height, window.innerHeight);
 		const left = Math.min(Math.max(0, rect.left), Math.max(0, maxLeft));
@@ -1411,8 +1416,6 @@ button[${BUTTON_ATTR}="mui"] svg {
 			applyDefaultGeom(panel);
 			enableDrag(panel);
 			enableEdgeResize(panel);
-		} else if (panel.hidden) {
-			clampPanel(panel);
 		}
 
 		loadTrackIntoPanel(panel, trackUrl);

--- a/userscript/sc-gate-dl.user.js
+++ b/userscript/sc-gate-dl.user.js
@@ -432,7 +432,7 @@
 
 	function isPanelBusy() {
 		const panel = document.getElementById(PANEL_ID);
-		return Boolean(panel && !panel.hidden);
+		return Boolean(panel && !panel.hidden && panel.dataset.jobId);
 	}
 
 	function hideTooltip() {

--- a/webui/astro.config.mjs
+++ b/webui/astro.config.mjs
@@ -5,5 +5,13 @@ import react from '@astrojs/react';
 
 // https://astro.build/config
 export default defineConfig({
-  integrations: [react()]
+	integrations: [react()],
+	vite: {
+		server: {
+			// Allow embedding from SoundCloud via the userscript overlay iframe
+			headers: {
+				'Access-Control-Allow-Private-Network': 'true',
+			},
+		},
+	},
 });

--- a/webui/src/components/App.css
+++ b/webui/src/components/App.css
@@ -511,6 +511,11 @@
 	color: var(--text-secondary);
 }
 
+.btn-cancel-download {
+	align-self: center;
+	margin-top: var(--space-sm);
+}
+
 /* Metadata form */
 .metadata-form {
 	padding: var(--space-xl);

--- a/webui/src/components/App.css
+++ b/webui/src/components/App.css
@@ -618,6 +618,15 @@
 @media (max-width: 600px) {
 	.metadata-grid {
 		grid-template-columns: 1fr;
+		justify-items: center;
+	}
+
+	.artwork-section {
+		margin-inline: auto;
+	}
+
+	.fields-section {
+		width: 100%;
 	}
 }
 

--- a/webui/src/components/App.css
+++ b/webui/src/components/App.css
@@ -688,6 +688,20 @@
 	color: var(--neon-cyan);
 }
 
+.artwork-upload:has(input:disabled) {
+	cursor: not-allowed;
+}
+
+.artwork-upload:has(input:disabled) span {
+	opacity: 0.6;
+	pointer-events: none;
+}
+
+.artwork-upload:has(input:disabled):hover span {
+	border-color: var(--border-subtle);
+	color: var(--text-secondary);
+}
+
 .btn-artwork-action {
 	cursor: pointer;
 }

--- a/webui/src/components/App.css
+++ b/webui/src/components/App.css
@@ -531,6 +531,7 @@
 	flex-direction: column;
 	gap: var(--space-md);
 	padding: var(--space-lg);
+	margin-bottom: var(--space-xl);
 	background: rgba(0, 217, 255, 0.05);
 	border: 1px solid rgba(0, 217, 255, 0.2);
 	border-radius: 8px;
@@ -547,34 +548,71 @@
 	color: var(--text-secondary);
 }
 
-.existing-metadata dl {
-	display: grid;
-	grid-template-columns: auto 1fr;
-	gap: var(--space-xs) var(--space-lg);
+.existing-metadata > .btn-secondary {
+	align-self: flex-start;
+	padding: var(--space-sm) var(--space-md);
+	font-size: 0.85rem;
+}
+
+.existing-metadata-list {
+	list-style: none;
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-xs);
+	margin: 0;
+	padding: 0;
 	font-family: var(--font-mono);
 	font-size: 0.85rem;
 }
 
-.existing-metadata dt {
+.existing-metadata-row {
+	display: grid;
+	grid-template-columns: 4.5rem 1fr auto;
+	align-items: center;
+	gap: var(--space-sm);
+}
+
+.existing-metadata-label {
 	color: var(--text-muted);
 }
 
-.existing-metadata dd {
+.existing-metadata-value {
 	color: var(--text-primary);
 	overflow-wrap: anywhere;
 	user-select: text;
+	min-width: 0;
 }
 
-.existing-metadata-actions {
-	display: flex;
-	gap: var(--space-sm);
-	flex-wrap: wrap;
+.btn-copy-existing {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+	width: 1.75rem;
+	height: 1.75rem;
+	padding: 0;
+	background: transparent;
+	border: 1px solid var(--border-subtle);
+	border-radius: 6px;
+	color: var(--neon-cyan);
+	cursor: pointer;
+	transition: all var(--transition-fast);
 }
 
-.existing-metadata-actions .btn-secondary {
-	flex: 1;
-	padding: var(--space-sm) var(--space-md);
-	font-size: 0.85rem;
+.btn-copy-existing:hover:not(:disabled) {
+	border-color: var(--neon-cyan);
+	background: rgba(0, 217, 255, 0.1);
+}
+
+.btn-copy-existing:focus-visible {
+	outline: none;
+	border-color: var(--neon-cyan);
+	box-shadow: 0 0 0 3px rgba(0, 217, 255, 0.1);
+}
+
+.btn-copy-existing:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
 }
 
 @media (max-width: 600px) {
@@ -642,6 +680,57 @@
 	display: flex;
 	flex-direction: column;
 	gap: var(--space-md);
+}
+
+.field-with-reset {
+	position: relative;
+	width: 100%;
+}
+
+.field-with-reset input {
+	display: block;
+	width: 100%;
+	box-sizing: border-box;
+}
+
+.field-with-reset.has-reset input {
+	padding-right: 2.5rem;
+}
+
+.btn-reset-field {
+	position: absolute;
+	top: 50%;
+	right: 0.75rem;
+	transform: translateY(-50%);
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 1.5rem;
+	height: 1.5rem;
+	padding: 0;
+	background: transparent;
+	border: none;
+	border-radius: 4px;
+	color: var(--text-muted);
+	cursor: pointer;
+	transition:
+		color var(--transition-fast),
+		background var(--transition-fast);
+}
+
+.btn-reset-field:hover:not(:disabled) {
+	color: var(--neon-cyan);
+	background: rgba(0, 217, 255, 0.1);
+}
+
+.btn-reset-field:focus-visible {
+	outline: 2px solid var(--neon-cyan);
+	outline-offset: 1px;
+}
+
+.btn-reset-field:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
 }
 
 /* Complete container */

--- a/webui/src/components/App.css
+++ b/webui/src/components/App.css
@@ -523,7 +523,7 @@
 	display: grid;
 	grid-template-columns: auto 1fr;
 	gap: var(--space-xl);
-	margin-bottom: var(--space-xl);
+	margin-bottom: 0;
 }
 
 .existing-metadata {
@@ -625,11 +625,12 @@
 	display: flex;
 	flex-direction: column;
 	gap: var(--space-md);
+	width: 160px;
 }
 
 .artwork-preview {
-	width: 160px;
-	height: 160px;
+	width: 100%;
+	aspect-ratio: 1;
 	border-radius: 8px;
 	overflow: hidden;
 	background: var(--bg-elevated);
@@ -653,7 +654,8 @@
 }
 
 .artwork-upload {
-	display: flex;
+	display: block;
+	width: 100%;
 	cursor: pointer;
 }
 
@@ -661,19 +663,52 @@
 	display: none;
 }
 
-.artwork-upload span {
+.artwork-upload span,
+.btn-artwork-action {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	box-sizing: border-box;
 	padding: var(--space-sm) var(--space-md);
 	background: var(--bg-elevated);
 	border: 1px solid var(--border-subtle);
 	border-radius: 6px;
+	font-family: var(--font-display);
 	font-size: 0.85rem;
+	font-weight: 500;
+	line-height: 1.25;
 	color: var(--text-secondary);
 	transition: all var(--transition-fast);
 }
 
-.artwork-upload:hover span {
+.artwork-upload:hover span,
+.btn-artwork-action:hover:not(:disabled) {
 	border-color: var(--neon-cyan);
 	color: var(--neon-cyan);
+}
+
+.btn-artwork-action {
+	cursor: pointer;
+}
+
+.btn-artwork-action:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+}
+
+.btn-auto-cleanup {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	box-sizing: border-box;
+	padding: var(--space-sm) var(--space-md);
+	border-width: 1px;
+	border-radius: 6px;
+	font-size: 0.85rem;
+	font-weight: 500;
+	line-height: 1.25;
 }
 
 .fields-section {
@@ -731,6 +766,22 @@
 .btn-reset-field:disabled {
 	opacity: 0.6;
 	cursor: not-allowed;
+}
+
+.filename-preview {
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-md);
+	margin-top: var(--space-md);
+	margin-bottom: var(--space-xl);
+	padding-top: var(--space-md);
+	border-top: 1px solid var(--border-subtle);
+}
+
+.filename-preview-input {
+	width: 100%;
+	opacity: 0.85;
+	cursor: default;
 }
 
 /* Complete container */

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -142,13 +142,18 @@ function artistTitleFilename(artist?: string, title?: string): string {
 	return `${safeArtist} - ${safeTitle}.mp3`;
 }
 
-function isLosslessFilename(filename: string): boolean {
+function needsMp3Conversion(filename: string): boolean {
 	const lower = filename.toLowerCase();
 	return (
 		lower.endsWith('.wav') ||
 		lower.endsWith('.aiff') ||
 		lower.endsWith('.aif') ||
-		lower.endsWith('.flac')
+		lower.endsWith('.flac') ||
+		lower.endsWith('.m4a') ||
+		lower.endsWith('.aac') ||
+		lower.endsWith('.ogg') ||
+		lower.endsWith('.opus') ||
+		lower.endsWith('.webm')
 	);
 }
 
@@ -164,12 +169,11 @@ function previewProcessedFilename(
 	if (options.nameAsArtistTitle) {
 		return artistTitleFilename(options.artist, options.title);
 	}
-	if (isLosslessFilename(downloadFilename)) {
-		return downloadFilename
-			.replace(/\.wav$/i, '.mp3')
-			.replace(/\.aiff$/i, '.mp3')
-			.replace(/\.aif$/i, '.mp3')
-			.replace(/\.flac$/i, '.mp3');
+	if (needsMp3Conversion(downloadFilename)) {
+		return downloadFilename.replace(
+			/\.(wav|aiff|aif|flac|m4a|aac|ogg|opus|webm)$/i,
+			'.mp3',
+		);
 	}
 	return downloadFilename;
 }

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Toaster, toast } from 'sonner';
 import './App.css';
 
@@ -43,6 +43,14 @@ interface JobState {
 }
 
 const API_BASE = 'http://localhost:3000';
+
+function notifyParent(
+	type: 'file-download' | 'new-download' | 'job' | 'cancelled' | 'ready',
+	payload?: { jobId?: string },
+) {
+	if (window.parent === window) return;
+	window.parent.postMessage({ source: 'sc-gate-dl', type, ...payload }, '*');
+}
 
 /** Promo fluff often glued onto SoundCloud / gate titles. */
 const PROMO_TAG =
@@ -187,6 +195,8 @@ export default function App() {
 	const [nameAsArtistTitle, setNameAsArtistTitle] = useState(false);
 	const [isLoading, setIsLoading] = useState(false);
 	const cleanupToastShownRef = useRef(false);
+	const autoStartedFromQueryRef = useRef(false);
+	const eventSourceRef = useRef<EventSource | null>(null);
 	const formatPercent = (value?: number) => Math.round(value ?? 0);
 
 	const showCleanupSoundcloudToast = useCallback(() => {
@@ -255,62 +265,244 @@ export default function App() {
 		});
 	}, []);
 
-	// Create job with SoundCloud URL
-	const handleSoundcloudSubmit = async (e: React.FormEvent) => {
-		e.preventDefault();
-		if (!soundcloudUrl.trim()) return;
+	// Start download process
+	const startDownload = useCallback(
+		async (jobId: string) => {
+			setStep('progress');
+			cleanupToastShownRef.current = false;
+			eventSourceRef.current?.close();
+			eventSourceRef.current = null;
+			notifyParent('job', { jobId });
 
-		setIsLoading(true);
-		setJob((prev) => ({ ...prev, error: null }));
+			try {
+				const response = await fetch(`${API_BASE}/api/job/${jobId}/start`, {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ headless: !headfulMode }),
+				});
+
+				if (!response.ok) {
+					const data = await response.json();
+					throw new Error(data.error || 'Failed to start download');
+				}
+
+				// Connect to SSE for progress updates
+				const eventSource = new EventSource(
+					`${API_BASE}/api/job/${jobId}/events`,
+				);
+				eventSourceRef.current = eventSource;
+
+				eventSource.onmessage = (event) => {
+					const progress: JobProgress = JSON.parse(event.data);
+					setJob((prev) => ({ ...prev, progress }));
+
+					// Browserless downloads never touch the SoundCloud account, so there
+					// is nothing to clean up afterwards.
+					if (
+						progress.stage === 'downloading' &&
+						(progress.downloadBytes || progress.totalBytes) &&
+						!progress.browserless &&
+						!cleanupToastShownRef.current
+					) {
+						showCleanupSoundcloudToast();
+						cleanupToastShownRef.current = true;
+					}
+
+					if (progress.stage === 'ready') {
+						eventSource.close();
+						eventSourceRef.current = null;
+						notifyParent('ready');
+						fetch(`${API_BASE}/api/job/${jobId}`)
+							.then((res) => res.json())
+							.then((data) => {
+								setJob((prev) => ({
+									...prev,
+									downloadFilename: data.downloadFilename,
+									outputFilename: data.outputFilename,
+									existingMetadata: data.existingMetadata,
+									outputFormat: data.outputFormat,
+								}));
+								setStep(
+									data.outputFormat === 'original' ? 'complete' : 'metadata',
+								);
+							})
+							.catch((err) => {
+								setJob((prev) => ({
+									...prev,
+									error:
+										err instanceof Error ? err.message : 'Failed to load job',
+								}));
+							});
+					} else if (progress.stage === 'error') {
+						eventSource.close();
+						eventSourceRef.current = null;
+						setJob((prev) => ({ ...prev, error: progress.message }));
+					} else if (progress.stage === 'cancelled') {
+						eventSource.close();
+						eventSourceRef.current = null;
+						setJob((prev) => ({
+							...prev,
+							progress,
+							error: null,
+						}));
+						setStep('url');
+						notifyParent('cancelled');
+					}
+				};
+
+				eventSource.onerror = () => {
+					eventSource.close();
+					if (eventSourceRef.current === eventSource) {
+						eventSourceRef.current = null;
+					}
+				};
+			} catch (err) {
+				setJob((prev) => ({
+					...prev,
+					error: err instanceof Error ? err.message : 'Unknown error',
+				}));
+			}
+		},
+		[headfulMode, showCleanupSoundcloudToast],
+	);
+
+	const cancelDownload = useCallback(async () => {
+		const jobId = job.jobId;
+		if (!jobId) return;
+
+		eventSourceRef.current?.close();
+		eventSourceRef.current = null;
 
 		try {
-			const response = await fetch(`${API_BASE}/api/job`, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({
-					soundcloudUrl,
-					skipAutomaticHypedditFetch,
-					outputFormat,
-				}),
-			});
-
-			const data = await response.json();
-
-			if (!response.ok) {
-				throw new Error(data.error || 'Failed to create job');
-			}
-
-			setJob({
-				...job,
-				jobId: data.jobId,
-				track: data.track,
-				hypedditUrl: data.hypedditUrl,
-				defaultMetadata: data.defaultMetadata,
-				existingMetadata: null,
-				outputFormat,
-				error: null,
-			});
-
-			// Pre-fill metadata
-			if (data.defaultMetadata) {
-				setMetadata(data.defaultMetadata);
-			}
-
-			if (skipAutomaticHypedditFetch || data.needsHypedditUrl) {
-				setStep('hypeddit');
-			} else {
-				// Auto-start download
-				startDownload(data.jobId);
-			}
+			await fetch(`${API_BASE}/api/job/${jobId}/cancel`, { method: 'POST' });
 		} catch (err) {
-			setJob((prev) => ({
-				...prev,
-				error: err instanceof Error ? err.message : 'Unknown error',
-			}));
-		} finally {
-			setIsLoading(false);
+			console.warn('Cancel request failed', err);
 		}
+
+		setJob((prev) => ({
+			...prev,
+			progress: {
+				stage: 'cancelled',
+				message: 'Download cancelled',
+				percent: prev.progress?.percent ?? 0,
+			},
+			error: null,
+		}));
+		setStep('url');
+		notifyParent('cancelled');
+	}, [job.jobId]);
+
+	// Parent userscript panel X → cancel in-progress job
+	useEffect(() => {
+		const onMessage = (event: MessageEvent) => {
+			const data = event.data;
+			if (!data || data.source !== 'sc-gate-dl-host') return;
+			if (data.type === 'cancel') {
+				void cancelDownload();
+			}
+		};
+		window.addEventListener('message', onMessage);
+		return () => window.removeEventListener('message', onMessage);
+	}, [cancelDownload]);
+
+	const createJob = useCallback(
+		async (url: string, formatOverride?: OutputFormat) => {
+			const trimmed = url.trim();
+			if (!trimmed) return;
+
+			const format = formatOverride ?? outputFormat;
+
+			setIsLoading(true);
+			setJob((prev) => ({ ...prev, error: null }));
+
+			try {
+				const response = await fetch(`${API_BASE}/api/job`, {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({
+						soundcloudUrl: trimmed,
+						skipAutomaticHypedditFetch,
+						outputFormat: format,
+					}),
+				});
+
+				const data = await response.json();
+
+				if (!response.ok) {
+					throw new Error(data.error || 'Failed to create job');
+				}
+
+				setJob((prev) => ({
+					...prev,
+					jobId: data.jobId,
+					track: data.track,
+					hypedditUrl: data.hypedditUrl,
+					defaultMetadata: data.defaultMetadata,
+					existingMetadata: null,
+					outputFormat: format,
+					error: null,
+				}));
+
+				if (data.defaultMetadata) {
+					setMetadata(data.defaultMetadata);
+				}
+
+				if (skipAutomaticHypedditFetch || data.needsHypedditUrl) {
+					setStep('hypeddit');
+				} else {
+					startDownload(data.jobId);
+				}
+			} catch (err) {
+				setJob((prev) => ({
+					...prev,
+					error: err instanceof Error ? err.message : 'Unknown error',
+				}));
+			} finally {
+				setIsLoading(false);
+			}
+		},
+		[skipAutomaticHypedditFetch, outputFormat, startDownload],
+	);
+
+	// Create job with SoundCloud URL
+	const handleSoundcloudSubmit = (e: React.FormEvent) => {
+		e.preventDefault();
+		void createJob(soundcloudUrl);
 	};
+
+	// Userscript / deep-link: ?url=&outputFormat= pre-fills and starts a job
+	useEffect(() => {
+		if (autoStartedFromQueryRef.current) return;
+		const params = new URLSearchParams(window.location.search);
+		let queryUrl = params.get('url') || params.get('soundcloudUrl');
+		if (!queryUrl) return;
+		autoStartedFromQueryRef.current = true;
+
+		// New SC listen layout may pass /n/artist/track — normalize to /artist/track
+		try {
+			const parsed = new URL(queryUrl);
+			const parts = parsed.pathname.split('/').filter(Boolean);
+			if (parts[0] === 'n' && parts.length >= 3) {
+				parsed.pathname = `/${parts[1]}/${parts[2]}`;
+				parsed.search = '';
+				parsed.hash = '';
+				queryUrl = parsed.toString();
+			}
+		} catch {
+			// keep queryUrl as-is
+		}
+
+		const formatParam = params.get('outputFormat');
+		const format: OutputFormat | undefined =
+			formatParam === 'original' || formatParam === 'mp3-320'
+				? formatParam
+				: undefined;
+		if (format) {
+			setOutputFormat(format);
+		}
+		setSoundcloudUrl(queryUrl);
+		void createJob(queryUrl, format);
+	}, [createJob]);
 
 	// Set Hypeddit URL and start download
 	const handleHypedditSubmit = async (e: React.FormEvent) => {
@@ -381,87 +573,6 @@ export default function App() {
 			setIsLoading(false);
 		}
 	};
-
-	// Start download process
-	const startDownload = useCallback(
-		async (jobId: string) => {
-			setStep('progress');
-			cleanupToastShownRef.current = false;
-
-			try {
-				const response = await fetch(`${API_BASE}/api/job/${jobId}/start`, {
-					method: 'POST',
-					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify({ headless: !headfulMode }),
-				});
-
-				if (!response.ok) {
-					const data = await response.json();
-					throw new Error(data.error || 'Failed to start download');
-				}
-
-				// Connect to SSE for progress updates
-				const eventSource = new EventSource(
-					`${API_BASE}/api/job/${jobId}/events`,
-				);
-
-				eventSource.onmessage = (event) => {
-					const progress: JobProgress = JSON.parse(event.data);
-					setJob((prev) => ({ ...prev, progress }));
-
-					// Browserless downloads never touch the SoundCloud account, so there
-					// is nothing to clean up afterwards.
-					if (
-						progress.stage === 'downloading' &&
-						(progress.downloadBytes || progress.totalBytes) &&
-						!progress.browserless &&
-						!cleanupToastShownRef.current
-					) {
-						showCleanupSoundcloudToast();
-						cleanupToastShownRef.current = true;
-					}
-
-					if (progress.stage === 'ready') {
-						eventSource.close();
-						fetch(`${API_BASE}/api/job/${jobId}`)
-							.then((res) => res.json())
-							.then((data) => {
-								setJob((prev) => ({
-									...prev,
-									downloadFilename: data.downloadFilename,
-									outputFilename: data.outputFilename,
-									existingMetadata: data.existingMetadata,
-									outputFormat: data.outputFormat,
-								}));
-								setStep(
-									data.outputFormat === 'original' ? 'complete' : 'metadata',
-								);
-							})
-							.catch((err) => {
-								setJob((prev) => ({
-									...prev,
-									error:
-										err instanceof Error ? err.message : 'Failed to load job',
-								}));
-							});
-					} else if (progress.stage === 'error') {
-						eventSource.close();
-						setJob((prev) => ({ ...prev, error: progress.message }));
-					}
-				};
-
-				eventSource.onerror = () => {
-					eventSource.close();
-				};
-			} catch (err) {
-				setJob((prev) => ({
-					...prev,
-					error: err instanceof Error ? err.message : 'Unknown error',
-				}));
-			}
-		},
-		[headfulMode, showCleanupSoundcloudToast],
-	);
 
 	// Process metadata and finalize
 	const processMetadata = async (preserveMetadata = false) => {
@@ -558,6 +669,7 @@ export default function App() {
 
 	// Reset and start over
 	const handleReset = () => {
+		notifyParent('new-download');
 		setSoundcloudUrl('');
 		setHypedditUrlInput('');
 		setSkipAutomaticHypedditFetch(false);
@@ -879,6 +991,13 @@ export default function App() {
 									</span>
 								)}
 						</div>
+						<button
+							type="button"
+							className="btn-secondary btn-cancel-download"
+							onClick={() => void cancelDownload()}
+						>
+							Cancel download
+						</button>
 					</div>
 				)}
 
@@ -1122,6 +1241,7 @@ export default function App() {
 								href={`${API_BASE}/api/job/${job.jobId}/file`}
 								download
 								className="btn-primary"
+								onClick={() => notifyParent('file-download')}
 							>
 								{job.outputFormat === 'original'
 									? 'Download Original'

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -978,6 +978,7 @@ export default function App() {
 									<input
 										type="file"
 										accept="image/*"
+										disabled={isLoading}
 										onChange={(e) =>
 											setCustomArtwork(e.target.files?.[0] || null)
 										}
@@ -1037,6 +1038,7 @@ export default function App() {
 													id={`meta-${key}`}
 													type="text"
 													value={currentValue}
+													disabled={isLoading}
 													onChange={(e) =>
 														setMetadata((prev) => ({
 															...prev,

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -407,6 +407,13 @@ export default function App() {
 		void processMetadata();
 	};
 
+	const defaultMetadataValues: Metadata = job.defaultMetadata ?? {
+		title: '',
+		artist: '',
+		album: '',
+		genre: '',
+	};
+
 	// Reset and start over
 	const handleReset = () => {
 		setSoundcloudUrl('');
@@ -743,37 +750,79 @@ export default function App() {
 								<div>
 									<h3>Existing MP3 Metadata</h3>
 									<p>
-										Copy these values into the form, or keep the file unchanged.
+										Copy a tag into the form, or keep the file’s tags unchanged
+										for the whole download.
 									</p>
 								</div>
-								<dl>
-									<dt>Title</dt>
-									<dd>{job.existingMetadata.title || 'Not set'}</dd>
-									<dt>Artist</dt>
-									<dd>{job.existingMetadata.artist || 'Not set'}</dd>
-									<dt>Album</dt>
-									<dd>{job.existingMetadata.album || 'Not set'}</dd>
-									<dt>Genre</dt>
-									<dd>{job.existingMetadata.genre || 'Not set'}</dd>
-								</dl>
-								<div className="existing-metadata-actions">
-									<button
-										type="button"
-										className="btn-secondary"
-										disabled={isLoading}
-										onClick={() => setMetadata(job.existingMetadata || {})}
-									>
-										Use Existing Values
-									</button>
-									<button
-										type="button"
-										className="btn-secondary"
-										disabled={isLoading}
-										onClick={() => void processMetadata(true)}
-									>
-										Leave Metadata As-Is
-									</button>
-								</div>
+								<ul className="existing-metadata-list">
+									{(
+										[
+											{ key: 'title', label: 'Title' },
+											{ key: 'artist', label: 'Artist' },
+											{ key: 'album', label: 'Album' },
+											{ key: 'genre', label: 'Genre' },
+										] as const
+									)
+										.map(({ key, label }) => ({
+											key,
+											label,
+											existingValue:
+												job.existingMetadata?.[key]?.trim() || '',
+										}))
+										.filter(({ existingValue }) => existingValue)
+										.map(({ key, label, existingValue }) => (
+											<li key={key} className="existing-metadata-row">
+												<span className="existing-metadata-label">
+													{label}
+												</span>
+												<span className="existing-metadata-value">
+													{existingValue}
+												</span>
+												<button
+													type="button"
+													className="btn-copy-existing"
+													disabled={isLoading}
+													title={`Copy ${label.toLowerCase()} into the form`}
+													aria-label={`Copy ${label.toLowerCase()} into the form`}
+													onClick={() =>
+														setMetadata((prev) => ({
+															...prev,
+															[key]: existingValue,
+														}))
+													}
+												>
+													<svg
+														viewBox="0 0 24 24"
+														width="14"
+														height="14"
+														aria-hidden="true"
+														fill="none"
+														stroke="currentColor"
+														strokeWidth="2"
+														strokeLinecap="round"
+														strokeLinejoin="round"
+													>
+														<rect
+															x="9"
+															y="9"
+															width="13"
+															height="13"
+															rx="2"
+														/>
+														<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+													</svg>
+												</button>
+											</li>
+										))}
+								</ul>
+								<button
+									type="button"
+									className="btn-secondary"
+									disabled={isLoading}
+									onClick={() => void processMetadata(true)}
+								>
+									Use this metadata as-is
+								</button>
 							</div>
 						)}
 						<div className="metadata-grid">
@@ -806,66 +855,85 @@ export default function App() {
 							</div>
 
 							<div className="fields-section">
-								<div className="form-group">
-									<label htmlFor="meta-title">Title</label>
-									<input
-										id="meta-title"
-										type="text"
-										value={metadata.title || ''}
-										onChange={(e) =>
-											setMetadata((prev) => ({
-												...prev,
-												title: e.target.value,
-											}))
-										}
-										placeholder="Track title"
-									/>
-								</div>
-								<div className="form-group">
-									<label htmlFor="meta-artist">Artist</label>
-									<input
-										id="meta-artist"
-										type="text"
-										value={metadata.artist || ''}
-										onChange={(e) =>
-											setMetadata((prev) => ({
-												...prev,
-												artist: e.target.value,
-											}))
-										}
-										placeholder="Artist name"
-									/>
-								</div>
-								<div className="form-group">
-									<label htmlFor="meta-album">Album</label>
-									<input
-										id="meta-album"
-										type="text"
-										value={metadata.album || ''}
-										onChange={(e) =>
-											setMetadata((prev) => ({
-												...prev,
-												album: e.target.value,
-											}))
-										}
-										placeholder="Album name"
-									/>
-								</div>
-								<div className="form-group">
-									<label htmlFor="meta-genre">Genre</label>
-									<input
-										id="meta-genre"
-										type="text"
-										value={metadata.genre || ''}
-										onChange={(e) =>
-											setMetadata((prev) => ({
-												...prev,
-												genre: e.target.value,
-											}))
-										}
-										placeholder="Genre"
-									/>
-								</div>
+								{(
+									[
+										{
+											key: 'title',
+											label: 'Title',
+											placeholder: 'Track title',
+										},
+										{
+											key: 'artist',
+											label: 'Artist',
+											placeholder: 'Artist name',
+										},
+										{
+											key: 'album',
+											label: 'Album',
+											placeholder: 'Album name',
+										},
+										{
+											key: 'genre',
+											label: 'Genre',
+											placeholder: 'Genre',
+										},
+									] as const
+								).map(({ key, label, placeholder }) => {
+									const currentValue = metadata[key] || '';
+									const defaultValue = defaultMetadataValues[key] || '';
+									const isDirty = currentValue !== defaultValue;
+									return (
+										<div className="form-group" key={key}>
+											<label htmlFor={`meta-${key}`}>{label}</label>
+											<div
+												className={`field-with-reset${isDirty ? ' has-reset' : ''}`}
+											>
+												<input
+													id={`meta-${key}`}
+													type="text"
+													value={currentValue}
+													onChange={(e) =>
+														setMetadata((prev) => ({
+															...prev,
+															[key]: e.target.value,
+														}))
+													}
+													placeholder={placeholder}
+												/>
+												{isDirty ? (
+													<button
+														type="button"
+														className="btn-reset-field"
+														disabled={isLoading}
+														title={`Reset ${label.toLowerCase()} to default`}
+														aria-label={`Reset ${label.toLowerCase()} to default`}
+														onClick={() =>
+															setMetadata((prev) => ({
+																...prev,
+																[key]: defaultValue,
+															}))
+														}
+													>
+														<svg
+															viewBox="0 0 24 24"
+															width="14"
+															height="14"
+															aria-hidden="true"
+															fill="none"
+															stroke="currentColor"
+															strokeWidth="2"
+															strokeLinecap="round"
+															strokeLinejoin="round"
+														>
+															<path d="M3 12a9 9 0 1 0 3-6.7" />
+															<path d="M3 4v5h5" />
+														</svg>
+													</button>
+												) : null}
+											</div>
+										</div>
+									);
+								})}
 							</div>
 						</div>
 

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -888,65 +888,53 @@ export default function App() {
 						onSubmit={handleMetadataSubmit}
 						className="form metadata-form animate-slide-up"
 					>
-						{job.existingMetadata && (
+						{existingTagRows.length > 0 ? (
 							<div className="existing-metadata">
-								{existingTagRows.length > 0 ? (
-									<>
-										<div>
-											<h3>Existing MP3 Metadata</h3>
-											<p>
-												Copy a tag into the form, or keep the file’s tags
-												unchanged for the whole download.
-											</p>
-										</div>
-										<ul className="existing-metadata-list">
-											{existingTagRows.map(({ key, label, existingValue }) => (
-												<li key={key} className="existing-metadata-row">
-													<span className="existing-metadata-label">
-														{label}
-													</span>
-													<span className="existing-metadata-value">
-														{existingValue}
-													</span>
-													<button
-														type="button"
-														className="btn-copy-existing"
-														disabled={isLoading}
-														title={`Copy ${label.toLowerCase()} into the form`}
-														aria-label={`Copy ${label.toLowerCase()} into the form`}
-														onClick={() =>
-															setMetadata((prev) => ({
-																...prev,
-																[key]: existingValue,
-															}))
-														}
-													>
-														<svg
-															viewBox="0 0 24 24"
-															width="14"
-															height="14"
-															aria-hidden="true"
-															fill="none"
-															stroke="currentColor"
-															strokeWidth="2"
-															strokeLinecap="round"
-															strokeLinejoin="round"
-														>
-															<rect
-																x="9"
-																y="9"
-																width="13"
-																height="13"
-																rx="2"
-															/>
-															<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-														</svg>
-													</button>
-												</li>
-											))}
-										</ul>
-									</>
-								) : null}
+								<div>
+									<h3>Existing MP3 Metadata</h3>
+									<p>
+										Copy a tag into the form, or keep the file’s tags unchanged
+										for the whole download.
+									</p>
+								</div>
+								<ul className="existing-metadata-list">
+									{existingTagRows.map(({ key, label, existingValue }) => (
+										<li key={key} className="existing-metadata-row">
+											<span className="existing-metadata-label">{label}</span>
+											<span className="existing-metadata-value">
+												{existingValue}
+											</span>
+											<button
+												type="button"
+												className="btn-copy-existing"
+												disabled={isLoading}
+												title={`Copy ${label.toLowerCase()} into the form`}
+												aria-label={`Copy ${label.toLowerCase()} into the form`}
+												onClick={() =>
+													setMetadata((prev) => ({
+														...prev,
+														[key]: existingValue,
+													}))
+												}
+											>
+												<svg
+													viewBox="0 0 24 24"
+													width="14"
+													height="14"
+													aria-hidden="true"
+													fill="none"
+													stroke="currentColor"
+													strokeWidth="2"
+													strokeLinecap="round"
+													strokeLinejoin="round"
+												>
+													<rect x="9" y="9" width="13" height="13" rx="2" />
+													<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+												</svg>
+											</button>
+										</li>
+									))}
+								</ul>
 								<button
 									type="button"
 									className="btn-secondary"
@@ -956,7 +944,7 @@ export default function App() {
 									Use this metadata as-is
 								</button>
 							</div>
-						)}
+						) : null}
 						<div className="metadata-grid">
 							<div className="artwork-section">
 								<div className="artwork-preview">

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -44,6 +44,119 @@ interface JobState {
 
 const API_BASE = 'http://localhost:3000';
 
+/** Promo fluff often glued onto SoundCloud / gate titles. */
+const PROMO_TAG =
+	String.raw`free\s*d(?:own)?l(?:oad)?s?|free[\s._-]*dl|freedl|out\s*now|premiere|exclusive`;
+
+function cleanPromoTags(value: string): string {
+	if (!value) return value;
+
+	let result = value;
+	result = result.replace(
+		new RegExp(String.raw`\s*[\[\(\{]\s*(?:${PROMO_TAG})\s*[\]\)\}]`, 'gi'),
+		' ',
+	);
+	result = result.replace(
+		new RegExp(
+			String.raw`(?:\s*[-–—|/·•]+\s*|\s+)(?:${PROMO_TAG})\s*$`,
+			'gi',
+		),
+		'',
+	);
+	result = result.replace(new RegExp(String.raw`(?:${PROMO_TAG})\s*$`, 'gi'), '');
+	result = result.replace(
+		new RegExp(
+			String.raw`^\s*(?:${PROMO_TAG})(?:\s*[-–—|/·•]+\s*|\s+)`,
+			'gi',
+		),
+		'',
+	);
+	result = result.replace(/\s{2,}/g, ' ');
+	result = result.replace(/^[\s\-–—|/·•]+|[\s\-–—|/·•]+$/g, '');
+	return result.trim();
+}
+
+/** Strip a leading `Artist - ` / `Artist — ` duplicate from the title. */
+function stripDuplicateArtistFromTitle(title: string, artist: string): string {
+	const trimmedArtist = artist.trim();
+	const trimmedTitle = title.trim();
+	if (!trimmedArtist || !trimmedTitle) return trimmedTitle;
+
+	const escaped = trimmedArtist.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	return trimmedTitle
+		.replace(new RegExp(String.raw`^${escaped}\s*[-–—|:]\s*`, 'i'), '')
+		.trim();
+}
+
+function cleanMetadataFields(meta: Metadata): Metadata {
+	const artist = cleanPromoTags(meta.artist || '');
+	const title = stripDuplicateArtistFromTitle(
+		cleanPromoTags(meta.title || ''),
+		artist,
+	);
+	return {
+		title,
+		artist,
+		album: cleanPromoTags(meta.album || ''),
+		genre: cleanPromoTags(meta.genre || ''),
+	};
+}
+
+function metadataNeedsCleanup(meta: Metadata): boolean {
+	const cleaned = cleanMetadataFields(meta);
+	return (
+		(meta.title || '') !== (cleaned.title || '') ||
+		(meta.artist || '') !== (cleaned.artist || '') ||
+		(meta.album || '') !== (cleaned.album || '') ||
+		(meta.genre || '') !== (cleaned.genre || '')
+	);
+}
+
+function sanitizeFilenamePart(value: string): string {
+	return value
+		.replace(/[<>:"/\\|?*]/g, '')
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+function artistTitleFilename(artist?: string, title?: string): string {
+	const safeArtist = sanitizeFilenamePart(artist || '') || 'Unknown Artist';
+	const safeTitle = sanitizeFilenamePart(title || '') || 'Unknown Title';
+	return `${safeArtist} - ${safeTitle}.mp3`;
+}
+
+function isLosslessFilename(filename: string): boolean {
+	const lower = filename.toLowerCase();
+	return (
+		lower.endsWith('.wav') ||
+		lower.endsWith('.aiff') ||
+		lower.endsWith('.aif') ||
+		lower.endsWith('.flac')
+	);
+}
+
+function previewProcessedFilename(
+	downloadFilename: string | null,
+	options: {
+		nameAsArtistTitle: boolean;
+		artist?: string;
+		title?: string;
+	},
+): string {
+	if (!downloadFilename) return '';
+	if (options.nameAsArtistTitle) {
+		return artistTitleFilename(options.artist, options.title);
+	}
+	if (isLosslessFilename(downloadFilename)) {
+		return downloadFilename
+			.replace(/\.wav$/i, '.mp3')
+			.replace(/\.aiff$/i, '.mp3')
+			.replace(/\.aif$/i, '.mp3')
+			.replace(/\.flac$/i, '.mp3');
+	}
+	return downloadFilename;
+}
+
 export default function App() {
 	const [step, setStep] = useState<Step>('url');
 	const [soundcloudUrl, setSoundcloudUrl] = useState('');
@@ -71,6 +184,7 @@ export default function App() {
 		genre: '',
 	});
 	const [customArtwork, setCustomArtwork] = useState<File | null>(null);
+	const [nameAsArtistTitle, setNameAsArtistTitle] = useState(false);
 	const [isLoading, setIsLoading] = useState(false);
 	const cleanupToastShownRef = useRef(false);
 	const formatPercent = (value?: number) => Math.round(value ?? 0);
@@ -362,7 +476,14 @@ export default function App() {
 				response = await fetch(`${API_BASE}/api/job/${job.jobId}/metadata`, {
 					method: 'POST',
 					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify({ preserveMetadata: true }),
+					body: JSON.stringify({
+						preserveMetadata: true,
+						nameAsArtistTitle,
+						title: metadata.title,
+						artist: metadata.artist,
+						album: metadata.album,
+						genre: metadata.genre,
+					}),
 				});
 			} else if (customArtwork) {
 				const formData = new FormData();
@@ -370,6 +491,7 @@ export default function App() {
 				formData.append('artist', metadata.artist || '');
 				formData.append('album', metadata.album || '');
 				formData.append('genre', metadata.genre || '');
+				formData.append('nameAsArtistTitle', String(nameAsArtistTitle));
 				formData.append('artwork', customArtwork);
 
 				response = await fetch(`${API_BASE}/api/job/${job.jobId}/metadata`, {
@@ -380,7 +502,7 @@ export default function App() {
 				response = await fetch(`${API_BASE}/api/job/${job.jobId}/metadata`, {
 					method: 'POST',
 					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify(metadata),
+					body: JSON.stringify({ ...metadata, nameAsArtistTitle }),
 				});
 			}
 
@@ -413,6 +535,12 @@ export default function App() {
 		album: '',
 		genre: '',
 	};
+	const canCleanupMetadata = metadataNeedsCleanup(metadata);
+	const outputFilenamePreview = previewProcessedFilename(job.downloadFilename, {
+		nameAsArtistTitle,
+		artist: metadata.artist,
+		title: metadata.title,
+	});
 	const existingTagRows = (
 		[
 			{ key: 'title', label: 'Title' },
@@ -448,6 +576,7 @@ export default function App() {
 		});
 		setMetadata({ title: '', artist: '', album: '', genre: '' });
 		setCustomArtwork(null);
+		setNameAsArtistTitle(false);
 		setStep('url');
 	};
 
@@ -855,6 +984,19 @@ export default function App() {
 									/>
 									<span>Change Artwork</span>
 								</label>
+								{canCleanupMetadata ? (
+									<button
+										type="button"
+										className="btn-secondary btn-auto-cleanup"
+										disabled={isLoading}
+										title="Remove promo tags like [FREE DL] and duplicate Artist - from the title"
+										onClick={() =>
+											setMetadata((prev) => cleanMetadataFields(prev))
+										}
+									>
+										Auto-Cleanup
+									</button>
+								) : null}
 							</div>
 
 							<div className="fields-section">
@@ -937,6 +1079,30 @@ export default function App() {
 										</div>
 									);
 								})}
+							</div>
+						</div>
+
+						<div className="filename-preview">
+							<label className="checkbox-row" htmlFor="name-as-artist-title">
+								<input
+									id="name-as-artist-title"
+									type="checkbox"
+									checked={nameAsArtistTitle}
+									disabled={isLoading}
+									onChange={(e) => setNameAsArtistTitle(e.target.checked)}
+								/>
+								<span>Name file as ARTIST - TITLE</span>
+							</label>
+							<div className="form-group">
+								<label htmlFor="output-filename-preview">Filename</label>
+								<input
+									id="output-filename-preview"
+									type="text"
+									className="filename-preview-input mono"
+									value={outputFilenamePreview}
+									disabled
+									readOnly
+								/>
 							</div>
 						</div>
 

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -92,7 +92,7 @@ function cleanPromoTags(value: string): string {
 	return result.trim();
 }
 
-/** Strip a leading `Artist - ` / `Artist — ` duplicate from the title. */
+/** Strip a leading/trailing `Artist - ` / ` - Artist` duplicate from the title. */
 function stripDuplicateArtistFromTitle(title: string, artist: string): string {
 	const trimmedArtist = artist.trim();
 	const trimmedTitle = title.trim();
@@ -101,6 +101,7 @@ function stripDuplicateArtistFromTitle(title: string, artist: string): string {
 	const escaped = trimmedArtist.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 	return trimmedTitle
 		.replace(new RegExp(String.raw`^${escaped}\s*[-–—|:]\s*`, 'i'), '')
+		.replace(new RegExp(String.raw`\s*[-–—|:]\s*${escaped}$`, 'i'), '')
 		.trim();
 }
 
@@ -1127,7 +1128,7 @@ export default function App() {
 										type="button"
 										className="btn-secondary btn-auto-cleanup"
 										disabled={isLoading}
-										title="Remove promo tags like [FREE DL] and duplicate Artist - from the title"
+										title="Remove promo tags like [FREE DL] and duplicate Artist - / - Artist from the title"
 										onClick={() =>
 											setMetadata((prev) => cleanMetadataFields(prev))
 										}

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -413,6 +413,20 @@ export default function App() {
 		album: '',
 		genre: '',
 	};
+	const existingTagRows = (
+		[
+			{ key: 'title', label: 'Title' },
+			{ key: 'artist', label: 'Artist' },
+			{ key: 'album', label: 'Album' },
+			{ key: 'genre', label: 'Genre' },
+		] as const
+	)
+		.map(({ key, label }) => ({
+			key,
+			label,
+			existingValue: job.existingMetadata?.[key]?.trim() || '',
+		}))
+		.filter(({ existingValue }) => existingValue);
 
 	// Reset and start over
 	const handleReset = () => {
@@ -747,74 +761,63 @@ export default function App() {
 					>
 						{job.existingMetadata && (
 							<div className="existing-metadata">
-								<div>
-									<h3>Existing MP3 Metadata</h3>
-									<p>
-										Copy a tag into the form, or keep the file’s tags unchanged
-										for the whole download.
-									</p>
-								</div>
-								<ul className="existing-metadata-list">
-									{(
-										[
-											{ key: 'title', label: 'Title' },
-											{ key: 'artist', label: 'Artist' },
-											{ key: 'album', label: 'Album' },
-											{ key: 'genre', label: 'Genre' },
-										] as const
-									)
-										.map(({ key, label }) => ({
-											key,
-											label,
-											existingValue:
-												job.existingMetadata?.[key]?.trim() || '',
-										}))
-										.filter(({ existingValue }) => existingValue)
-										.map(({ key, label, existingValue }) => (
-											<li key={key} className="existing-metadata-row">
-												<span className="existing-metadata-label">
-													{label}
-												</span>
-												<span className="existing-metadata-value">
-													{existingValue}
-												</span>
-												<button
-													type="button"
-													className="btn-copy-existing"
-													disabled={isLoading}
-													title={`Copy ${label.toLowerCase()} into the form`}
-													aria-label={`Copy ${label.toLowerCase()} into the form`}
-													onClick={() =>
-														setMetadata((prev) => ({
-															...prev,
-															[key]: existingValue,
-														}))
-													}
-												>
-													<svg
-														viewBox="0 0 24 24"
-														width="14"
-														height="14"
-														aria-hidden="true"
-														fill="none"
-														stroke="currentColor"
-														strokeWidth="2"
-														strokeLinecap="round"
-														strokeLinejoin="round"
+								{existingTagRows.length > 0 ? (
+									<>
+										<div>
+											<h3>Existing MP3 Metadata</h3>
+											<p>
+												Copy a tag into the form, or keep the file’s tags
+												unchanged for the whole download.
+											</p>
+										</div>
+										<ul className="existing-metadata-list">
+											{existingTagRows.map(({ key, label, existingValue }) => (
+												<li key={key} className="existing-metadata-row">
+													<span className="existing-metadata-label">
+														{label}
+													</span>
+													<span className="existing-metadata-value">
+														{existingValue}
+													</span>
+													<button
+														type="button"
+														className="btn-copy-existing"
+														disabled={isLoading}
+														title={`Copy ${label.toLowerCase()} into the form`}
+														aria-label={`Copy ${label.toLowerCase()} into the form`}
+														onClick={() =>
+															setMetadata((prev) => ({
+																...prev,
+																[key]: existingValue,
+															}))
+														}
 													>
-														<rect
-															x="9"
-															y="9"
-															width="13"
-															height="13"
-															rx="2"
-														/>
-														<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-													</svg>
-												</button>
-											</li>
-										))}
-								</ul>
+														<svg
+															viewBox="0 0 24 24"
+															width="14"
+															height="14"
+															aria-hidden="true"
+															fill="none"
+															stroke="currentColor"
+															strokeWidth="2"
+															strokeLinecap="round"
+															strokeLinejoin="round"
+														>
+															<rect
+																x="9"
+																y="9"
+																width="13"
+																height="13"
+																rx="2"
+															/>
+															<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+														</svg>
+													</button>
+												</li>
+											))}
+										</ul>
+									</>
+								) : null}
 								<button
 									type="button"
 									className="btn-secondary"

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -44,6 +44,14 @@ interface JobState {
 
 const API_BASE = 'http://localhost:3000';
 
+const ALLOWED_HOST_ORIGINS = new Set([
+	'https://soundcloud.com',
+	'https://www.soundcloud.com',
+	'https://m.soundcloud.com',
+	'http://localhost:4321',
+	'http://127.0.0.1:4321',
+]);
+
 function notifyParent(
 	type: 'file-download' | 'new-download' | 'job' | 'cancelled' | 'ready',
 	payload?: { jobId?: string },
@@ -351,10 +359,15 @@ export default function App() {
 				};
 
 				eventSource.onerror = () => {
+					if (eventSource.readyState === EventSource.CONNECTING) return;
 					eventSource.close();
 					if (eventSourceRef.current === eventSource) {
 						eventSourceRef.current = null;
 					}
+					setJob((prev) => ({
+						...prev,
+						error: 'Lost connection to download progress',
+					}));
 				};
 			} catch (err) {
 				setJob((prev) => ({
@@ -370,14 +383,30 @@ export default function App() {
 		const jobId = job.jobId;
 		if (!jobId) return;
 
+		try {
+			const response = await fetch(`${API_BASE}/api/job/${jobId}/cancel`, {
+				method: 'POST',
+			});
+			if (!response.ok) {
+				const data = await response.json().catch(() => ({}));
+				setJob((prev) => ({
+					...prev,
+					error:
+						(data as { error?: string }).error || 'Failed to cancel download',
+				}));
+				return;
+			}
+		} catch (err) {
+			setJob((prev) => ({
+				...prev,
+				error:
+					err instanceof Error ? err.message : 'Failed to cancel download',
+			}));
+			return;
+		}
+
 		eventSourceRef.current?.close();
 		eventSourceRef.current = null;
-
-		try {
-			await fetch(`${API_BASE}/api/job/${jobId}/cancel`, { method: 'POST' });
-		} catch (err) {
-			console.warn('Cancel request failed', err);
-		}
 
 		setJob((prev) => ({
 			...prev,
@@ -395,6 +424,7 @@ export default function App() {
 	// Parent userscript panel X → cancel in-progress job
 	useEffect(() => {
 		const onMessage = (event: MessageEvent) => {
+			if (!ALLOWED_HOST_ORIGINS.has(event.origin)) return;
 			const data = event.data;
 			if (!data || data.source !== 'sc-gate-dl-host') return;
 			if (data.type === 'cancel') {

--- a/webui/src/styles/global.css
+++ b/webui/src/styles/global.css
@@ -78,6 +78,13 @@ body {
 	background-attachment: fixed;
 }
 
+button,
+input,
+select,
+textarea {
+	font: inherit;
+}
+
 /* Typography */
 h1, h2, h3, h4, h5, h6 {
 	font-weight: 600;


### PR DESCRIPTION
## Summary
- Hypeddit: when the HTTP/browserless path fails (e.g. Spotify verification), automatically fall back to the browser using the job’s headless setting instead of dead-ending with a “retry headful” error (CLI + Web UI)
- Metadata: cleanup promo fluff (including trailing `- Artist` duplicates), filename preview, safer `ARTIST - TITLE` naming with collision protection, per-field copy/reset, and hide empty existing-tag UI
- Original downloads: pass SoundCloud cookies through to yt-dlp when available
- Userscript: Violentmonkey panel next to SoundCloud store/buy links that embeds the real Web UI (`?url=` / `outputFormat` deep-link), with format + auto-close menu options
- Queue: clicking download while the panel is open enqueues the track; a small draggable queue window (default top-left) lists pending items and auto-starts the next after the current download finishes
- Cancel: Web UI **Cancel download** and panel × / Escape stop an in-progress job and close CloakBrowser cleanly (`POST /api/job/:id/cancel`)

## Test plan
- [ ] Hypeddit gate that works via HTTP alone stays browserless
- [ ] Hypeddit gate that needs browser verification falls back automatically in headless and headful modes (CLI + Web UI)
- [ ] Metadata step: cleanup strips promo tags and both leading/trailing artist duplicates; filename preview and `ARTIST - TITLE` rename work; empty sections stay hidden
- [ ] Original format download uses cookies when SoundCloud session is available
- [ ] Install userscript → icon beside store/buy → floating panel loads Web UI and starts the track
- [ ] While a download panel is open, clicking another track adds it to the queue window (top-left); after finish/auto-close or Start New Download, the next queued track starts
- [ ] Queue × clears all; per-item × removes one; queue survives closing the main panel
- [ ] Cancel from Web UI during progress closes the browser; panel × / Escape does the same
- [ ] Auto-close after file download / Start New Download still works when enabled (and advances the queue when present)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added download cancellation with progress updates, cleanup, and restart support.
  - Added automatic metadata cleanup, field resets, and `ARTIST - TITLE` filename previews.
  - Added collision-safe filename handling.
  - Added SoundCloud original-download support using available cookies.
  - Added broader audio-to-MP3 conversion with bitrate-aware output.
  - Added a SoundCloud userscript with download controls, queue management, format selection, and floating-panel support.
  - Hypeddit downloads now fall back to browser verification after HTTP failures.

- **Documentation**
  - Added setup and usage instructions for the SoundCloud userscript and deep links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->