### PR TITLE
feat: improve feed tracking and gate handling

### DIFF
--- a/src/directDownload.ts
+++ b/src/directDownload.ts
@@ -59,6 +59,8 @@ async function writeBodyWithSizeLimit(
 	body: ReadableStream<Uint8Array>,
 	target: string,
 	maxBytes: number,
+	totalBytes: number,
+	onProgress: (receivedBytes: number, totalBytes: number) => void,
 ): Promise<void> {
 	const writer = Bun.file(target).writer();
 	const reader = body.getReader();
@@ -75,6 +77,9 @@ async function writeBodyWithSizeLimit(
 				);
 			}
 			writer.write(value);
+			if (totalBytes > 0) {
+				onProgress(total, totalBytes);
+			}
 		}
 		await writer.end();
 	} catch (error) {
@@ -156,8 +161,8 @@ export class DirectDownloader {
 		}
 
 		const contentLengthHeader = response.headers.get('content-length');
+		const contentLength = Number(contentLengthHeader) || 0;
 		if (contentLengthHeader) {
-			const contentLength = Number(contentLengthHeader);
 			if (
 				Number.isFinite(contentLength) &&
 				contentLength > MAX_DOWNLOAD_BYTES
@@ -188,7 +193,27 @@ export class DirectDownloader {
 		}
 
 		const target = join('./downloads', filename);
-		await writeBodyWithSizeLimit(response.body, target, MAX_DOWNLOAD_BYTES);
+		let lastProgressEmit = 0;
+		await writeBodyWithSizeLimit(
+			response.body,
+			target,
+			MAX_DOWNLOAD_BYTES,
+			contentLength,
+			(receivedBytes, totalBytes) => {
+				const now = Date.now();
+				if (now - lastProgressEmit < 250 && receivedBytes < totalBytes) return;
+				lastProgressEmit = now;
+				this.progressCallback?.(
+					'downloading',
+					`Downloading... ${(receivedBytes / 1024 / 1024).toFixed(1)} / ${(totalBytes / 1024 / 1024).toFixed(1)} MB`,
+					0,
+					{ downloadBytes: receivedBytes, totalBytes, browserless: true },
+				);
+			},
+		);
+		this.progressCallback?.('downloading', 'Download complete', 100, {
+			browserless: true,
+		});
 		console.log(`Saved ${filename}`);
 		return filename;
 	}

--- a/src/directDownload.ts
+++ b/src/directDownload.ts
@@ -103,7 +103,7 @@ export class DirectDownloader {
 	async downloadAudio(url: string): Promise<string> {
 		const downloadUrl = normalizeDirectDownloadUrl(url);
 		console.log(`Downloading direct file: ${downloadUrl}`);
-		this.progressCallback?.('downloading', 'Downloading direct file...', 40, {
+		this.progressCallback?.('downloading', 'Downloading direct file...', 0, {
 			browserless: true,
 		});
 

--- a/src/downloadgater.ts
+++ b/src/downloadgater.ts
@@ -603,7 +603,11 @@ export class DownloadgaterDownloader {
 	}
 
 	private async handleDownload(page: Page) {
-		this.emitProgress('downloading', 'Preparing DownloadGater download...', 75);
+		this.emitProgress(
+			'handling_gates',
+			'Preparing DownloadGater download...',
+			75,
+		);
 
 		const client = await page.createCDPSession();
 		await client.send('Browser.setDownloadBehavior', {

--- a/src/downloadgater.ts
+++ b/src/downloadgater.ts
@@ -266,24 +266,35 @@ export class DownloadgaterDownloader {
 	}
 
 	/**
-	 * Honor-system Spotify gate: open the requested Spotify page, close the new
-	 * tab, then confirm on DownloadGater. No Spotify OAuth is required.
+	 * Shared honor-system gate flow: open the requested social page, wait for
+	 * DownloadGater's confirmation, close the popup, and confirm completion.
 	 */
-	private async handleSpotifyStep(page: Page) {
-		for (let attempt = 0; attempt < 4; attempt++) {
-			if ((await this.detectPane(page)) !== 'spotify') return;
+	private async handleHonorSystemPopupStep(
+		page: Page,
+		options: {
+			pane: 'instagram' | 'spotify';
+			actionButtonPattern: string;
+			confirmButtonPattern: string;
+			popupUrlPattern: string;
+			maxAttempts: number;
+			confirmationTimeoutMs: number;
+		},
+	) {
+		for (let attempt = 0; attempt < options.maxAttempts; attempt++) {
+			if ((await this.detectPane(page)) !== options.pane) return;
+			if (await this.hasDownloadButton(page)) return;
 
 			const pagesBefore = new Set(await this.browser.pages(true));
-			const opened = await page.evaluate(() => {
+			const opened = await page.evaluate((pattern) => {
+				const actionPattern = new RegExp(pattern, 'i');
 				const btn = Array.from(document.querySelectorAll('button')).find(
 					(el) =>
-						/^(follow|save|open).*spotify$/i.test(
-							(el.textContent || '').trim(),
-						) && !(el as HTMLButtonElement).disabled,
+						actionPattern.test((el.textContent || '').trim()) &&
+						!(el as HTMLButtonElement).disabled,
 				) as HTMLButtonElement | undefined;
 				btn?.click();
 				return !!btn;
-			});
+			}, options.actionButtonPattern);
 
 			if (!opened) {
 				await timeout(500);
@@ -293,22 +304,33 @@ export class DownloadgaterDownloader {
 			let popup: Page | undefined;
 			const popupDeadline = Date.now() + 8_000;
 			while (!popup && Date.now() < popupDeadline) {
-				popup = (await this.browser.pages(true)).find(
-					(candidate) => candidate !== page && !pagesBefore.has(candidate),
+				const pages = await this.browser.pages(true);
+				popup = pages.find(
+					(candidate) =>
+						candidate !== page &&
+						!pagesBefore.has(candidate) &&
+						candidate.url() !== 'about:blank',
+				);
+				popup ??= pages.find(
+					(candidate) =>
+						candidate !== page &&
+						new RegExp(options.popupUrlPattern, 'i').test(candidate.url()),
 				);
 				if (!popup) await timeout(200);
 			}
 
 			await page
 				.waitForFunction(
-					() =>
-						Array.from(document.querySelectorAll('button')).some(
+					(pattern) => {
+						const confirmPattern = new RegExp(pattern, 'i');
+						return Array.from(document.querySelectorAll('button')).some(
 							(el) =>
-								/^(i followed|i saved it|i opened it|i['’]?(?:ve)? done it)$/i.test(
-									(el.textContent || '').trim(),
-								) && !(el as HTMLButtonElement).disabled,
-						),
-					{ timeout: 8_000 },
+								confirmPattern.test((el.textContent || '').trim()) &&
+								!(el as HTMLButtonElement).disabled,
+						);
+					},
+					{ timeout: options.confirmationTimeoutMs },
+					options.confirmButtonPattern,
 				)
 				.catch(() => {});
 
@@ -316,24 +338,37 @@ export class DownloadgaterDownloader {
 				await popup.close().catch(() => {});
 			}
 
-			const confirmed = await page.evaluate(() => {
+			const confirmed = await page.evaluate((pattern) => {
+				const confirmPattern = new RegExp(pattern, 'i');
 				const btn = Array.from(document.querySelectorAll('button')).find(
 					(el) =>
-						/^(i followed|i saved it|i opened it|i['’]?(?:ve)? done it)$/i.test(
-							(el.textContent || '').trim(),
-						) && !(el as HTMLButtonElement).disabled,
+						confirmPattern.test((el.textContent || '').trim()) &&
+						!(el as HTMLButtonElement).disabled,
 				) as HTMLButtonElement | undefined;
 				btn?.click();
 				return !!btn;
-			});
+			}, options.confirmButtonPattern);
 
-			if (confirmed) await timeout(800);
-			if ((await this.detectPane(page)) !== 'spotify') return;
+			await timeout(confirmed ? 800 : 500);
+			if ((await this.detectPane(page)) !== options.pane) return;
 		}
 
 		throw new Error(
-			'DownloadGater Spotify step did not advance. Allow popups and retry.',
+			`DownloadGater ${options.pane} step did not advance. Allow popups and retry.`,
 		);
+	}
+
+	/** Honor-system Spotify gate; no Spotify OAuth is required. */
+	private async handleSpotifyStep(page: Page) {
+		await this.handleHonorSystemPopupStep(page, {
+			pane: 'spotify',
+			actionButtonPattern: '^(follow|save|open).*spotify$',
+			confirmButtonPattern:
+				"^(i followed|i saved it|i opened it|i['’]?(?:ve)? done it)$",
+			popupUrlPattern: 'open\\.spotify\\.com',
+			maxAttempts: 4,
+			confirmationTimeoutMs: 8_000,
+		});
 	}
 
 	private async clickUnlockFinishIfPresent(page: Page): Promise<boolean> {
@@ -361,76 +396,14 @@ export class DownloadgaterDownloader {
 	 * timer, then confirm. Multiple IG targets are served one at a time.
 	 */
 	private async handleInstagramStep(page: Page) {
-		for (let attempt = 0; attempt < 8; attempt++) {
-			if ((await this.detectPane(page)) !== 'instagram') return;
-			if (await this.hasDownloadButton(page)) return;
-
-			const pagesBefore = new Set(await this.browser.pages(true));
-
-			const followClicked = await page.evaluate(() => {
-				const btn = Array.from(document.querySelectorAll('button')).find(
-					(el) =>
-						/follow on instagram/i.test(el.textContent || '') &&
-						!(el as HTMLButtonElement).disabled,
-				) as HTMLButtonElement | undefined;
-				btn?.click();
-				return !!btn;
-			});
-
-			if (followClicked) {
-				let popup: Page | undefined;
-				const started = Date.now();
-				while (!popup && Date.now() - started < 8_000) {
-					const pages = await this.browser.pages(true);
-					popup = pages.find(
-						(candidate) =>
-							candidate !== page &&
-							!pagesBefore.has(candidate) &&
-							candidate.url() !== 'about:blank',
-					);
-					if (!popup) {
-						popup = pages.find(
-							(candidate) =>
-								candidate !== page && /instagram\.com/i.test(candidate.url()),
-						);
-					}
-					if (!popup) await timeout(200);
-				}
-
-				// Site unlocks after ~5s with the popup open.
-				await timeout(5_500);
-
-				if (popup && !popup.isClosed()) {
-					try {
-						await popup.close();
-					} catch {
-						// ignore
-					}
-				}
-			}
-
-			const confirmed = await page.evaluate(() => {
-				const btn = Array.from(document.querySelectorAll('button')).find(
-					(el) =>
-						/^(i followed|i opened it)$/i.test((el.textContent || '').trim()) &&
-						!(el as HTMLButtonElement).disabled,
-				) as HTMLButtonElement | undefined;
-				btn?.click();
-				return !!btn;
-			});
-
-			if (confirmed) {
-				await timeout(800);
-			} else {
-				await timeout(500);
-			}
-
-			if ((await this.detectPane(page)) !== 'instagram') return;
-		}
-
-		throw new Error(
-			'DownloadGater Instagram step did not advance. Allow popups and retry.',
-		);
+		await this.handleHonorSystemPopupStep(page, {
+			pane: 'instagram',
+			actionButtonPattern: 'follow on instagram',
+			confirmButtonPattern: '^(i followed|i opened it)$',
+			popupUrlPattern: 'instagram\\.com',
+			maxAttempts: 8,
+			confirmationTimeoutMs: 8_000,
+		});
 	}
 
 	private async handleSoundcloudConnect(page: Page) {
@@ -727,7 +700,7 @@ export class DownloadgaterDownloader {
 			this.emitProgress(
 				'downloading',
 				`Downloading ${this.downloadFilename}...`,
-				76,
+				0,
 			);
 		});
 
@@ -736,7 +709,7 @@ export class DownloadgaterDownloader {
 			if (event.state === 'completed') {
 				pBar.stop();
 				console.log('Download completed');
-				this.emitProgress('downloading', 'Download complete', 85);
+				this.emitProgress('downloading', 'Download complete', 100);
 				downloadCompleteResolve(this.downloadFilename);
 			} else if (event.state === 'inProgress') {
 				const { receivedBytes, totalBytes } = event;
@@ -748,11 +721,12 @@ export class DownloadgaterDownloader {
 				} else {
 					pBar.start(totalBytes, receivedBytes, { prefix: 'Downloading' });
 				}
-				const downloadPercent = totalBytes > 0 ? receivedBytes / totalBytes : 0;
+				const downloadPercent =
+					totalBytes > 0 ? (receivedBytes / totalBytes) * 100 : 0;
 				this.emitProgress(
 					'downloading',
 					`Downloading... ${(receivedBytes / 1024 / 1024).toFixed(1)} / ${(totalBytes / 1024 / 1024).toFixed(1)} MB`,
-					76 + downloadPercent * 8,
+					downloadPercent,
 					{ downloadBytes: receivedBytes, totalBytes },
 				);
 			} else if (event.state === 'canceled') {

--- a/src/downloadgater.ts
+++ b/src/downloadgater.ts
@@ -314,6 +314,7 @@ export class DownloadgaterDownloader {
 				popup ??= pages.find(
 					(candidate) =>
 						candidate !== page &&
+						!pagesBefore.has(candidate) &&
 						new RegExp(options.popupUrlPattern, 'i').test(candidate.url()),
 				);
 				if (!popup) await timeout(200);
@@ -721,12 +722,10 @@ export class DownloadgaterDownloader {
 				} else {
 					pBar.start(totalBytes, receivedBytes, { prefix: 'Downloading' });
 				}
-				const downloadPercent =
-					totalBytes > 0 ? (receivedBytes / totalBytes) * 100 : 0;
 				this.emitProgress(
 					'downloading',
 					`Downloading... ${(receivedBytes / 1024 / 1024).toFixed(1)} / ${(totalBytes / 1024 / 1024).toFixed(1)} MB`,
-					downloadPercent,
+					0,
 					{ downloadBytes: receivedBytes, totalBytes },
 				);
 			} else if (event.state === 'canceled') {

--- a/src/downloadgater.ts
+++ b/src/downloadgater.ts
@@ -83,85 +83,88 @@ export class DownloadgaterDownloader {
 		);
 
 		const page = await this.browser.newPage();
-		await page.setViewport({ width: 1920, height: 1080 });
-		await page.goto(url, { waitUntil: 'domcontentloaded' });
 		try {
-			await page.waitForNetworkIdle({ timeout: 15_000, idleTime: 10 });
-		} catch {
-			// continue
-		}
-
-		await this.clickFreeDownload(page);
-
-		let soundcloudAttempted = false;
-		const deadline = Date.now() + 180_000;
-		while (Date.now() < deadline) {
-			if (await this.hasDownloadButton(page)) break;
-
-			// Post-OAuth UI can show "Verified unlock" / Finish before Download file.
-			await this.clickUnlockFinishIfPresent(page);
-			if (await this.hasDownloadButton(page)) break;
-
-			const pane = await this.detectPane(page);
-			console.log('DownloadGater pane:', pane);
-
-			if (pane === 'instagram') {
-				this.emitProgress(
-					'handling_gates',
-					'Handling DownloadGater Instagram follows...',
-					40,
-					{ currentGate: 'ig' },
-				);
-				await this.handleInstagramStep(page);
-				continue;
+			await page.setViewport({ width: 1920, height: 1080 });
+			await page.goto(url, { waitUntil: 'domcontentloaded' });
+			try {
+				await page.waitForNetworkIdle({ timeout: 15_000, idleTime: 10 });
+			} catch {
+				// continue
 			}
 
-			if (pane === 'soundcloud') {
-				if (soundcloudAttempted) {
-					const urlError = await this.readSoundcloudUrlError(page);
-					if (urlError) {
-						throw new Error(
-							`DownloadGater SoundCloud unlock failed: ${urlError}`,
-						);
-					}
-					// Still hydrating unlock → Download file; do not re-click Connect.
-					await timeout(500);
+			await this.clickFreeDownload(page);
+
+			let soundcloudAttempted = false;
+			const deadline = Date.now() + 180_000;
+			while (Date.now() < deadline) {
+				if (await this.hasDownloadButton(page)) break;
+
+				// Post-OAuth UI can show "Verified unlock" / Finish before Download file.
+				await this.clickUnlockFinishIfPresent(page);
+				if (await this.hasDownloadButton(page)) break;
+
+				const pane = await this.detectPane(page);
+				console.log('DownloadGater pane:', pane);
+
+				if (pane === 'instagram') {
+					this.emitProgress(
+						'handling_gates',
+						'Handling DownloadGater Instagram follows...',
+						40,
+						{ currentGate: 'ig' },
+					);
+					await this.handleInstagramStep(page);
 					continue;
 				}
-				soundcloudAttempted = true;
-				this.emitProgress(
-					'handling_gates',
-					'Connecting SoundCloud on DownloadGater...',
-					55,
-					{ currentGate: 'sc' },
-				);
-				await this.handleSoundcloudConnect(page);
-				continue;
+
+				if (pane === 'soundcloud') {
+					if (soundcloudAttempted) {
+						const urlError = await this.readSoundcloudUrlError(page);
+						if (urlError) {
+							throw new Error(
+								`DownloadGater SoundCloud unlock failed: ${urlError}`,
+							);
+						}
+						// Still hydrating unlock → Download file; do not re-click Connect.
+						await timeout(500);
+						continue;
+					}
+					soundcloudAttempted = true;
+					this.emitProgress(
+						'handling_gates',
+						'Connecting SoundCloud on DownloadGater...',
+						55,
+						{ currentGate: 'sc' },
+					);
+					await this.handleSoundcloudConnect(page);
+					continue;
+				}
+
+				if (pane === 'spotify') {
+					this.emitProgress(
+						'handling_gates',
+						'Handling DownloadGater Spotify step...',
+						35,
+						{ currentGate: 'sp' },
+					);
+					await this.handleSpotifyStep(page);
+					continue;
+				}
+
+				await timeout(500);
 			}
 
-			if (pane === 'spotify') {
-				this.emitProgress(
-					'handling_gates',
-					'Handling DownloadGater Spotify step...',
-					35,
-					{ currentGate: 'sp' },
+			if (!(await this.hasDownloadButton(page))) {
+				throw new Error(
+					'DownloadGater download button never appeared after completing gates.',
 				);
-				await this.handleSpotifyStep(page);
-				continue;
 			}
 
-			await timeout(500);
+			await this.handleDownload(page);
+			return this.downloadFilename;
+		} finally {
+			await page.close().catch(() => {});
 		}
-
-		if (!(await this.hasDownloadButton(page))) {
-			throw new Error(
-				'DownloadGater download button never appeared after completing gates.',
-			);
-		}
-
-		await this.handleDownload(page);
-		await page.close();
-		return this.downloadFilename;
 	}
 
 	async close() {
@@ -280,6 +283,7 @@ export class DownloadgaterDownloader {
 			confirmationTimeoutMs: number;
 		},
 	) {
+		const popupUrlPattern = new RegExp(options.popupUrlPattern, 'i');
 		for (let attempt = 0; attempt < options.maxAttempts; attempt++) {
 			if ((await this.detectPane(page)) !== options.pane) return;
 			if (await this.hasDownloadButton(page)) return;
@@ -309,15 +313,13 @@ export class DownloadgaterDownloader {
 					(candidate) =>
 						candidate !== page &&
 						!pagesBefore.has(candidate) &&
-						candidate.url() !== 'about:blank',
-				);
-				popup ??= pages.find(
-					(candidate) =>
-						candidate !== page &&
-						!pagesBefore.has(candidate) &&
-						new RegExp(options.popupUrlPattern, 'i').test(candidate.url()),
+						popupUrlPattern.test(candidate.url()),
 				);
 				if (!popup) await timeout(200);
+			}
+			if (!popup) {
+				await timeout(500);
+				continue;
 			}
 
 			await page

--- a/src/downloadgater.ts
+++ b/src/downloadgater.ts
@@ -140,9 +140,14 @@ export class DownloadgaterDownloader {
 			}
 
 			if (pane === 'spotify') {
-				throw new Error(
-					'This DownloadGater gate requires Spotify OAuth, which is not supported yet.',
+				this.emitProgress(
+					'handling_gates',
+					'Handling DownloadGater Spotify step...',
+					35,
+					{ currentGate: 'sp' },
 				);
+				await this.handleSpotifyStep(page);
+				continue;
 			}
 
 			await timeout(500);
@@ -257,6 +262,77 @@ export class DownloadgaterDownloader {
 			Array.from(document.querySelectorAll('button')).some((btn) =>
 				/^(download file|download zip)$/i.test((btn.textContent || '').trim()),
 			),
+		);
+	}
+
+	/**
+	 * Honor-system Spotify gate: open the requested Spotify page, close the new
+	 * tab, then confirm on DownloadGater. No Spotify OAuth is required.
+	 */
+	private async handleSpotifyStep(page: Page) {
+		for (let attempt = 0; attempt < 4; attempt++) {
+			if ((await this.detectPane(page)) !== 'spotify') return;
+
+			const pagesBefore = new Set(await this.browser.pages(true));
+			const opened = await page.evaluate(() => {
+				const btn = Array.from(document.querySelectorAll('button')).find(
+					(el) =>
+						/^(follow|save|open).*spotify$/i.test(
+							(el.textContent || '').trim(),
+						) && !(el as HTMLButtonElement).disabled,
+				) as HTMLButtonElement | undefined;
+				btn?.click();
+				return !!btn;
+			});
+
+			if (!opened) {
+				await timeout(500);
+				continue;
+			}
+
+			let popup: Page | undefined;
+			const popupDeadline = Date.now() + 8_000;
+			while (!popup && Date.now() < popupDeadline) {
+				popup = (await this.browser.pages(true)).find(
+					(candidate) => candidate !== page && !pagesBefore.has(candidate),
+				);
+				if (!popup) await timeout(200);
+			}
+
+			await page
+				.waitForFunction(
+					() =>
+						Array.from(document.querySelectorAll('button')).some(
+							(el) =>
+								/^(i followed|i saved it|i opened it|i['’]?(?:ve)? done it)$/i.test(
+									(el.textContent || '').trim(),
+								) && !(el as HTMLButtonElement).disabled,
+						),
+					{ timeout: 8_000 },
+				)
+				.catch(() => {});
+
+			if (popup && !popup.isClosed()) {
+				await popup.close().catch(() => {});
+			}
+
+			const confirmed = await page.evaluate(() => {
+				const btn = Array.from(document.querySelectorAll('button')).find(
+					(el) =>
+						/^(i followed|i saved it|i opened it|i['’]?(?:ve)? done it)$/i.test(
+							(el.textContent || '').trim(),
+						) && !(el as HTMLButtonElement).disabled,
+				) as HTMLButtonElement | undefined;
+				btn?.click();
+				return !!btn;
+			});
+
+			if (confirmed) await timeout(800);
+			if ((await this.detectPane(page)) !== 'spotify') return;
+		}
+
+		throw new Error(
+			'DownloadGater Spotify step did not advance. Allow popups and retry.',
 		);
 	}
 

--- a/src/droploud.ts
+++ b/src/droploud.ts
@@ -1921,7 +1921,7 @@ export class DroploudDownloader {
 			this.emitProgress(
 				'downloading',
 				`Downloading ${this.downloadFilename}...`,
-				76,
+				0,
 			);
 		});
 
@@ -1930,7 +1930,7 @@ export class DroploudDownloader {
 			if (event.state === 'completed') {
 				pBar.stop();
 				console.log('Download completed');
-				this.emitProgress('downloading', 'Download complete', 85);
+				this.emitProgress('downloading', 'Download complete', 100);
 				downloadCompleteResolve(this.downloadFilename);
 			} else if (event.state === 'inProgress') {
 				const { receivedBytes, totalBytes } = event;
@@ -1942,11 +1942,12 @@ export class DroploudDownloader {
 				} else {
 					pBar.start(totalBytes, receivedBytes, { prefix: 'Downloading' });
 				}
-				const downloadPercent = totalBytes > 0 ? receivedBytes / totalBytes : 0;
+				const downloadPercent =
+					totalBytes > 0 ? (receivedBytes / totalBytes) * 100 : 0;
 				this.emitProgress(
 					'downloading',
 					`Downloading... ${(receivedBytes / 1024 / 1024).toFixed(1)} / ${(totalBytes / 1024 / 1024).toFixed(1)} MB`,
-					76 + downloadPercent * 8,
+					downloadPercent,
 					{ downloadBytes: receivedBytes, totalBytes },
 				);
 			} else if (event.state === 'canceled') {

--- a/src/droploud.ts
+++ b/src/droploud.ts
@@ -1942,12 +1942,10 @@ export class DroploudDownloader {
 				} else {
 					pBar.start(totalBytes, receivedBytes, { prefix: 'Downloading' });
 				}
-				const downloadPercent =
-					totalBytes > 0 ? (receivedBytes / totalBytes) * 100 : 0;
 				this.emitProgress(
 					'downloading',
 					`Downloading... ${(receivedBytes / 1024 / 1024).toFixed(1)} / ${(totalBytes / 1024 / 1024).toFixed(1)} MB`,
-					downloadPercent,
+					0,
 					{ downloadBytes: receivedBytes, totalBytes },
 				);
 			} else if (event.state === 'canceled') {

--- a/src/droploud.ts
+++ b/src/droploud.ts
@@ -1877,7 +1877,7 @@ export class DroploudDownloader {
 	}
 
 	private async handleDownload(page: Page) {
-		this.emitProgress('downloading', 'Preparing Droploud download...', 75);
+		this.emitProgress('handling_gates', 'Preparing Droploud download...', 75);
 
 		const client = await page.createCDPSession();
 		await client.send('Browser.setDownloadBehavior', {

--- a/src/gaterush.ts
+++ b/src/gaterush.ts
@@ -551,7 +551,7 @@ export class GaterushDownloader {
 			this.emitProgress(
 				'downloading',
 				`Downloading ${this.downloadFilename}...`,
-				76,
+				0,
 			);
 		});
 
@@ -560,7 +560,7 @@ export class GaterushDownloader {
 			if (event.state === 'completed') {
 				pBar.stop();
 				console.log('Download completed');
-				this.emitProgress('downloading', 'Download complete', 85);
+				this.emitProgress('downloading', 'Download complete', 100);
 				downloadCompleteResolve(this.downloadFilename);
 			} else if (event.state === 'inProgress') {
 				const { receivedBytes, totalBytes } = event;
@@ -572,11 +572,12 @@ export class GaterushDownloader {
 				} else {
 					pBar.start(totalBytes, receivedBytes, { prefix: 'Downloading' });
 				}
-				const downloadPercent = totalBytes > 0 ? receivedBytes / totalBytes : 0;
+				const downloadPercent =
+					totalBytes > 0 ? (receivedBytes / totalBytes) * 100 : 0;
 				this.emitProgress(
 					'downloading',
 					`Downloading... ${(receivedBytes / 1024 / 1024).toFixed(1)} / ${(totalBytes / 1024 / 1024).toFixed(1)} MB`,
-					76 + downloadPercent * 8,
+					downloadPercent,
 					{ downloadBytes: receivedBytes, totalBytes },
 				);
 			} else if (event.state === 'canceled') {

--- a/src/gaterush.ts
+++ b/src/gaterush.ts
@@ -507,7 +507,7 @@ export class GaterushDownloader {
 	}
 
 	private async handleDownload(page: Page) {
-		this.emitProgress('downloading', 'Preparing GateRush download...', 75);
+		this.emitProgress('handling_gates', 'Preparing GateRush download...', 75);
 
 		const client = await page.createCDPSession();
 		await client.send('Browser.setDownloadBehavior', {

--- a/src/gaterush.ts
+++ b/src/gaterush.ts
@@ -572,12 +572,10 @@ export class GaterushDownloader {
 				} else {
 					pBar.start(totalBytes, receivedBytes, { prefix: 'Downloading' });
 				}
-				const downloadPercent =
-					totalBytes > 0 ? (receivedBytes / totalBytes) * 100 : 0;
 				this.emitProgress(
 					'downloading',
 					`Downloading... ${(receivedBytes / 1024 / 1024).toFixed(1)} / ${(totalBytes / 1024 / 1024).toFixed(1)} MB`,
-					downloadPercent,
+					0,
 					{ downloadBytes: receivedBytes, totalBytes },
 				);
 			} else if (event.state === 'canceled') {

--- a/src/hypeddit.ts
+++ b/src/hypeddit.ts
@@ -649,7 +649,7 @@ export class HypedditDownloader {
 			throw new Error('Download button not found');
 		}
 		console.log('Download button found, setting up CDP session...');
-		this.emitProgress('downloading', 'Preparing download...', 75);
+		this.emitProgress('handling_gates', 'Preparing download...', 75);
 
 		// configure CDP session to allow monitoring download events
 		const client = await page.createCDPSession();

--- a/src/hypeddit.ts
+++ b/src/hypeddit.ts
@@ -715,12 +715,10 @@ export class HypedditDownloader {
 						pBar.start(totalBytes, receivedBytes, { prefix: 'Downloading' });
 					}
 
-					const downloadPercent =
-						totalBytes > 0 ? (receivedBytes / totalBytes) * 100 : 0;
 					this.emitProgress(
 						'downloading',
 						`Downloading... ${(receivedBytes / 1024 / 1024).toFixed(1)} / ${(totalBytes / 1024 / 1024).toFixed(1)} MB`,
-						downloadPercent,
+						0,
 						{
 							downloadBytes: receivedBytes,
 							totalBytes: totalBytes,

--- a/src/hypeddit.ts
+++ b/src/hypeddit.ts
@@ -691,7 +691,7 @@ export class HypedditDownloader {
 			this.emitProgress(
 				'downloading',
 				`Downloading ${this.downloadFilename}...`,
-				76,
+				0,
 			);
 		});
 
@@ -701,7 +701,7 @@ export class HypedditDownloader {
 				if (event.state === 'completed') {
 					pBar.stop();
 					console.log('Download completed');
-					this.emitProgress('downloading', 'Download complete', 85);
+					this.emitProgress('downloading', 'Download complete', 100);
 					downloadCompleteResolve(this.downloadFilename);
 				} else if (event.state === 'inProgress') {
 					const { receivedBytes, totalBytes } = event;
@@ -716,12 +716,11 @@ export class HypedditDownloader {
 					}
 
 					const downloadPercent =
-						totalBytes > 0 ? receivedBytes / totalBytes : 0;
-					const scaledPercent = 76 + downloadPercent * 8;
+						totalBytes > 0 ? (receivedBytes / totalBytes) * 100 : 0;
 					this.emitProgress(
 						'downloading',
 						`Downloading... ${(receivedBytes / 1024 / 1024).toFixed(1)} / ${(totalBytes / 1024 / 1024).toFixed(1)} MB`,
-						scaledPercent,
+						downloadPercent,
 						{
 							downloadBytes: receivedBytes,
 							totalBytes: totalBytes,

--- a/src/hypedditHttp.ts
+++ b/src/hypedditHttp.ts
@@ -246,7 +246,7 @@ export class HypedditHttpDownloader {
 	}
 
 	private async saveFile(downloadUrl: string): Promise<string> {
-		this.progressCallback?.('downloading', 'Downloading file...', 76);
+		this.progressCallback?.('downloading', 'Downloading file...', 0);
 		const response = await fetch(downloadUrl, {
 			signal: this.abortController.signal,
 		});
@@ -288,11 +288,10 @@ export class HypedditHttpDownloader {
 					const now = Date.now();
 					if (now - lastEmit > 250 && totalBytes > 0) {
 						lastEmit = now;
-						const downloadPercent = receivedBytes / totalBytes;
 						this.progressCallback?.(
 							'downloading',
 							`Downloading... ${(receivedBytes / 1024 / 1024).toFixed(1)} / ${(totalBytes / 1024 / 1024).toFixed(1)} MB`,
-							76 + downloadPercent * 8,
+							(receivedBytes / totalBytes) * 100,
 							{ downloadBytes: receivedBytes, totalBytes, browserless: true },
 						);
 					}
@@ -316,7 +315,7 @@ export class HypedditHttpDownloader {
 		}
 
 		console.log(`Browserless: downloaded ${filename}`);
-		this.progressCallback?.('downloading', 'Download complete', 85);
+		this.progressCallback?.('downloading', 'Download complete', 100);
 		return filename;
 	}
 

--- a/src/hypedditHttp.ts
+++ b/src/hypedditHttp.ts
@@ -291,7 +291,7 @@ export class HypedditHttpDownloader {
 						this.progressCallback?.(
 							'downloading',
 							`Downloading... ${(receivedBytes / 1024 / 1024).toFixed(1)} / ${(totalBytes / 1024 / 1024).toFixed(1)} MB`,
-							(receivedBytes / totalBytes) * 100,
+							0,
 							{ downloadBytes: receivedBytes, totalBytes, browserless: true },
 						);
 					}

--- a/src/server.ts
+++ b/src/server.ts
@@ -216,8 +216,6 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 						100,
 						Math.max(0, (extra.downloadBytes / extra.totalBytes) * 100),
 					);
-				} else {
-					stagePercent = /download complete/i.test(message) ? 100 : 0;
 				}
 			}
 			jobStore.updateProgress(jobId, stage, message, stagePercent, extra);
@@ -248,8 +246,10 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 			const sourceLabel = provider === 'bandcamp' ? 'Bandcamp' : 'SoundCloud';
 			jobStore.updateProgress(
 				jobId,
-				'downloading',
-				`Downloading from ${sourceLabel} via yt-dlp...`,
+				provider === 'bandcamp' ? 'handling_gates' : 'downloading',
+				provider === 'bandcamp'
+					? 'Resolving Bandcamp track...'
+					: 'Downloading from SoundCloud via yt-dlp...',
 				0,
 				{ browserless: true },
 			);
@@ -288,8 +288,8 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 						jobStore.update(jobId, { bandcampAlbumTracks: null });
 						jobStore.updateProgress(
 							jobId,
-							'downloading',
-							`Downloading from ${sourceLabel} via yt-dlp...`,
+							'handling_gates',
+							'Resolving selected Bandcamp track...',
 							0,
 							{ browserless: true },
 						);

--- a/src/server.ts
+++ b/src/server.ts
@@ -205,7 +205,22 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 			extra?: Partial<Job['progress']>,
 		) => {
 			if (jobStore.isCancelled(jobId)) return;
-			jobStore.updateProgress(jobId, stage, message, percent, extra);
+			let stagePercent = percent;
+			if (stage === 'downloading') {
+				if (
+					extra?.downloadBytes !== undefined &&
+					extra.totalBytes !== undefined &&
+					extra.totalBytes > 0
+				) {
+					stagePercent = Math.min(
+						100,
+						Math.max(0, (extra.downloadBytes / extra.totalBytes) * 100),
+					);
+				} else {
+					stagePercent = /download complete/i.test(message) ? 100 : 0;
+				}
+			}
+			jobStore.updateProgress(jobId, stage, message, stagePercent, extra);
 		};
 
 		const gateConfigBase = {
@@ -235,7 +250,7 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 				jobId,
 				'downloading',
 				`Downloading from ${sourceLabel} via yt-dlp...`,
-				40,
+				0,
 				{ browserless: true },
 			);
 			const ytDlpDownloader = new YtDlpDownloader(sourceLabel);
@@ -275,7 +290,7 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 							jobId,
 							'downloading',
 							`Downloading from ${sourceLabel} via yt-dlp...`,
-							50,
+							0,
 							{ browserless: true },
 						);
 						return selectedUrl;
@@ -357,7 +372,7 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 				jobId,
 				'downloading',
 				'Downloading direct file...',
-				40,
+				0,
 				{ browserless: true },
 			);
 			const directDownloader = new DirectDownloader();

--- a/src/ytdlp.ts
+++ b/src/ytdlp.ts
@@ -172,7 +172,7 @@ export class YtDlpDownloader {
 		this.progressCallback?.(
 			'downloading',
 			`Downloading from ${this.sourceLabel} via yt-dlp...`,
-			50,
+			0,
 			{ browserless: true },
 		);
 		console.log(`${this.sourceLabel}: downloading via yt-dlp → ${downloadUrl}`);
@@ -259,7 +259,7 @@ export class YtDlpDownloader {
 		}
 
 		console.log(`${this.sourceLabel}: downloaded ${filename}`);
-		this.progressCallback?.('downloading', 'Download complete', 85, {
+		this.progressCallback?.('downloading', 'Download complete', 100, {
 			browserless: true,
 		});
 		return filename;
@@ -274,7 +274,7 @@ export class YtDlpDownloader {
 		const matchingLabel = matchTitle
 			? `Matching “${matchTitle}” on Bandcamp album...`
 			: 'Listing Bandcamp album tracks...';
-		this.progressCallback?.('downloading', matchingLabel, 45, {
+		this.progressCallback?.('handling_gates', matchingLabel, 45, {
 			browserless: true,
 		});
 		console.log(

--- a/userscript/sc-gate-dl.user.js
+++ b/userscript/sc-gate-dl.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         sc-gate-dl
 // @namespace    https://github.com/D3SOX/sc-gate-dl
-// @version      1.9.1
+// @version      1.10.0
 // @description  Add sc-gate-dl download controls and remember your position in the SoundCloud feed
 // @author       D3SOX
 // @match        https://soundcloud.com/*
@@ -30,7 +30,6 @@
 	const OUTPUT_FORMAT_KEY = 'sc-gate-dl-output-format';
 	const AUTO_CLOSE_KEY = 'sc-gate-dl-auto-close';
 	const FEED_CHECKPOINT_KEY = 'sc-gate-dl-feed-checkpoint';
-	const FEED_DIRECTION_KEY = 'sc-gate-dl-feed-direction';
 	const DEFAULT_WEBUI_BASE = 'http://localhost:4321';
 	const BUTTON_ATTR = 'data-sc-gate-dl-btn';
 	const WRAP_ATTR = 'data-sc-gate-dl-wrap';
@@ -335,7 +334,24 @@
 		return Number.isFinite(timestamp) ? timestamp : null;
 	}
 
-	function loadFeedCheckpoint() {
+	function parseFeedCheckpoint(value) {
+		const url = normalizeTrackUrl(value?.url || '');
+		if (!url) return null;
+		return {
+			url,
+			label:
+				typeof value.label === 'string'
+					? value.label
+					: trackLabelFromUrl(url),
+			feedTimestamp:
+				typeof value.feedTimestamp === 'number'
+					? value.feedTimestamp
+					: null,
+			savedAt: typeof value.savedAt === 'number' ? value.savedAt : 0,
+		};
+	}
+
+	function loadFeedCheckpoints() {
 		let raw = null;
 		try {
 			if (typeof GM_getValue === 'function') {
@@ -347,27 +363,20 @@
 		try {
 			raw ??= localStorage.getItem(FEED_CHECKPOINT_KEY);
 			const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
-			const url = normalizeTrackUrl(parsed?.url || '');
-			if (!url) return null;
-			return {
-				url,
-				label:
-					typeof parsed.label === 'string'
-						? parsed.label
-						: trackLabelFromUrl(url),
-				feedTimestamp:
-					typeof parsed.feedTimestamp === 'number'
-						? parsed.feedTimestamp
-						: null,
-				savedAt: typeof parsed.savedAt === 'number' ? parsed.savedAt : 0,
+			const legacy = parseFeedCheckpoint(parsed);
+			if (legacy) return { newer: legacy, older: legacy };
+			const checkpoints = {
+				newer: parseFeedCheckpoint(parsed?.newer),
+				older: parseFeedCheckpoint(parsed?.older),
 			};
+			return checkpoints.newer || checkpoints.older ? checkpoints : null;
 		} catch {
 			return null;
 		}
 	}
 
-	function persistFeedCheckpoint(checkpoint) {
-		const raw = JSON.stringify(checkpoint);
+	function persistFeedCheckpoints(checkpoints) {
+		const raw = JSON.stringify(checkpoints);
 		try {
 			if (typeof GM_setValue === 'function') {
 				GM_setValue(FEED_CHECKPOINT_KEY, raw);
@@ -382,7 +391,7 @@
 		}
 	}
 
-	function resetFeedCheckpoint() {
+	function resetFeedCheckpoints() {
 		try {
 			if (typeof GM_setValue === 'function') {
 				GM_setValue(FEED_CHECKPOINT_KEY, null);
@@ -395,46 +404,7 @@
 		} catch {
 			// ignore
 		}
-		setFeedStatus('Checkpoint reset. The next played track will be saved.');
-		updateFeedNavigator();
-	}
-
-	function getFeedDirection() {
-		let value = null;
-		try {
-			if (typeof GM_getValue === 'function') {
-				value = GM_getValue(FEED_DIRECTION_KEY, null);
-			}
-		} catch {
-			// ignore
-		}
-		try {
-			value ??= localStorage.getItem(FEED_DIRECTION_KEY);
-		} catch {
-			// ignore
-		}
-		return value === 'older' ? 'older' : 'newer';
-	}
-
-	function setFeedDirection(direction) {
-		const value = direction === 'older' ? 'older' : 'newer';
-		try {
-			if (typeof GM_setValue === 'function') {
-				GM_setValue(FEED_DIRECTION_KEY, value);
-			}
-		} catch {
-			// ignore
-		}
-		try {
-			localStorage.setItem(FEED_DIRECTION_KEY, value);
-		} catch {
-			// ignore
-		}
-		setFeedStatus(
-			value === 'newer'
-				? 'Tracking the farthest-up (newest) played track.'
-				: 'Tracking the farthest-down (oldest) played track.',
-		);
+		setFeedStatus('Positions reset. The next played track will seed both.');
 		updateFeedNavigator();
 	}
 
@@ -458,9 +428,8 @@
 			: trackLabelFromUrl(url);
 	}
 
-	function shouldAdvanceCheckpoint(saved, card, candidateTimestamp) {
+	function shouldAdvanceCheckpoint(saved, card, candidateTimestamp, direction) {
 		if (!saved || saved.url === trackUrlFromCard(card)) return true;
-		const direction = getFeedDirection();
 		if (saved.feedTimestamp != null && candidateTimestamp != null) {
 			return direction === 'newer'
 				? candidateTimestamp >= saved.feedTimestamp
@@ -478,24 +447,33 @@
 		if (!isFeedPage() || !(card instanceof Element)) return;
 		const url = trackUrlFromCard(card);
 		if (!url) return;
-		const saved = loadFeedCheckpoint();
 		const timestamp = feedTimestamp(card);
-		if (!shouldAdvanceCheckpoint(saved, card, timestamp)) return;
 		const label = checkpointLabelFromCard(card, url);
-		if (saved?.url === url) {
-			if (saved.label !== label) {
-				persistFeedCheckpoint({ ...saved, label });
-				updateFeedNavigator();
-			}
-			return;
-		}
-		persistFeedCheckpoint({
+		const checkpoints = loadFeedCheckpoints() ?? { newer: null, older: null };
+		const candidate = {
 			url,
 			label,
 			feedTimestamp: timestamp,
 			savedAt: Date.now(),
-		});
-		updateFeedNavigator();
+		};
+		let changed = false;
+		for (const direction of ['newer', 'older']) {
+			const saved = checkpoints[direction];
+			if (!shouldAdvanceCheckpoint(saved, card, timestamp, direction)) continue;
+			if (saved?.url === url) {
+				if (saved.label !== label) {
+					checkpoints[direction] = { ...saved, label };
+					changed = true;
+				}
+			} else {
+				checkpoints[direction] = candidate;
+				changed = true;
+			}
+		}
+		if (changed) {
+			persistFeedCheckpoints(checkpoints);
+			updateFeedNavigator();
+		}
 	}
 
 	function recordPlayingFeedTrack() {
@@ -526,24 +504,23 @@
 	function updateFeedNavigator() {
 		const nav = document.getElementById(FEED_NAV_ID);
 		if (!nav) return;
-		const checkpoint = loadFeedCheckpoint();
-		const resume = nav.querySelector('.sc-gate-dl-feed-resume');
+		const checkpoints = loadFeedCheckpoints();
+		const resumeNewer = nav.querySelector('.sc-gate-dl-feed-resume-newer');
+		const resumeOlder = nav.querySelector('.sc-gate-dl-feed-resume-older');
 		const find = nav.querySelector('.sc-gate-dl-feed-find');
-		const direction = nav.querySelector('.sc-gate-dl-feed-direction');
-		if (resume instanceof HTMLButtonElement) {
-			resume.disabled = !feedSearchActive && !checkpoint;
-			resume.textContent = feedSearchActive
+		const updateResumeButton = (button, checkpoint, label) => {
+			if (!(button instanceof HTMLButtonElement)) return;
+			button.disabled = !feedSearchActive && !checkpoint;
+			button.textContent = feedSearchActive
 				? 'Cancel scrolling'
 				: checkpoint
-					? `Resume: ${checkpoint.label}`
+					? `Resume ${label}: ${checkpoint.label}`
 					: 'No listened track saved yet';
-			resume.title = checkpoint?.url || '';
-		}
+			button.title = checkpoint?.url || '';
+		};
+		updateResumeButton(resumeNewer, checkpoints?.newer, 'farthest up');
+		updateResumeButton(resumeOlder, checkpoints?.older, 'farthest down');
 		if (find instanceof HTMLButtonElement) find.disabled = feedSearchActive;
-		if (direction instanceof HTMLSelectElement) {
-			direction.value = getFeedDirection();
-			direction.disabled = feedSearchActive;
-		}
 	}
 
 	function waitForMoreFeed(snapshot, token, targetUrl) {
@@ -676,31 +653,27 @@
 					<span>Feed position</span>
 					<button type="button" class="sc-gate-dl-feed-close" aria-label="Close" title="Close">×</button>
 				</div>
-				<button type="button" class="sc-gate-dl-feed-resume"></button>
+				<button type="button" class="sc-gate-dl-feed-resume-newer"></button>
+				<button type="button" class="sc-gate-dl-feed-resume-older"></button>
 				<button type="button" class="sc-gate-dl-feed-find">Find track URL…</button>
-				<label class="sc-gate-dl-feed-setting">
-					<span>Keep</span>
-					<select class="sc-gate-dl-feed-direction" aria-label="Saved-track direction">
-						<option value="newer">Farthest up (newest)</option>
-						<option value="older">Farthest down (oldest)</option>
-					</select>
-				</label>
-				<button type="button" class="sc-gate-dl-feed-reset">Reset saved track</button>
+				<button type="button" class="sc-gate-dl-feed-reset">Reset saved positions</button>
 				<div class="sc-gate-dl-feed-status" aria-live="polite"></div>
 			`;
 			nav
 				.querySelector('.sc-gate-dl-feed-close')
 				?.addEventListener('click', () => toggleFeedNavigator());
-			nav
-				.querySelector('.sc-gate-dl-feed-resume')
-				?.addEventListener('click', () => {
-					if (feedSearchActive) {
-						cancelFeedSearch();
-						return;
-					}
-					const checkpoint = loadFeedCheckpoint();
-					if (checkpoint) void scrollToFeedTrack(checkpoint.url);
-				});
+			for (const direction of ['newer', 'older']) {
+				nav
+					.querySelector(`.sc-gate-dl-feed-resume-${direction}`)
+					?.addEventListener('click', () => {
+						if (feedSearchActive) {
+							cancelFeedSearch();
+							return;
+						}
+						const checkpoint = loadFeedCheckpoints()?.[direction];
+						if (checkpoint) void scrollToFeedTrack(checkpoint.url);
+					});
+			}
 			nav
 				.querySelector('.sc-gate-dl-feed-find')
 				?.addEventListener('click', () => {
@@ -710,15 +683,8 @@
 					if (input?.trim()) void scrollToFeedTrack(input.trim());
 				});
 			nav
-				.querySelector('.sc-gate-dl-feed-direction')
-				?.addEventListener('change', (event) => {
-					if (event.target instanceof HTMLSelectElement) {
-						setFeedDirection(event.target.value);
-					}
-				});
-			nav
 				.querySelector('.sc-gate-dl-feed-reset')
-				?.addEventListener('click', resetFeedCheckpoint);
+				?.addEventListener('click', resetFeedCheckpoints);
 			document.documentElement.appendChild(nav);
 		}
 		nav.hidden = false;
@@ -1217,22 +1183,6 @@
 #${FEED_NAV_ID} button:disabled { color: #777; cursor: default; }
 #${FEED_NAV_ID} .sc-gate-dl-feed-find { text-align: center; }
 #${FEED_NAV_ID} .sc-gate-dl-feed-reset { color: #aaa; text-align: center; }
-#${FEED_NAV_ID} .sc-gate-dl-feed-setting {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	color: #aaa;
-}
-#${FEED_NAV_ID} .sc-gate-dl-feed-setting select {
-	flex: 1;
-	min-width: 0;
-	padding: 5px 7px;
-	border: 1px solid rgba(255, 255, 255, 0.14);
-	border-radius: 6px;
-	background: #0f0f12;
-	color: #eee;
-	font: inherit;
-}
 #${FEED_NAV_ID} .sc-gate-dl-feed-status:empty { display: none; }
 #${FEED_NAV_ID} .sc-gate-dl-feed-status {
 	padding: 1px 2px;

--- a/userscript/sc-gate-dl.user.js
+++ b/userscript/sc-gate-dl.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         sc-gate-dl
 // @namespace    https://github.com/D3SOX/sc-gate-dl
-// @version      1.9.0
+// @version      1.9.1
 // @description  Add sc-gate-dl download controls and remember your position in the SoundCloud feed
 // @author       D3SOX
 // @match        https://soundcloud.com/*
@@ -439,13 +439,19 @@
 	}
 
 	function checkpointLabelFromCard(card, url) {
-		const title = card
-			.querySelector('a.soundTitle__title, a[href][class*="soundTitle"]')
+		const normalizedUrl = normalizeTrackUrl(url);
+		const title = Array.from(card.querySelectorAll('a[href]'))
+			.find(
+				(link) =>
+					!link.matches('.soundTitle__username, [class*="username"]') &&
+					normalizeTrackUrl(link.href) === normalizedUrl &&
+					link.textContent?.trim(),
+			)
 			?.textContent?.trim();
 		const artist = card
 			.querySelector('.soundTitle__username, a.soundTitle__username')
 			?.textContent?.trim();
-		return title
+		return title && title !== artist
 			? artist
 				? `${artist} — ${title}`
 				: title
@@ -475,10 +481,17 @@
 		const saved = loadFeedCheckpoint();
 		const timestamp = feedTimestamp(card);
 		if (!shouldAdvanceCheckpoint(saved, card, timestamp)) return;
-		if (saved?.url === url) return;
+		const label = checkpointLabelFromCard(card, url);
+		if (saved?.url === url) {
+			if (saved.label !== label) {
+				persistFeedCheckpoint({ ...saved, label });
+				updateFeedNavigator();
+			}
+			return;
+		}
 		persistFeedCheckpoint({
 			url,
-			label: checkpointLabelFromCard(card, url),
+			label,
 			feedTimestamp: timestamp,
 			savedAt: Date.now(),
 		});

--- a/userscript/sc-gate-dl.user.js
+++ b/userscript/sc-gate-dl.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         sc-gate-dl
 // @namespace    https://github.com/D3SOX/sc-gate-dl
-// @version      1.10.1
+// @version      1.10.2
 // @description  Add sc-gate-dl download controls and remember your position in the SoundCloud feed
 // @author       D3SOX
 // @match        https://soundcloud.com/*
@@ -11,6 +11,7 @@
 // @grant        GM_unregisterMenuCommand
 // @grant        GM_getValue
 // @grant        GM_setValue
+// @grant        GM_deleteValue
 // @connect      localhost
 // @connect      127.0.0.1
 // @run-at       document-idle
@@ -59,6 +60,7 @@
 
 	/** @type {{ url: string, label: string }[]} */
 	const downloadQueue = [];
+	const feedTrackUrlCache = new WeakMap();
 
 	const RESERVED_FIRST = new Set([
 		'you',
@@ -282,22 +284,32 @@
 
 	/** Feed/search cards only — track pages use the current URL. */
 	function trackUrlFromCard(el) {
-		const sound = el?.closest?.(
+		const closest = el?.closest?.(
 			'.sound, .soundList__item, .userStreamItem, .searchItem__trackItem, .listenContext',
 		);
-		if (!sound) return null;
+		if (!closest) return null;
+		const sound = closest.matches('.sound')
+			? closest
+			: closest.querySelector('.sound') || closest;
+		if (feedTrackUrlCache.has(sound)) return feedTrackUrlCache.get(sound);
+		let trackUrl = null;
 		const titleLink = sound.querySelector(
 			'a.soundTitle__title, a[href][class*="soundTitle"]',
 		);
 		if (titleLink?.href) {
 			const fromTitle = normalizeTrackUrl(titleLink.href);
-			if (fromTitle) return fromTitle;
+			if (fromTitle) trackUrl = fromTitle;
 		}
-		for (const a of sound.querySelectorAll('a[href]')) {
-			const fromA = normalizeTrackUrl(a.href);
-			if (fromA) return fromA;
+		if (!trackUrl) {
+			for (const a of sound.querySelectorAll('a[href]')) {
+				const fromA = normalizeTrackUrl(a.href);
+				if (!fromA) continue;
+				trackUrl = fromA;
+				break;
+			}
 		}
-		return null;
+		if (trackUrl) feedTrackUrlCache.set(sound, trackUrl);
+		return trackUrl;
 	}
 
 	function isFeedPage() {
@@ -393,7 +405,9 @@
 
 	function resetFeedCheckpoints() {
 		try {
-			if (typeof GM_setValue === 'function') {
+			if (typeof GM_deleteValue === 'function') {
+				GM_deleteValue(FEED_CHECKPOINT_KEY);
+			} else if (typeof GM_setValue === 'function') {
 				GM_setValue(FEED_CHECKPOINT_KEY, null);
 			}
 		} catch {
@@ -438,17 +452,23 @@
 		const savedCard = findFeedCard(saved.url);
 		if (!savedCard) return false;
 		const cards = feedCards();
+		const candidateIndex = cards.indexOf(card);
+		const savedIndex = cards.indexOf(savedCard);
+		if (candidateIndex < 0 || savedIndex < 0) return false;
 		return direction === 'newer'
-			? cards.indexOf(card) <= cards.indexOf(savedCard)
-			: cards.indexOf(card) >= cards.indexOf(savedCard);
+			? candidateIndex <= savedIndex
+			: candidateIndex >= savedIndex;
 	}
 
 	function saveFeedCheckpointFromCard(card) {
 		if (!isFeedPage() || !(card instanceof Element)) return;
-		const url = trackUrlFromCard(card);
+		const feedCard = card.matches('.sound')
+			? card
+			: card.querySelector('.sound') || card;
+		const url = trackUrlFromCard(feedCard);
 		if (!url) return;
-		const timestamp = feedTimestamp(card);
-		const label = checkpointLabelFromCard(card, url);
+		const timestamp = feedTimestamp(feedCard);
+		const label = checkpointLabelFromCard(feedCard, url);
 		const checkpoints = loadFeedCheckpoints() ?? { newer: null, older: null };
 		const candidate = {
 			url,
@@ -459,7 +479,7 @@
 		let changed = false;
 		for (const direction of ['newer', 'older']) {
 			const saved = checkpoints[direction];
-			if (!shouldAdvanceCheckpoint(saved, card, timestamp, direction)) continue;
+			if (!shouldAdvanceCheckpoint(saved, feedCard, timestamp, direction)) continue;
 			if (saved?.url === url) {
 				if (saved.label !== label) {
 					checkpoints[direction] = { ...saved, label };
@@ -476,19 +496,28 @@
 		}
 	}
 
+	let lastRecordedPlayingUrl = null;
+
 	function recordPlayingFeedTrack() {
 		if (!isFeedPage()) return;
 		const playing = document.querySelector(
 			'.playControls .playControl.playing, .playControls__play.playing, .playControls button[title^="Pause"], .playControls button[aria-label^="Pause"]',
 		);
-		if (!playing) return;
+		if (!playing) {
+			lastRecordedPlayingUrl = null;
+			return;
+		}
 		const link = document.querySelector(
 			'.playbackSoundBadge__titleLink[href], .playbackSoundBadge a[href][class*="title"]',
 		);
 		const url =
 			link instanceof HTMLAnchorElement ? normalizeTrackUrl(link.href) : null;
+		if (!url || url === lastRecordedPlayingUrl) return;
 		const card = url ? findFeedCard(url) : null;
-		if (card) saveFeedCheckpointFromCard(card);
+		if (card) {
+			saveFeedCheckpointFromCard(card);
+			lastRecordedPlayingUrl = url;
+		}
 	}
 
 	let feedSearchToken = 0;
@@ -527,12 +556,14 @@
 	function waitForMoreFeed(snapshot, token, targetUrl) {
 		return new Promise((resolve) => {
 			let finished = false;
+			let mutationTimer = 0;
 			const finish = (grew) => {
 				if (finished) return;
 				finished = true;
 				observer.disconnect();
 				window.clearInterval(bottomTimer);
 				window.clearTimeout(timeoutTimer);
+				window.clearTimeout(mutationTimer);
 				resolve(grew);
 			};
 			const hasChanged = () => {
@@ -548,7 +579,13 @@
 					finish(true);
 				}
 			};
-			const observer = new MutationObserver(hasChanged);
+			const observer = new MutationObserver(() => {
+				if (mutationTimer) return;
+				mutationTimer = window.setTimeout(() => {
+					mutationTimer = 0;
+					hasChanged();
+				}, 100);
+			});
 			observer.observe(document.body, { childList: true, subtree: true });
 			const bottomTimer = window.setInterval(() => {
 				window.scrollTo(0, document.documentElement.scrollHeight);

--- a/userscript/sc-gate-dl.user.js
+++ b/userscript/sc-gate-dl.user.js
@@ -1,8 +1,8 @@
 // ==UserScript==
 // @name         sc-gate-dl
 // @namespace    https://github.com/D3SOX/sc-gate-dl
-// @version      1.7.0
-// @description  Open the sc-gate-dl Web UI in a floating panel next to SoundCloud store/buy links
+// @version      1.9.0
+// @description  Add sc-gate-dl download controls and remember your position in the SoundCloud feed
 // @author       D3SOX
 // @match        https://soundcloud.com/*
 // @match        https://www.soundcloud.com/*
@@ -29,6 +29,8 @@
 	const QUEUE_GEOM_KEY = 'sc-gate-dl-queue-geom';
 	const OUTPUT_FORMAT_KEY = 'sc-gate-dl-output-format';
 	const AUTO_CLOSE_KEY = 'sc-gate-dl-auto-close';
+	const FEED_CHECKPOINT_KEY = 'sc-gate-dl-feed-checkpoint';
+	const FEED_DIRECTION_KEY = 'sc-gate-dl-feed-direction';
 	const DEFAULT_WEBUI_BASE = 'http://localhost:4321';
 	const BUTTON_ATTR = 'data-sc-gate-dl-btn';
 	const WRAP_ATTR = 'data-sc-gate-dl-wrap';
@@ -36,9 +38,12 @@
 	const QUEUE_ID = 'sc-gate-dl-queue';
 	const STYLE_ID = 'sc-gate-dl-styles';
 	const TOOLTIP_ID = 'sc-gate-dl-tooltip';
+	const FEED_NAV_ID = 'sc-gate-dl-feed-nav';
 	const TOOLTIP_LABEL = 'Download with sc-gate-dl';
 	const MIN_PANEL_W = 280;
 	const MIN_PANEL_H = 240;
+	const FEED_CARD_SELECTOR = '.sound, .soundList__item, .userStreamItem';
+	const FEED_LOAD_TIMEOUT_MS = 15_000;
 
 	const DEFAULT_GEOM = {
 		width: 400,
@@ -203,6 +208,9 @@
 
 	function registerMenuCommands() {
 		if (typeof GM_registerMenuCommand !== 'function') return;
+		GM_registerMenuCommand('Feed position controls…', () => {
+			toggleFeedNavigator();
+		});
 		GM_registerMenuCommand('Choose output format…', () => {
 			openFormatDialog();
 		});
@@ -276,7 +284,7 @@
 	/** Feed/search cards only — track pages use the current URL. */
 	function trackUrlFromCard(el) {
 		const sound = el?.closest?.(
-			'.sound, .soundList__item, .searchItem__trackItem, .listenContext',
+			'.sound, .soundList__item, .userStreamItem, .searchItem__trackItem, .listenContext',
 		);
 		if (!sound) return null;
 		const titleLink = sound.querySelector(
@@ -291,6 +299,417 @@
 			if (fromA) return fromA;
 		}
 		return null;
+	}
+
+	function isFeedPage() {
+		return /^\/(?:you\/stream|feed)\/?$/i.test(document.location.pathname);
+	}
+
+	function feedCards() {
+		const sounds = Array.from(
+			document.querySelectorAll(
+				'.userStream .sound, .stream__list .sound, .soundList__item .sound',
+			),
+		);
+		return sounds.length > 0
+			? sounds
+			: Array.from(
+					document.querySelectorAll('.soundList__item, .userStreamItem'),
+				);
+	}
+
+	function findFeedCard(trackUrl) {
+		const normalized = normalizeTrackUrl(trackUrl);
+		if (!normalized) return null;
+		return (
+			feedCards().find((card) => trackUrlFromCard(card) === normalized) || null
+		);
+	}
+
+	function feedTimestamp(card) {
+		const time = card.querySelector(
+			'.sound__header time[datetime], .soundTitle time[datetime], time[datetime]',
+		);
+		if (!(time instanceof HTMLTimeElement)) return null;
+		const timestamp = Date.parse(time.dateTime);
+		return Number.isFinite(timestamp) ? timestamp : null;
+	}
+
+	function loadFeedCheckpoint() {
+		let raw = null;
+		try {
+			if (typeof GM_getValue === 'function') {
+				raw = GM_getValue(FEED_CHECKPOINT_KEY, null);
+			}
+		} catch {
+			// ignore
+		}
+		try {
+			raw ??= localStorage.getItem(FEED_CHECKPOINT_KEY);
+			const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+			const url = normalizeTrackUrl(parsed?.url || '');
+			if (!url) return null;
+			return {
+				url,
+				label:
+					typeof parsed.label === 'string'
+						? parsed.label
+						: trackLabelFromUrl(url),
+				feedTimestamp:
+					typeof parsed.feedTimestamp === 'number'
+						? parsed.feedTimestamp
+						: null,
+				savedAt: typeof parsed.savedAt === 'number' ? parsed.savedAt : 0,
+			};
+		} catch {
+			return null;
+		}
+	}
+
+	function persistFeedCheckpoint(checkpoint) {
+		const raw = JSON.stringify(checkpoint);
+		try {
+			if (typeof GM_setValue === 'function') {
+				GM_setValue(FEED_CHECKPOINT_KEY, raw);
+			}
+		} catch {
+			// ignore
+		}
+		try {
+			localStorage.setItem(FEED_CHECKPOINT_KEY, raw);
+		} catch {
+			// ignore
+		}
+	}
+
+	function resetFeedCheckpoint() {
+		try {
+			if (typeof GM_setValue === 'function') {
+				GM_setValue(FEED_CHECKPOINT_KEY, null);
+			}
+		} catch {
+			// ignore
+		}
+		try {
+			localStorage.removeItem(FEED_CHECKPOINT_KEY);
+		} catch {
+			// ignore
+		}
+		setFeedStatus('Checkpoint reset. The next played track will be saved.');
+		updateFeedNavigator();
+	}
+
+	function getFeedDirection() {
+		let value = null;
+		try {
+			if (typeof GM_getValue === 'function') {
+				value = GM_getValue(FEED_DIRECTION_KEY, null);
+			}
+		} catch {
+			// ignore
+		}
+		try {
+			value ??= localStorage.getItem(FEED_DIRECTION_KEY);
+		} catch {
+			// ignore
+		}
+		return value === 'older' ? 'older' : 'newer';
+	}
+
+	function setFeedDirection(direction) {
+		const value = direction === 'older' ? 'older' : 'newer';
+		try {
+			if (typeof GM_setValue === 'function') {
+				GM_setValue(FEED_DIRECTION_KEY, value);
+			}
+		} catch {
+			// ignore
+		}
+		try {
+			localStorage.setItem(FEED_DIRECTION_KEY, value);
+		} catch {
+			// ignore
+		}
+		setFeedStatus(
+			value === 'newer'
+				? 'Tracking the farthest-up (newest) played track.'
+				: 'Tracking the farthest-down (oldest) played track.',
+		);
+		updateFeedNavigator();
+	}
+
+	function checkpointLabelFromCard(card, url) {
+		const title = card
+			.querySelector('a.soundTitle__title, a[href][class*="soundTitle"]')
+			?.textContent?.trim();
+		const artist = card
+			.querySelector('.soundTitle__username, a.soundTitle__username')
+			?.textContent?.trim();
+		return title
+			? artist
+				? `${artist} — ${title}`
+				: title
+			: trackLabelFromUrl(url);
+	}
+
+	function shouldAdvanceCheckpoint(saved, card, candidateTimestamp) {
+		if (!saved || saved.url === trackUrlFromCard(card)) return true;
+		const direction = getFeedDirection();
+		if (saved.feedTimestamp != null && candidateTimestamp != null) {
+			return direction === 'newer'
+				? candidateTimestamp >= saved.feedTimestamp
+				: candidateTimestamp <= saved.feedTimestamp;
+		}
+		const savedCard = findFeedCard(saved.url);
+		if (!savedCard) return false;
+		const cards = feedCards();
+		return direction === 'newer'
+			? cards.indexOf(card) <= cards.indexOf(savedCard)
+			: cards.indexOf(card) >= cards.indexOf(savedCard);
+	}
+
+	function saveFeedCheckpointFromCard(card) {
+		if (!isFeedPage() || !(card instanceof Element)) return;
+		const url = trackUrlFromCard(card);
+		if (!url) return;
+		const saved = loadFeedCheckpoint();
+		const timestamp = feedTimestamp(card);
+		if (!shouldAdvanceCheckpoint(saved, card, timestamp)) return;
+		if (saved?.url === url) return;
+		persistFeedCheckpoint({
+			url,
+			label: checkpointLabelFromCard(card, url),
+			feedTimestamp: timestamp,
+			savedAt: Date.now(),
+		});
+		updateFeedNavigator();
+	}
+
+	function recordPlayingFeedTrack() {
+		if (!isFeedPage()) return;
+		const playing = document.querySelector(
+			'.playControls .playControl.playing, .playControls__play.playing, .playControls button[title^="Pause"], .playControls button[aria-label^="Pause"]',
+		);
+		if (!playing) return;
+		const link = document.querySelector(
+			'.playbackSoundBadge__titleLink[href], .playbackSoundBadge a[href][class*="title"]',
+		);
+		const url =
+			link instanceof HTMLAnchorElement ? normalizeTrackUrl(link.href) : null;
+		const card = url ? findFeedCard(url) : null;
+		if (card) saveFeedCheckpointFromCard(card);
+	}
+
+	let feedSearchToken = 0;
+	let feedSearchActive = false;
+
+	function setFeedStatus(message) {
+		const status = document.querySelector(
+			`#${FEED_NAV_ID} .sc-gate-dl-feed-status`,
+		);
+		if (status) status.textContent = message;
+	}
+
+	function updateFeedNavigator() {
+		const nav = document.getElementById(FEED_NAV_ID);
+		if (!nav) return;
+		const checkpoint = loadFeedCheckpoint();
+		const resume = nav.querySelector('.sc-gate-dl-feed-resume');
+		const find = nav.querySelector('.sc-gate-dl-feed-find');
+		const direction = nav.querySelector('.sc-gate-dl-feed-direction');
+		if (resume instanceof HTMLButtonElement) {
+			resume.disabled = !feedSearchActive && !checkpoint;
+			resume.textContent = feedSearchActive
+				? 'Cancel scrolling'
+				: checkpoint
+					? `Resume: ${checkpoint.label}`
+					: 'No listened track saved yet';
+			resume.title = checkpoint?.url || '';
+		}
+		if (find instanceof HTMLButtonElement) find.disabled = feedSearchActive;
+		if (direction instanceof HTMLSelectElement) {
+			direction.value = getFeedDirection();
+			direction.disabled = feedSearchActive;
+		}
+	}
+
+	function waitForMoreFeed(snapshot, token, targetUrl) {
+		return new Promise((resolve) => {
+			let finished = false;
+			const finish = (grew) => {
+				if (finished) return;
+				finished = true;
+				observer.disconnect();
+				window.clearInterval(bottomTimer);
+				window.clearTimeout(timeoutTimer);
+				resolve(grew);
+			};
+			const hasChanged = () => {
+				if (token !== feedSearchToken) return finish(false);
+				if (findFeedCard(targetUrl)) return finish(true);
+				const cards = feedCards();
+				const lastUrl = trackUrlFromCard(cards.at(-1));
+				if (
+					cards.length > snapshot.count ||
+					(lastUrl && lastUrl !== snapshot.lastUrl) ||
+					document.documentElement.scrollHeight > snapshot.height + 20
+				) {
+					finish(true);
+				}
+			};
+			const observer = new MutationObserver(hasChanged);
+			observer.observe(document.body, { childList: true, subtree: true });
+			const bottomTimer = window.setInterval(() => {
+				window.scrollTo(0, document.documentElement.scrollHeight);
+				hasChanged();
+			}, 750);
+			const timeoutTimer = window.setTimeout(
+				() => finish(false),
+				FEED_LOAD_TIMEOUT_MS,
+			);
+		});
+	}
+
+	async function scrollToFeedTrack(trackUrl) {
+		const url = normalizeTrackUrl(trackUrl);
+		if (!url) {
+			setFeedStatus('Enter a valid SoundCloud track URL.');
+			return;
+		}
+		if (!isFeedPage()) {
+			setFeedStatus('Open your SoundCloud Stream first.');
+			return;
+		}
+		const token = ++feedSearchToken;
+		feedSearchActive = true;
+		updateFeedNavigator();
+		let stalledLoads = 0;
+
+		while (token === feedSearchToken && isFeedPage()) {
+			const card = findFeedCard(url);
+			if (card instanceof HTMLElement) {
+				card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+				window.setTimeout(() => {
+					if (card.isConnected) card.scrollIntoView({ block: 'center' });
+				}, 450);
+				card.classList.add('sc-gate-dl-feed-target');
+				window.setTimeout(
+					() => card.classList.remove('sc-gate-dl-feed-target'),
+					2400,
+				);
+				setFeedStatus('Track found and centered.');
+				break;
+			}
+
+			const cards = feedCards();
+			setFeedStatus(
+				`Loading more tracks… ${cards.length.toLocaleString()} checked`,
+			);
+			const snapshot = {
+				count: cards.length,
+				lastUrl: trackUrlFromCard(cards.at(-1)),
+				height: document.documentElement.scrollHeight,
+			};
+			window.scrollTo(0, document.documentElement.scrollHeight);
+			const grew = await waitForMoreFeed(snapshot, token, url);
+			stalledLoads = grew ? 0 : stalledLoads + 1;
+			if (stalledLoads >= 2) {
+				setFeedStatus('Track was not found in the available feed.');
+				break;
+			}
+		}
+
+		if (token === feedSearchToken) {
+			feedSearchActive = false;
+			updateFeedNavigator();
+		}
+	}
+
+	function cancelFeedSearch() {
+		if (!feedSearchActive) return;
+		feedSearchToken++;
+		feedSearchActive = false;
+		setFeedStatus('Scrolling cancelled.');
+		updateFeedNavigator();
+	}
+
+	function toggleFeedNavigator() {
+		const nav = document.getElementById(FEED_NAV_ID);
+		if (nav && !nav.hidden) {
+			if (feedSearchActive) cancelFeedSearch();
+			nav.hidden = true;
+			return;
+		}
+		ensureFeedNavigator(true);
+	}
+
+	function ensureFeedNavigator(open = false) {
+		let nav = document.getElementById(FEED_NAV_ID);
+		if (!isFeedPage()) {
+			if (feedSearchActive) cancelFeedSearch();
+			if (nav) nav.hidden = true;
+			if (open) {
+				alert('sc-gate-dl: open your SoundCloud Stream first.');
+			}
+			return;
+		}
+		if (!open) return;
+		if (!nav) {
+			nav = document.createElement('aside');
+			nav.id = FEED_NAV_ID;
+			nav.setAttribute('aria-label', 'SoundCloud feed position');
+			nav.innerHTML = `
+				<div class="sc-gate-dl-feed-heading">
+					<span>Feed position</span>
+					<button type="button" class="sc-gate-dl-feed-close" aria-label="Close" title="Close">×</button>
+				</div>
+				<button type="button" class="sc-gate-dl-feed-resume"></button>
+				<button type="button" class="sc-gate-dl-feed-find">Find track URL…</button>
+				<label class="sc-gate-dl-feed-setting">
+					<span>Keep</span>
+					<select class="sc-gate-dl-feed-direction" aria-label="Saved-track direction">
+						<option value="newer">Farthest up (newest)</option>
+						<option value="older">Farthest down (oldest)</option>
+					</select>
+				</label>
+				<button type="button" class="sc-gate-dl-feed-reset">Reset saved track</button>
+				<div class="sc-gate-dl-feed-status" aria-live="polite"></div>
+			`;
+			nav
+				.querySelector('.sc-gate-dl-feed-close')
+				?.addEventListener('click', () => toggleFeedNavigator());
+			nav
+				.querySelector('.sc-gate-dl-feed-resume')
+				?.addEventListener('click', () => {
+					if (feedSearchActive) {
+						cancelFeedSearch();
+						return;
+					}
+					const checkpoint = loadFeedCheckpoint();
+					if (checkpoint) void scrollToFeedTrack(checkpoint.url);
+				});
+			nav
+				.querySelector('.sc-gate-dl-feed-find')
+				?.addEventListener('click', () => {
+					const input = window.prompt(
+						'SoundCloud track URL to find in your feed:',
+					);
+					if (input?.trim()) void scrollToFeedTrack(input.trim());
+				});
+			nav
+				.querySelector('.sc-gate-dl-feed-direction')
+				?.addEventListener('change', (event) => {
+					if (event.target instanceof HTMLSelectElement) {
+						setFeedDirection(event.target.value);
+					}
+				});
+			nav
+				.querySelector('.sc-gate-dl-feed-reset')
+				?.addEventListener('click', resetFeedCheckpoint);
+			document.documentElement.appendChild(nav);
+		}
+		nav.hidden = false;
+		updateFeedNavigator();
 	}
 
 	function resolveTrackUrl(el) {
@@ -728,6 +1147,90 @@
 #${PANEL_ID} .sc-gate-dl-rh[data-dir="nw"] { top: 0; left: 0; width: 10px; height: 10px; cursor: nw-resize; }
 #${PANEL_ID} .sc-gate-dl-rh[data-dir="se"] { bottom: 0; right: 0; width: 10px; height: 10px; cursor: se-resize; }
 #${PANEL_ID} .sc-gate-dl-rh[data-dir="sw"] { bottom: 0; left: 0; width: 10px; height: 10px; cursor: sw-resize; }
+
+/* Feed checkpoint and deep-scroll controls */
+#${FEED_NAV_ID} {
+	position: fixed;
+	right: 16px;
+	bottom: 72px;
+	z-index: 2147483644;
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	box-sizing: border-box;
+	width: min(300px, calc(100vw - 32px));
+	padding: 8px;
+	background: #16161c;
+	border: 1px solid rgba(255, 255, 255, 0.12);
+	border-radius: 8px;
+	box-shadow: 0 8px 28px rgba(0, 0, 0, 0.4);
+	font: 500 12px/1.3 Interstate, "Lucida Grande", Arial, sans-serif;
+}
+#${FEED_NAV_ID}[hidden] { display: none !important; }
+#${FEED_NAV_ID} .sc-gate-dl-feed-heading {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	color: #eee;
+	font-weight: 700;
+}
+#${FEED_NAV_ID} button {
+	appearance: none;
+	box-sizing: border-box;
+	width: 100%;
+	min-height: 30px;
+	padding: 6px 9px;
+	overflow: hidden;
+	border: 1px solid rgba(255, 255, 255, 0.14);
+	border-radius: 6px;
+	background: #0f0f12;
+	color: #eee;
+	font: inherit;
+	text-align: left;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	cursor: pointer;
+}
+#${FEED_NAV_ID} button.sc-gate-dl-feed-close {
+	width: auto;
+	min-height: 0;
+	padding: 0 5px;
+	border: 0;
+	background: transparent;
+	font-size: 18px;
+	line-height: 1;
+}
+#${FEED_NAV_ID} button:hover:not(:disabled) { border-color: #f50; color: #fff; }
+#${FEED_NAV_ID} button:disabled { color: #777; cursor: default; }
+#${FEED_NAV_ID} .sc-gate-dl-feed-find { text-align: center; }
+#${FEED_NAV_ID} .sc-gate-dl-feed-reset { color: #aaa; text-align: center; }
+#${FEED_NAV_ID} .sc-gate-dl-feed-setting {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	color: #aaa;
+}
+#${FEED_NAV_ID} .sc-gate-dl-feed-setting select {
+	flex: 1;
+	min-width: 0;
+	padding: 5px 7px;
+	border: 1px solid rgba(255, 255, 255, 0.14);
+	border-radius: 6px;
+	background: #0f0f12;
+	color: #eee;
+	font: inherit;
+}
+#${FEED_NAV_ID} .sc-gate-dl-feed-status:empty { display: none; }
+#${FEED_NAV_ID} .sc-gate-dl-feed-status {
+	padding: 1px 2px;
+	color: #aaa;
+	font-size: 11px;
+}
+.sc-gate-dl-feed-target {
+	outline: 3px solid #f50 !important;
+	outline-offset: 5px;
+	transition: outline-color 300ms ease;
+}
 
 /* Match SoundCloud .tooltip (rgb(48,48,48) / #303030) */
 #${TOOLTIP_ID} {
@@ -1582,6 +2085,21 @@ button[${BUTTON_ATTR}="mui"] svg {
 
 	ensureStyles();
 	scan();
+	ensureFeedNavigator();
+
+	document.addEventListener(
+		'click',
+		(event) => {
+			if (!isFeedPage() || !(event.target instanceof Element)) return;
+			const playControl = event.target.closest(
+				'button.playControl, button.sc-button-play, button.sc-button-pause, .soundTitle__playButton, .sound__coverArt .playButton',
+			);
+			if (!playControl) return;
+			const card = playControl.closest(FEED_CARD_SELECTOR);
+			if (card) saveFeedCheckpointFromCard(card);
+		},
+		true,
+	);
 
 	const observer = new MutationObserver((mutations) => {
 		let shouldScan = false;
@@ -1603,7 +2121,9 @@ button[${BUTTON_ATTR}="mui"] svg {
 		if (location.href !== lastHref) {
 			lastHref = location.href;
 			scan();
+			ensureFeedNavigator();
 		}
+		recordPlayingFeedTrack();
 	}, 1000);
 
 	registerMenuCommands();

--- a/userscript/sc-gate-dl.user.js
+++ b/userscript/sc-gate-dl.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         sc-gate-dl
 // @namespace    https://github.com/D3SOX/sc-gate-dl
-// @version      1.10.0
+// @version      1.10.1
 // @description  Add sc-gate-dl download controls and remember your position in the SoundCloud feed
 // @author       D3SOX
 // @match        https://soundcloud.com/*
@@ -507,19 +507,20 @@
 		const checkpoints = loadFeedCheckpoints();
 		const resumeNewer = nav.querySelector('.sc-gate-dl-feed-resume-newer');
 		const resumeOlder = nav.querySelector('.sc-gate-dl-feed-resume-older');
+		const cancel = nav.querySelector('.sc-gate-dl-feed-cancel');
 		const find = nav.querySelector('.sc-gate-dl-feed-find');
 		const updateResumeButton = (button, checkpoint, label) => {
 			if (!(button instanceof HTMLButtonElement)) return;
-			button.disabled = !feedSearchActive && !checkpoint;
-			button.textContent = feedSearchActive
-				? 'Cancel scrolling'
-				: checkpoint
-					? `Resume ${label}: ${checkpoint.label}`
-					: 'No listened track saved yet';
+			button.hidden = feedSearchActive;
+			button.disabled = !checkpoint;
+			button.textContent = checkpoint
+				? `Resume ${label}: ${checkpoint.label}`
+				: 'No listened track saved yet';
 			button.title = checkpoint?.url || '';
 		};
 		updateResumeButton(resumeNewer, checkpoints?.newer, 'farthest up');
 		updateResumeButton(resumeOlder, checkpoints?.older, 'farthest down');
+		if (cancel instanceof HTMLButtonElement) cancel.hidden = !feedSearchActive;
 		if (find instanceof HTMLButtonElement) find.disabled = feedSearchActive;
 	}
 
@@ -655,6 +656,7 @@
 				</div>
 				<button type="button" class="sc-gate-dl-feed-resume-newer"></button>
 				<button type="button" class="sc-gate-dl-feed-resume-older"></button>
+				<button type="button" class="sc-gate-dl-feed-cancel" hidden>Cancel scrolling</button>
 				<button type="button" class="sc-gate-dl-feed-find">Find track URL…</button>
 				<button type="button" class="sc-gate-dl-feed-reset">Reset saved positions</button>
 				<div class="sc-gate-dl-feed-status" aria-live="polite"></div>
@@ -674,6 +676,9 @@
 						if (checkpoint) void scrollToFeedTrack(checkpoint.url);
 					});
 			}
+			nav
+				.querySelector('.sc-gate-dl-feed-cancel')
+				?.addEventListener('click', cancelFeedSearch);
 			nav
 				.querySelector('.sc-gate-dl-feed-find')
 				?.addEventListener('click', () => {
@@ -1179,6 +1184,7 @@
 	font-size: 18px;
 	line-height: 1;
 }
+#${FEED_NAV_ID} button[hidden] { display: none !important; }
 #${FEED_NAV_ID} button:hover:not(:disabled) { border-color: #f50; color: #fff; }
 #${FEED_NAV_ID} button:disabled { color: #777; cursor: default; }
 #${FEED_NAV_ID} .sc-gate-dl-feed-find { text-align: center; }

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Toaster, toast } from 'sonner';
 import './App.css';
 
-type Step = 'url' | 'hypeddit' | 'progress' | 'metadata' | 'complete';
+type Step = 'url' | 'gate' | 'download' | 'metadata' | 'complete';
 type OutputFormat = 'original' | 'mp3-320';
 
 interface Metadata {
@@ -29,6 +29,13 @@ interface JobProgress {
 	browserless?: boolean;
 	bandcampAlbumTracks?: BandcampAlbumTrackChoice[];
 }
+
+const GATE_PROGRESS_STAGES = new Set([
+	'initializing_browser',
+	'preparing_logins',
+	'handling_gates',
+	'waiting_bandcamp_track',
+]);
 
 interface BandcampAlbumTrackChoice {
 	title: string;
@@ -288,7 +295,15 @@ export default function App() {
 	// Start download process
 	const startDownload = useCallback(
 		async (jobId: string) => {
-			setStep('progress');
+			setStep('gate');
+			setJob((prev) => ({
+				...prev,
+				progress: {
+					stage: 'handling_gates',
+					message: 'Entering gate...',
+					percent: 0,
+				},
+			}));
 			cleanupToastShownRef.current = false;
 			eventSourceRef.current?.close();
 			eventSourceRef.current = null;
@@ -315,6 +330,14 @@ export default function App() {
 				eventSource.onmessage = (event) => {
 					const progress: JobProgress = JSON.parse(event.data);
 					setJob((prev) => ({ ...prev, progress }));
+
+					if (progress.stage === 'downloading') {
+						setStep('download');
+					} else if (progress.stage === 'processing_audio') {
+						setStep('metadata');
+					} else if (GATE_PROGRESS_STAGES.has(progress.stage)) {
+						setStep('gate');
+					}
 
 					// Browserless downloads never touch the SoundCloud account, so there
 					// is nothing to clean up afterwards.
@@ -496,7 +519,7 @@ export default function App() {
 				}
 
 				if (skipAutomaticHypedditFetch || data.needsHypedditUrl) {
-					setStep('hypeddit');
+					setStep('gate');
 				} else {
 					startDownload(data.jobId);
 				}
@@ -729,6 +752,8 @@ export default function App() {
 		artist: metadata.artist,
 		title: metadata.title,
 	});
+	const isHandlingGate =
+		step === 'gate' && GATE_PROGRESS_STAGES.has(job.progress?.stage ?? '');
 	const existingTagRows = (
 		[
 			{ key: 'title', label: 'Title' },
@@ -825,21 +850,21 @@ export default function App() {
 			{/* Step indicator */}
 			<div className="steps">
 				<div
-					className={`step ${step === 'url' ? 'active' : ''} ${['hypeddit', 'progress', 'metadata', 'complete'].includes(step) ? 'completed' : ''}`}
+					className={`step ${step === 'url' ? 'active' : ''} ${['gate', 'download', 'metadata', 'complete'].includes(step) ? 'completed' : ''}`}
 				>
 					<span className="step-number">1</span>
 					<span className="step-label">SoundCloud</span>
 				</div>
 				<div className="step-connector" />
 				<div
-					className={`step ${step === 'hypeddit' ? 'active' : ''} ${['progress', 'metadata', 'complete'].includes(step) ? 'completed' : ''}`}
+					className={`step ${step === 'gate' ? 'active' : ''} ${['download', 'metadata', 'complete'].includes(step) ? 'completed' : ''}`}
 				>
 					<span className="step-number">2</span>
 					<span className="step-label">Gate</span>
 				</div>
 				<div className="step-connector" />
 				<div
-					className={`step ${step === 'progress' ? 'active' : ''} ${['metadata', 'complete'].includes(step) ? 'completed' : ''}`}
+					className={`step ${step === 'download' ? 'active' : ''} ${['metadata', 'complete'].includes(step) ? 'completed' : ''}`}
 				>
 					<span className="step-number">3</span>
 					<span className="step-label">Download</span>
@@ -968,7 +993,7 @@ export default function App() {
 				)}
 
 				{/* Step 2: Gate URL (if needed) */}
-				{step === 'hypeddit' && (
+				{step === 'gate' && !isHandlingGate && (
 					<div className="form animate-slide-up">
 						<div className="notice">
 							<span className="notice-icon">i</span>
@@ -1039,8 +1064,8 @@ export default function App() {
 					</div>
 				)}
 
-				{/* Step 3: Progress */}
-				{step === 'progress' && (
+				{/* Steps 2–3: Gate handling, then download progress */}
+				{(isHandlingGate || step === 'download') && (
 					<div className="progress-container animate-slide-up">
 						{job.progress?.stage === 'waiting_bandcamp_track' ? (
 							<div className="bandcamp-track-picker">
@@ -1083,7 +1108,9 @@ export default function App() {
 							<>
 								<div className="progress-stage">
 									<span className="stage-label">
-										{job.progress?.message || 'Initializing...'}
+										{job.progress?.downloadBytes !== undefined
+											? 'Downloading...'
+											: job.progress?.message || 'Initializing...'}
 									</span>
 									{job.progress?.currentGate && (
 										<span className="gate-badge">
@@ -1091,23 +1118,27 @@ export default function App() {
 										</span>
 									)}
 								</div>
-								<div className="progress-bar">
-									<div
-										className="progress-fill"
-										style={{ width: `${job.progress?.percent || 0}%` }}
-									/>
-								</div>
-								<div className="progress-stats">
-									<span>{formatPercent(job.progress?.percent)}%</span>
-									{job.progress?.downloadBytes !== undefined &&
-										job.progress?.totalBytes !== undefined && (
-											<span>
-												{(job.progress.downloadBytes / 1024 / 1024).toFixed(1)}{' '}
-												/{' '}
-												{(job.progress.totalBytes / 1024 / 1024).toFixed(1)} MB
-											</span>
-										)}
-								</div>
+								{step === 'download' && (
+									<>
+										<div className="progress-bar">
+											<div
+												className="progress-fill"
+												style={{ width: `${job.progress?.percent || 0}%` }}
+											/>
+										</div>
+										<div className="progress-stats">
+											<span>{formatPercent(job.progress?.percent)}%</span>
+											{job.progress?.downloadBytes !== undefined &&
+												job.progress?.totalBytes !== undefined && (
+													<span>
+														{(job.progress.downloadBytes / 1024 / 1024).toFixed(1)}{' '}
+														/{' '}
+														{(job.progress.totalBytes / 1024 / 1024).toFixed(1)} MB
+													</span>
+												)}
+										</div>
+									</>
+								)}
 								<button
 									type="button"
 									className="btn-secondary btn-cancel-download"
@@ -1121,7 +1152,14 @@ export default function App() {
 				)}
 
 				{/* Step 4: Metadata */}
-				{step === 'metadata' && (
+				{step === 'metadata' && job.progress?.stage === 'processing_audio' && (
+					<div className="progress-container animate-slide-up">
+						<div className="progress-stage">
+							<span className="stage-label">{job.progress.message}</span>
+						</div>
+					</div>
+				)}
+				{step === 'metadata' && job.progress?.stage !== 'processing_audio' && (
 					<form
 						onSubmit={handleMetadataSubmit}
 						className="form metadata-form animate-slide-up"


### PR DESCRIPTION
## What changed

### SoundCloud feed position controls

- track the farthest-up/newest and farthest-down/oldest played tracks independently on every playback
- migrate the previous single saved position into both boundaries
- provide separate resume buttons for both boundaries
- show one dedicated **Cancel scrolling** button while searching instead of replacing both resume buttons
- display checkpoints as `Artist — Track Title` by matching the exact track URL and excluding uploader links
- keep manual track lookup, reset controls, deep scrolling, and target highlighting
- cache resolved feed-card URLs, debounce feed mutation scans, and skip unchanged playback URLs
- delete saved userscript state with `GM_deleteValue`
- bump the userscript to version `1.10.2`

### Gate and download workflow

- use the sequence **SoundCloud → Gate → Download → Metadata → Done**
- keep gate URL entry, browser preparation, social gates, and Bandcamp track selection in the Gate step
- activate Download only when the file transfer starts
- normalize transfer progress to 0–100%
- report byte progress for direct downloads
- show the MB counter only once, below the progress bar
- move artwork preparation into the Metadata step

### DownloadGater Spotify support

- handle honor-system Spotify gates without OAuth
- open the requested Spotify page in a new tab
- wait for DownloadGater's confirmation button, close only the newly opened tab, and confirm the action
- support confirmation labels such as **I followed**, **I saved it**, **I opened it**, and **I've done it**
- retry cleanly and report the Spotify gate as part of the Gate step
- share the popup/confirmation implementation with DownloadGater Instagram gates

## Why

Feed tracking previously stored only one direction at a time, and its broad title selector could display the uploader twice. During deep scrolling, both resume buttons also turned into duplicate cancel buttons.

Gate automation was shown as download progress on a whole-job percentage scale, so Download could become active before any transfer and only move through roughly 75–85%. DownloadGater Spotify gates stopped with an unsupported-OAuth error even though the site only requires opening its Spotify link and confirming the honor-system step.

These changes make the saved feed boundaries, UI stages, transfer progress, and DownloadGater behavior match what the user is actually doing.

## Validation

- `bun test` — 32 tests passed
- `bunx tsc --noEmit -p webui/tsconfig.json`
- `bunx biome check src/server.ts src/directDownload.ts src/hypeddit.ts src/droploud.ts src/gaterush.ts src/downloadgater.ts`
- `node --check userscript/sc-gate-dl.user.js`
- `git diff --check`
- live DownloadGater validation with `limoncello-paint-the-town-red-84870`: advanced from Spotify to SoundCloud and left no Spotify tab open
- GitHub Actions `lint` check passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SoundCloud feed navigation with saved playback checkpoints, resume support, search, cancellation, reset, and status reporting.
  * Added visual highlighting for tracks found during feed navigation.
  * Added clearer download workflow stages for gate handling, downloading, audio processing, and metadata editing.

* **Improvements**
  * Download progress now begins at 0%, reflects transfer progress when available, and completes at 100%.
  * Improved Spotify and Instagram gate handling with confirmation and retry behavior.
  * Progress displays now separate gate handling from download activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->