### PR TITLE
feat: add Xvfb browser mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,5 @@ MANAGED_SC_OAUTH_TOKEN=
 # WebUI browser jobs default to headless (also toggleable per job in the UI).
 # Set false to force headed for all jobs when the UI option is not sent.
 # BROWSER_HEADLESS=false
+# Proxy timezone/locale matching is automatic; uncomment only to disable it.
+# CLOAKBROWSER_GEOIP=false

--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ If you want to use the CLI and not be prompted for values every time, you can cr
 cp config.example.json config.json
 ```
 
+Set `xvfb` to `true` to keep the browser window invisible while running
+CloakBrowser in headed mode. This avoids Chromium's detectable headless rendering
+path. Install `xorg-server-xvfb` on Arch Linux (`xvfb` on Debian/Ubuntu) first.
+
+For anti-bot sites, configure a residential proxy with
+`CLOAKBROWSER_PROXY` (SOCKS5 is preferred when available). Proxy GeoIP matching
+and humanized browser input are enabled automatically; set
+`CLOAKBROWSER_GEOIP=false` only to opt out. The Web UI also exposes Xvfb mode
+next to its headful-browser option.
+
 ## Usage
 
 ### CLI

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Wait for Astro to be started. It will then tell you the address it's available o
 
 If it's the first time you're running it you will need to initialize the logins by clicking the button in the footer.
 
-You can deep-link a track with `?url=` (also accepted as `?soundcloudUrl=`) and optional `outputFormat` (`mp3-320` or `original`), which pre-fills the form and starts the job:
+You can deep-link a track with `?url=` (also accepted as `?soundcloudUrl=`) and optional `outputFormat` (`mp3-320`, `flac`, or `original`), which pre-fills the form and starts the job. FLAC output preserves lossless sources; converting a lossy source to FLAC changes the container but cannot restore lost quality.
 
 ```text
 http://localhost:4321/?url=https://soundcloud.com/artist/track&outputFormat=mp3-320

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "cloakbrowser": "^0.5.3",
         "execa": "^10.0.1",
         "find-bin": "^1.1.1",
+        "mmdb-lib": "^3.0.2",
         "puppeteer": "^25.4.0",
         "soundcloud.ts": "^0.7.4",
       },
@@ -194,6 +195,8 @@
     "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
 
     "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
+
+    "mmdb-lib": ["mmdb-lib@3.0.2", "", {}, "sha512-7e87vk0DdWT647wjcfEtWeMtjm+zVGqNohN/aeIymbUfjHQ2T4Sx5kM+1irVDBSloNC3CkGKxswdMoo8yhqTDg=="],
 
     "modern-tar": ["modern-tar@0.7.6", "", {}, "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg=="],
 

--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,6 @@
 {
   "headless": true,
+  "xvfb": false,
   "initializeLogins": true,
   "deleteLosslessAfterConversion": true,
   "cleanupSoundCloudAccount": true

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"cloakbrowser": "^0.5.3",
 		"execa": "^10.0.1",
 		"find-bin": "^1.1.1",
+		"mmdb-lib": "^3.0.2",
 		"puppeteer": "^25.4.0",
 		"soundcloud.ts": "^0.7.4"
 	},

--- a/src/audioProcessor.ts
+++ b/src/audioProcessor.ts
@@ -1,5 +1,6 @@
 import { existsSync } from 'node:fs';
-import { basename, join } from 'node:path';
+import { rename } from 'node:fs/promises';
+import { basename, extname, join } from 'node:path';
 import { confirm, input } from '@inquirer/prompts';
 import { execa } from 'execa';
 import type { SoundcloudTrack } from 'soundcloud.ts';
@@ -7,13 +8,14 @@ import {
 	pickUniqueDownloadFilename,
 	withDownloadRenameLock,
 } from './downloadRename';
-import type { Metadata } from './types';
+import type { Metadata, OutputFormat } from './types';
 import {
 	getDefaultMetadata,
 	isLosslessFormat,
 	isMp3Format,
 	needsMp3Conversion,
 	REPO_URL,
+	toFlacFilename,
 	toMp3Filename,
 } from './utils';
 
@@ -146,6 +148,7 @@ export class AudioProcessor {
 		metadata: Metadata,
 		artwork: { buffer: ArrayBuffer; fileName: string },
 		losslessHandling: 'prompt' | 'always' | 'never' = 'prompt',
+		outputFormat: Exclude<OutputFormat, 'original'> = 'mp3-320',
 	): Promise<string> {
 		const inputPath = join('./downloads', filename);
 
@@ -157,6 +160,22 @@ export class AudioProcessor {
 		}
 
 		try {
+			if (outputFormat === 'flac') {
+				const outputPath = await this.convertToFlac(
+					inputPath,
+					artworkPath,
+					metadata,
+					filename,
+				);
+				await this.maybeRemoveSource(
+					inputPath,
+					outputPath,
+					filename,
+					losslessHandling,
+				);
+				return outputPath;
+			}
+
 			// Convert non-MP3 audio (lossless or lossy containers like m4a) to MP3.
 			if (needsMp3Conversion(filename)) {
 				const outputPath = await this.convertToMp3(
@@ -166,22 +185,12 @@ export class AudioProcessor {
 					filename,
 				);
 
-				// ask if you want to remove the source file
-				let removeSourceFile = true;
-				if (losslessHandling === 'prompt') {
-					removeSourceFile = await confirm({
-						message: `Do you want to remove the ${isLosslessFormat(filename) ? 'lossless' : 'source'} file now?`,
-						default: true,
-					});
-				} else if (losslessHandling === 'always') {
-					removeSourceFile = true;
-				} else if (losslessHandling === 'never') {
-					removeSourceFile = false;
-				}
-				if (removeSourceFile) {
-					await Bun.file(inputPath).unlink();
-					console.log(`✓ Removed ${inputPath}`);
-				}
+				await this.maybeRemoveSource(
+					inputPath,
+					outputPath,
+					filename,
+					losslessHandling,
+				);
 				return outputPath;
 			}
 			// otherwise if it is an MP3, we retag it with the correct metadata
@@ -206,6 +215,27 @@ export class AudioProcessor {
 			} catch {
 				// ignore cleanup errors
 			}
+		}
+	}
+
+	private async maybeRemoveSource(
+		inputPath: string,
+		outputPath: string,
+		filename: string,
+		losslessHandling: 'prompt' | 'always' | 'never',
+	): Promise<void> {
+		if (inputPath === outputPath) return;
+
+		let removeSourceFile = losslessHandling !== 'never';
+		if (losslessHandling === 'prompt') {
+			removeSourceFile = await confirm({
+				message: `Do you want to remove the ${isLosslessFormat(filename) ? 'lossless' : 'source'} file now?`,
+				default: true,
+			});
+		}
+		if (removeSourceFile) {
+			await Bun.file(inputPath).unlink();
+			console.log(`✓ Removed ${inputPath}`);
 		}
 	}
 
@@ -256,6 +286,20 @@ export class AudioProcessor {
 			bitrateKbps,
 			codecName: audioStream?.codec_name ?? null,
 		};
+	}
+
+	/** Detect whether the downloaded audio codec is lossless. */
+	async isLosslessAudio(inputPath: string): Promise<boolean | null> {
+		const { codecName } = await this.probeAudioStream(inputPath);
+		if (!codecName) return null;
+		const codec = codecName.toLowerCase();
+		return (
+			codec === 'alac' ||
+			codec === 'flac' ||
+			codec === 'wavpack' ||
+			codec === 'ape' ||
+			codec.startsWith('pcm_')
+		);
 	}
 
 	/**
@@ -363,6 +407,86 @@ export class AudioProcessor {
 			}
 			throw error;
 		}
+		console.log(`✓ Converted to ${outputPath}`);
+		return outputPath;
+	}
+
+	private async convertToFlac(
+		inputPath: string,
+		artworkPath: string,
+		metadata: Metadata,
+		filename: string,
+	): Promise<string> {
+		const replacingFlac = extname(filename).toLowerCase() === '.flac';
+		const outputPath = replacingFlac
+			? join('./downloads', `.converting-${crypto.randomUUID()}.flac`)
+			: await withDownloadRenameLock(async () => {
+					const desiredFilename = toFlacFilename(filename);
+					const finalName = pickUniqueDownloadFilename({
+						desiredFilename,
+						currentFilename: basename(inputPath),
+						jobId: crypto.randomUUID(),
+						exists: (name) => existsSync(join('./downloads', name)),
+						isOwnedByOtherJob: () => false,
+					});
+					const path = join('./downloads', finalName);
+					if (!existsSync(path)) await Bun.write(path, new Uint8Array());
+					return path;
+				});
+
+		const losslessSource = await this.isLosslessAudio(inputPath);
+		if (losslessSource === false) {
+			const { codecName } = await this.probeAudioStream(inputPath);
+			console.warn(
+				`Source codec ${codecName ?? 'unknown'} is lossy; FLAC conversion cannot restore lost audio quality.`,
+			);
+		}
+
+		const args = [
+			'-i',
+			inputPath,
+			'-i',
+			artworkPath,
+			'-map',
+			'0:a',
+			'-map',
+			'1:v',
+			'-c:a',
+			'flac',
+			'-compression_level',
+			'8',
+			'-c:v',
+			'copy',
+			'-disposition:v',
+			'attached_pic',
+			'-metadata:s:v',
+			'title=Album cover',
+			'-metadata:s:v',
+			'comment=Cover (front)',
+		];
+
+		if (metadata.title) args.push('-metadata', `title=${metadata.title}`);
+		if (metadata.artist) args.push('-metadata', `artist=${metadata.artist}`);
+		if (metadata.album) args.push('-metadata', `album=${metadata.album}`);
+		if (metadata.genre) args.push('-metadata', `genre=${metadata.genre}`);
+		args.push('-y', outputPath);
+
+		console.log('Converting to FLAC...');
+		try {
+			await execa(this.ffmpegBin, args);
+			if (replacingFlac) {
+				await Bun.file(inputPath).unlink();
+				await rename(outputPath, inputPath);
+				console.log(`✓ Converted to ${inputPath}`);
+				return inputPath;
+			}
+		} catch (error) {
+			await Bun.file(outputPath)
+				.unlink()
+				.catch(() => {});
+			throw error;
+		}
+
 		console.log(`✓ Converted to ${outputPath}`);
 		return outputPath;
 	}

--- a/src/browserLaunch.test.ts
+++ b/src/browserLaunch.test.ts
@@ -1,5 +1,83 @@
 import { describe, expect, test } from 'bun:test';
-import { buildXvfbBrowserEnv } from './browserLaunch';
+import {
+	buildXvfbBrowserEnv,
+	createXvfbManager,
+	readXvfbDisplay,
+	type XvfbSession,
+} from './browserLaunch';
+
+const streamOf = (text: string) =>
+	new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.enqueue(new TextEncoder().encode(text));
+			controller.close();
+		},
+	});
+
+const fakeSession = (display: string, kill: () => void): XvfbSession => ({
+	display,
+	users: 0,
+	process: {
+		stdout: streamOf(''),
+		stderr: streamOf(''),
+		exited: new Promise<number>(() => {}),
+		kill,
+	},
+});
+
+describe('readXvfbDisplay', () => {
+	test('parses the display number written by -displayfd', async () => {
+		expect(await readXvfbDisplay(streamOf('99\n'))).toBe(':99');
+	});
+
+	test('rejects invalid or empty output', async () => {
+		await expect(readXvfbDisplay(streamOf('nope\n'))).rejects.toThrow(
+			'invalid display number',
+		);
+		await expect(readXvfbDisplay(streamOf(''))).rejects.toThrow(
+			'invalid display number',
+		);
+	});
+});
+
+describe('createXvfbManager', () => {
+	test('kills the shared process only after the final release', async () => {
+		let kills = 0;
+		const acquire = createXvfbManager(async () =>
+			fakeSession(':1', () => {
+				kills += 1;
+			}),
+		);
+		const first = await acquire();
+		const second = await acquire();
+
+		first.release();
+		expect(kills).toBe(0);
+		second.release();
+		second.release();
+		expect(kills).toBe(1);
+	});
+
+	test('retries when the active session is released during acquire', async () => {
+		const kills = [0, 0];
+		let starts = 0;
+		const acquire = createXvfbManager(async () => {
+			const index = starts++;
+			return fakeSession(`:${index + 1}`, () => {
+				kills[index] = (kills[index] ?? 0) + 1;
+			});
+		});
+		const first = await acquire();
+		const pendingSecond = acquire();
+		first.release();
+
+		const second = await pendingSecond;
+		expect(second.display).toBe(':2');
+		expect(kills).toEqual([1, 0]);
+		second.release();
+		expect(kills).toEqual([1, 1]);
+	});
+});
 
 describe('buildXvfbBrowserEnv', () => {
 	test('forces X11 and removes the inherited Wayland display', () => {

--- a/src/browserLaunch.test.ts
+++ b/src/browserLaunch.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test';
+import { buildXvfbBrowserEnv } from './browserLaunch';
+
+describe('buildXvfbBrowserEnv', () => {
+	test('forces X11 and removes the inherited Wayland display', () => {
+		expect(
+			buildXvfbBrowserEnv(':99', {
+				DISPLAY: ':0',
+				WAYLAND_DISPLAY: 'wayland-0',
+				XDG_SESSION_TYPE: 'wayland',
+				PATH: '/usr/bin',
+			}),
+		).toEqual({
+			DISPLAY: ':99',
+			XDG_SESSION_TYPE: 'x11',
+			OZONE_PLATFORM: 'x11',
+			PATH: '/usr/bin',
+		});
+	});
+});

--- a/src/browserLaunch.ts
+++ b/src/browserLaunch.ts
@@ -3,6 +3,8 @@ import type { Browser } from 'puppeteer';
 
 export type AppBrowserLaunchOptions = {
 	headless?: boolean;
+	/** Run headed Chromium inside an invisible Xvfb display. */
+	xvfb?: boolean;
 	userDataDir?: string;
 	/** Extra Chromium/CloakBrowser flags merged onto the defaults. */
 	args?: string[];
@@ -10,6 +12,22 @@ export type AppBrowserLaunchOptions = {
 	defaultViewport?: { width: number; height: number } | null;
 	humanize?: boolean;
 };
+
+type XvfbProcess = {
+	stdout: ReadableStream<Uint8Array>;
+	stderr: ReadableStream<Uint8Array>;
+	exited: Promise<number>;
+	kill: () => void;
+};
+
+type XvfbSession = {
+	display: string;
+	process: XvfbProcess;
+	users: number;
+};
+
+let xvfbSession: XvfbSession | null = null;
+let xvfbStartPromise: Promise<XvfbSession> | null = null;
 
 export const DEFAULT_BROWSER_ARGS = [
 	'--no-sandbox',
@@ -22,10 +40,116 @@ export const DEFAULT_BROWSER_ARGS = [
 	'--window-size=1920,1080',
 ];
 
+async function readXvfbDisplay(
+	stdout: ReadableStream<Uint8Array>,
+): Promise<string> {
+	const reader = stdout.getReader();
+	const decoder = new TextDecoder();
+	let output = '';
+
+	while (!output.includes('\n')) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		output += decoder.decode(value, { stream: true });
+	}
+
+	reader.releaseLock();
+	const displayNumber = output.trim();
+	if (!/^\d+$/.test(displayNumber)) {
+		throw new Error(
+			`Xvfb returned an invalid display number: ${output.trim()}`,
+		);
+	}
+	return `:${displayNumber}`;
+}
+
+async function startXvfb(): Promise<XvfbSession> {
+	let process: XvfbProcess;
+	try {
+		process = Bun.spawn(
+			[
+				'Xvfb',
+				'-displayfd',
+				'1',
+				'-screen',
+				'0',
+				'1920x1080x24',
+				'-nolisten',
+				'tcp',
+			],
+			{ stdin: 'ignore', stdout: 'pipe', stderr: 'pipe' },
+		);
+	} catch (error) {
+		throw new Error(
+			`Could not start Xvfb. Install it or disable the Xvfb option. ${error instanceof Error ? error.message : ''}`.trim(),
+		);
+	}
+
+	let startTimeout: ReturnType<typeof setTimeout> | undefined;
+	try {
+		const display = await Promise.race([
+			readXvfbDisplay(process.stdout),
+			new Promise<never>((_, reject) => {
+				startTimeout = setTimeout(
+					() => reject(new Error('Xvfb did not start within 5 seconds')),
+					5_000,
+				);
+			}),
+			process.exited.then(async (exitCode) => {
+				const stderr = await new Response(process.stderr).text();
+				throw new Error(
+					`Xvfb exited with code ${exitCode}${stderr.trim() ? `: ${stderr.trim()}` : ''}`,
+				);
+			}),
+		]);
+		return { display, process, users: 0 };
+	} catch (error) {
+		process.kill();
+		throw error;
+	} finally {
+		if (startTimeout) clearTimeout(startTimeout);
+	}
+}
+
+async function acquireXvfb(): Promise<{
+	display: string;
+	release: () => void;
+}> {
+	if (!xvfbStartPromise) {
+		xvfbStartPromise = startXvfb()
+			.then((session) => {
+				xvfbSession = session;
+				return session;
+			})
+			.catch((error) => {
+				xvfbStartPromise = null;
+				throw error;
+			});
+	}
+
+	const session = await xvfbStartPromise;
+	session.users += 1;
+	let released = false;
+
+	return {
+		display: session.display,
+		release: () => {
+			if (released) return;
+			released = true;
+			session.users -= 1;
+			if (session.users === 0 && xvfbSession === session) {
+				session.process.kill();
+				xvfbSession = null;
+				xvfbStartPromise = null;
+			}
+		},
+	};
+}
+
 /**
  * Launch CloakBrowser (stealth Chromium) for all automation.
  * Optional `CLOAKBROWSER_PROXY` / `PROXY_URL` for residential egress when an IP is hard-blocked.
- * Set `CLOAKBROWSER_GEOIP=true` (requires `bun add mmdb-lib`) to match timezone to the proxy.
+ * Proxy GeoIP matching is enabled by default and can be disabled with `CLOAKBROWSER_GEOIP=false`.
  */
 export async function launchAppBrowser(
 	options: AppBrowserLaunchOptions = {},
@@ -37,29 +161,49 @@ export async function launchAppBrowser(
 		process.env.PROXY_URL?.trim() ||
 		undefined;
 
-	const geoip = Boolean(proxy) && process.env.CLOAKBROWSER_GEOIP === 'true';
+	const geoip = Boolean(proxy) && process.env.CLOAKBROWSER_GEOIP !== 'false';
+	const useXvfb = options.xvfb ?? false;
+	const xvfb = useXvfb ? await acquireXvfb() : null;
 
 	const args = [...DEFAULT_BROWSER_ARGS, ...(options.args ?? [])];
 
 	const launchOpts = {
-		headless: options.headless ?? true,
+		// Xvfb keeps the browser invisible while preserving headed-mode signals.
+		headless: useXvfb ? false : (options.headless ?? true),
 		humanize: options.humanize ?? true,
 		stealthArgs: true,
 		...(proxy ? { proxy, ...(geoip ? { geoip: true } : {}) } : {}),
 		args,
 		launchOptions: {
+			...(xvfb
+				? {
+						env: Object.fromEntries(
+							Object.entries({ ...process.env, DISPLAY: xvfb.display }).filter(
+								(entry): entry is [string, string] =>
+									typeof entry[1] === 'string',
+							),
+						),
+					}
+				: {}),
 			...(options.defaultViewport !== undefined
 				? { defaultViewport: options.defaultViewport }
 				: {}),
 		},
 	};
 
-	const browser = options.userDataDir
-		? await launchPersistentContext({
-				...launchOpts,
-				userDataDir: options.userDataDir,
-			})
-		: await launch(launchOpts);
+	try {
+		const browser = options.userDataDir
+			? await launchPersistentContext({
+					...launchOpts,
+					userDataDir: options.userDataDir,
+				})
+			: await launch(launchOpts);
 
-	return browser as Browser;
+		const appBrowser = browser as Browser;
+		if (xvfb) appBrowser.once('disconnected', xvfb.release);
+		return appBrowser;
+	} catch (error) {
+		xvfb?.release();
+		throw error;
+	}
 }

--- a/src/browserLaunch.ts
+++ b/src/browserLaunch.ts
@@ -40,6 +40,23 @@ export const DEFAULT_BROWSER_ARGS = [
 	'--window-size=1920,1080',
 ];
 
+export function buildXvfbBrowserEnv(
+	display: string,
+	env: Record<string, string | undefined> = process.env,
+): Record<string, string> {
+	return Object.fromEntries(
+		Object.entries({
+			...env,
+			DISPLAY: display,
+			WAYLAND_DISPLAY: undefined,
+			XDG_SESSION_TYPE: 'x11',
+			OZONE_PLATFORM: 'x11',
+		}).filter(
+			(entry): entry is [string, string] => typeof entry[1] === 'string',
+		),
+	);
+}
+
 async function readXvfbDisplay(
 	stdout: ReadableStream<Uint8Array>,
 ): Promise<string> {
@@ -165,7 +182,12 @@ export async function launchAppBrowser(
 	const useXvfb = options.xvfb ?? false;
 	const xvfb = useXvfb ? await acquireXvfb() : null;
 
-	const args = [...DEFAULT_BROWSER_ARGS, ...(options.args ?? [])];
+	const args = [
+		...DEFAULT_BROWSER_ARGS,
+		...(options.args ?? []),
+		// Plasma Wayland otherwise lets Chromium bypass DISPLAY and open visibly.
+		...(useXvfb ? ['--ozone-platform=x11'] : []),
+	];
 
 	const launchOpts = {
 		// Xvfb keeps the browser invisible while preserving headed-mode signals.
@@ -177,12 +199,7 @@ export async function launchAppBrowser(
 		launchOptions: {
 			...(xvfb
 				? {
-						env: Object.fromEntries(
-							Object.entries({ ...process.env, DISPLAY: xvfb.display }).filter(
-								(entry): entry is [string, string] =>
-									typeof entry[1] === 'string',
-							),
-						),
+						env: buildXvfbBrowserEnv(xvfb.display),
 					}
 				: {}),
 			...(options.defaultViewport !== undefined

--- a/src/browserLaunch.ts
+++ b/src/browserLaunch.ts
@@ -1,6 +1,6 @@
 import { launch, launchPersistentContext } from 'cloakbrowser/puppeteer';
 import type { Browser } from 'puppeteer';
-import type { BrowserMode } from './types';
+import type { BrowserMode, HypedditConfig } from './types';
 
 export type AppBrowserLaunchOptions = {
 	headless?: boolean;
@@ -45,6 +45,15 @@ export function browserModeToLaunchOptions(
 		headless: browserMode === 'headless',
 		xvfb: browserMode === 'xvfb',
 	};
+}
+
+export function launchConfiguredBrowser(
+	config: HypedditConfig,
+): Promise<Browser> {
+	return launchAppBrowser({
+		...browserModeToLaunchOptions(config.browserMode),
+		userDataDir: config.userDataDir ?? './browser-data',
+	});
 }
 
 export function buildXvfbBrowserEnv(

--- a/src/browserLaunch.ts
+++ b/src/browserLaunch.ts
@@ -1,5 +1,6 @@
 import { launch, launchPersistentContext } from 'cloakbrowser/puppeteer';
 import type { Browser } from 'puppeteer';
+import type { BrowserMode } from './types';
 
 export type AppBrowserLaunchOptions = {
 	headless?: boolean;
@@ -13,21 +14,18 @@ export type AppBrowserLaunchOptions = {
 	humanize?: boolean;
 };
 
-type XvfbProcess = {
+export type XvfbProcess = {
 	stdout: ReadableStream<Uint8Array>;
 	stderr: ReadableStream<Uint8Array>;
 	exited: Promise<number>;
 	kill: () => void;
 };
 
-type XvfbSession = {
+export type XvfbSession = {
 	display: string;
 	process: XvfbProcess;
 	users: number;
 };
-
-let xvfbSession: XvfbSession | null = null;
-let xvfbStartPromise: Promise<XvfbSession> | null = null;
 
 export const DEFAULT_BROWSER_ARGS = [
 	'--no-sandbox',
@@ -39,6 +37,15 @@ export const DEFAULT_BROWSER_ARGS = [
 	'--disable-restore-session-state',
 	'--window-size=1920,1080',
 ];
+
+export function browserModeToLaunchOptions(
+	browserMode: BrowserMode,
+): Pick<AppBrowserLaunchOptions, 'headless' | 'xvfb'> {
+	return {
+		headless: browserMode === 'headless',
+		xvfb: browserMode === 'xvfb',
+	};
+}
 
 export function buildXvfbBrowserEnv(
 	display: string,
@@ -57,7 +64,7 @@ export function buildXvfbBrowserEnv(
 	);
 }
 
-async function readXvfbDisplay(
+export async function readXvfbDisplay(
 	stdout: ReadableStream<Uint8Array>,
 ): Promise<string> {
 	const reader = stdout.getReader();
@@ -128,40 +135,53 @@ async function startXvfb(): Promise<XvfbSession> {
 	}
 }
 
-async function acquireXvfb(): Promise<{
-	display: string;
-	release: () => void;
-}> {
-	if (!xvfbStartPromise) {
-		xvfbStartPromise = startXvfb()
-			.then((session) => {
-				xvfbSession = session;
-				return session;
-			})
-			.catch((error) => {
-				xvfbStartPromise = null;
-				throw error;
-			});
-	}
+export function createXvfbManager(
+	start: () => Promise<XvfbSession> = startXvfb,
+): () => Promise<{ display: string; release: () => void }> {
+	let activeSession: XvfbSession | null = null;
+	let startPromise: Promise<XvfbSession> | null = null;
 
-	const session = await xvfbStartPromise;
-	session.users += 1;
-	let released = false;
-
-	return {
-		display: session.display,
-		release: () => {
-			if (released) return;
-			released = true;
-			session.users -= 1;
-			if (session.users === 0 && xvfbSession === session) {
-				session.process.kill();
-				xvfbSession = null;
-				xvfbStartPromise = null;
+	return async function acquireXvfb() {
+		let session: XvfbSession;
+		while (true) {
+			if (!startPromise) {
+				startPromise = start()
+					.then((started) => {
+						activeSession = started;
+						return started;
+					})
+					.catch((error) => {
+						startPromise = null;
+						throw error;
+					});
 			}
-		},
+
+			const candidate = await startPromise;
+			if (activeSession === candidate) {
+				session = candidate;
+				session.users += 1;
+				break;
+			}
+		}
+
+		let released = false;
+		return {
+			display: session.display,
+			release: () => {
+				if (released) return;
+				released = true;
+				session.users -= 1;
+				if (session.users === 0 && activeSession === session) {
+					session.process.kill();
+					activeSession = null;
+					startPromise = null;
+				}
+			},
+		};
 	};
 }
+
+const acquireXvfb = createXvfbManager();
 
 /**
  * Launch CloakBrowser (stealth Chromium) for all automation.

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,7 @@ export async function loadConfig(): Promise<AppConfig | null> {
 
 	const entries = CONFIG_KEYS.map((key) => {
 		if (!(key in raw)) {
+			if (key === 'xvfb') return [key, exampleConfig[key]] as const;
 			throw new Error(`config.json is missing required key: ${key}`);
 		}
 		const value = raw[key];

--- a/src/deepLink.test.ts
+++ b/src/deepLink.test.ts
@@ -1,14 +1,39 @@
 import { describe, expect, test } from 'bun:test';
-import { shouldAutoStartDeepLink } from '../webui/src/components/deepLink';
-import { isBrowserMode } from './types';
+import {
+	readStoredBrowserMode,
+	shouldAutoStartDeepLink,
+} from '../webui/src/components/deepLink';
 
-describe('deep-link browser mode hydration', () => {
-	test('waits until a stored Xvfb mode has been applied', () => {
+describe('deep-link startup predicate', () => {
+	test('waits for browser-mode hydration', () => {
 		const queryUrl = 'https://soundcloud.com/artist/track';
 		expect(shouldAutoStartDeepLink(false, false, queryUrl)).toBeFalse();
-
-		const storedMode = 'xvfb';
-		expect(isBrowserMode(storedMode)).toBeTrue();
 		expect(shouldAutoStartDeepLink(true, false, queryUrl)).toBeTrue();
+	});
+
+	test('does not restart an already-started deep link', () => {
+		expect(
+			shouldAutoStartDeepLink(
+				true,
+				true,
+				'https://soundcloud.com/artist/track',
+			),
+		).toBeFalse();
+	});
+
+	test('requires a query URL', () => {
+		expect(shouldAutoStartDeepLink(true, false, null)).toBeFalse();
+	});
+});
+
+describe('browser-mode preference hydration', () => {
+	test('reads stored Xvfb through the same helper used by the UI', () => {
+		const storage = { getItem: () => 'xvfb' };
+		expect(readStoredBrowserMode(storage, 'browser-mode')).toBe('xvfb');
+	});
+
+	test('ignores invalid stored modes', () => {
+		const storage = { getItem: () => 'invalid' };
+		expect(readStoredBrowserMode(storage, 'browser-mode')).toBeNull();
 	});
 });

--- a/src/deepLink.test.ts
+++ b/src/deepLink.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'bun:test';
+import { shouldAutoStartDeepLink } from '../webui/src/components/deepLink';
+import { isBrowserMode } from './types';
+
+describe('deep-link browser mode hydration', () => {
+	test('waits until a stored Xvfb mode has been applied', () => {
+		const queryUrl = 'https://soundcloud.com/artist/track';
+		expect(shouldAutoStartDeepLink(false, false, queryUrl)).toBeFalse();
+
+		const storedMode = 'xvfb';
+		expect(isBrowserMode(storedMode)).toBeTrue();
+		expect(shouldAutoStartDeepLink(true, false, queryUrl)).toBeTrue();
+	});
+});

--- a/src/downloadgater.ts
+++ b/src/downloadgater.ts
@@ -32,6 +32,7 @@ export class DownloadgaterDownloader {
 	async initialize() {
 		this.browser = await launchAppBrowser({
 			headless: this.config.headless,
+			xvfb: this.config.xvfb,
 			userDataDir: this.config.userDataDir ?? './browser-data',
 		});
 

--- a/src/downloadgater.ts
+++ b/src/downloadgater.ts
@@ -1,6 +1,6 @@
 import { Presets, SingleBar } from 'cli-progress';
 import type { Browser, Page } from 'puppeteer';
-import { launchAppBrowser } from './browserLaunch';
+import { browserModeToLaunchOptions, launchAppBrowser } from './browserLaunch';
 import type { ProgressCallback } from './hypeddit';
 import Selectors from './selectors';
 import type { HypedditConfig } from './types';
@@ -31,8 +31,7 @@ export class DownloadgaterDownloader {
 
 	async initialize() {
 		this.browser = await launchAppBrowser({
-			headless: this.config.headless,
-			xvfb: this.config.xvfb,
+			...browserModeToLaunchOptions(this.config.browserMode),
 			userDataDir: this.config.userDataDir ?? './browser-data',
 		});
 

--- a/src/downloadgater.ts
+++ b/src/downloadgater.ts
@@ -1,6 +1,6 @@
 import { Presets, SingleBar } from 'cli-progress';
 import type { Browser, Page } from 'puppeteer';
-import { browserModeToLaunchOptions, launchAppBrowser } from './browserLaunch';
+import { launchConfiguredBrowser } from './browserLaunch';
 import type { ProgressCallback } from './hypeddit';
 import Selectors from './selectors';
 import type { HypedditConfig } from './types';
@@ -30,10 +30,7 @@ export class DownloadgaterDownloader {
 	}
 
 	async initialize() {
-		this.browser = await launchAppBrowser({
-			...browserModeToLaunchOptions(this.config.browserMode),
-			userDataDir: this.config.userDataDir ?? './browser-data',
-		});
+		this.browser = await launchConfiguredBrowser(this.config);
 
 		const browserContext = this.browser.defaultBrowserContext();
 		const soundCloudCookies = await loadCookies('soundcloud-cookies.json');

--- a/src/droploud.ts
+++ b/src/droploud.ts
@@ -1,6 +1,6 @@
 import { Presets, SingleBar } from 'cli-progress';
 import type { Browser, Page } from 'puppeteer';
-import { launchAppBrowser } from './browserLaunch';
+import { browserModeToLaunchOptions, launchAppBrowser } from './browserLaunch';
 import type { ProgressCallback } from './hypeddit';
 import Selectors from './selectors';
 import { SoundcloudClient } from './soundcloud';
@@ -41,8 +41,7 @@ export class DroploudDownloader {
 
 	async initialize() {
 		this.browser = await launchAppBrowser({
-			headless: this.config.headless,
-			xvfb: this.config.xvfb,
+			...browserModeToLaunchOptions(this.config.browserMode),
 			userDataDir: this.config.userDataDir ?? './browser-data',
 		});
 
@@ -784,7 +783,7 @@ export class DroploudDownloader {
 			return;
 		}
 
-		if (!this.config.headless && !closed && !page.isClosed()) {
+		if (this.config.browserMode === 'headed' && !closed && !page.isClosed()) {
 			console.log(
 				'Droploud: waiting up to 2 minutes for manual Repost / captcha solve…',
 			);

--- a/src/droploud.ts
+++ b/src/droploud.ts
@@ -1,6 +1,6 @@
 import { Presets, SingleBar } from 'cli-progress';
 import type { Browser, Page } from 'puppeteer';
-import { browserModeToLaunchOptions, launchAppBrowser } from './browserLaunch';
+import { launchConfiguredBrowser } from './browserLaunch';
 import type { ProgressCallback } from './hypeddit';
 import Selectors from './selectors';
 import { SoundcloudClient } from './soundcloud';
@@ -40,10 +40,7 @@ export class DroploudDownloader {
 	}
 
 	async initialize() {
-		this.browser = await launchAppBrowser({
-			...browserModeToLaunchOptions(this.config.browserMode),
-			userDataDir: this.config.userDataDir ?? './browser-data',
-		});
+		this.browser = await launchConfiguredBrowser(this.config);
 
 		const browserContext = this.browser.defaultBrowserContext();
 		const soundCloudCookies = await loadCookies('soundcloud-cookies.json');

--- a/src/droploud.ts
+++ b/src/droploud.ts
@@ -42,6 +42,7 @@ export class DroploudDownloader {
 	async initialize() {
 		this.browser = await launchAppBrowser({
 			headless: this.config.headless,
+			xvfb: this.config.xvfb,
 			userDataDir: this.config.userDataDir ?? './browser-data',
 		});
 

--- a/src/gaterush.ts
+++ b/src/gaterush.ts
@@ -32,6 +32,7 @@ export class GaterushDownloader {
 	async initialize() {
 		this.browser = await launchAppBrowser({
 			headless: this.config.headless,
+			xvfb: this.config.xvfb,
 			userDataDir: this.config.userDataDir ?? './browser-data',
 		});
 

--- a/src/gaterush.ts
+++ b/src/gaterush.ts
@@ -1,6 +1,6 @@
 import { Presets, SingleBar } from 'cli-progress';
 import type { Browser, Page } from 'puppeteer';
-import { launchAppBrowser } from './browserLaunch';
+import { browserModeToLaunchOptions, launchAppBrowser } from './browserLaunch';
 import type { ProgressCallback } from './hypeddit';
 import Selectors from './selectors';
 import type { HypedditConfig } from './types';
@@ -31,8 +31,7 @@ export class GaterushDownloader {
 
 	async initialize() {
 		this.browser = await launchAppBrowser({
-			headless: this.config.headless,
-			xvfb: this.config.xvfb,
+			...browserModeToLaunchOptions(this.config.browserMode),
 			userDataDir: this.config.userDataDir ?? './browser-data',
 		});
 

--- a/src/gaterush.ts
+++ b/src/gaterush.ts
@@ -1,6 +1,6 @@
 import { Presets, SingleBar } from 'cli-progress';
 import type { Browser, Page } from 'puppeteer';
-import { browserModeToLaunchOptions, launchAppBrowser } from './browserLaunch';
+import { launchConfiguredBrowser } from './browserLaunch';
 import type { ProgressCallback } from './hypeddit';
 import Selectors from './selectors';
 import type { HypedditConfig } from './types';
@@ -30,10 +30,7 @@ export class GaterushDownloader {
 	}
 
 	async initialize() {
-		this.browser = await launchAppBrowser({
-			...browserModeToLaunchOptions(this.config.browserMode),
-			userDataDir: this.config.userDataDir ?? './browser-data',
-		});
+		this.browser = await launchConfiguredBrowser(this.config);
 
 		const browserContext = this.browser.defaultBrowserContext();
 		const soundCloudCookies = await loadCookies('soundcloud-cookies.json');

--- a/src/hypeddit.ts
+++ b/src/hypeddit.ts
@@ -1,6 +1,6 @@
 import { Presets, SingleBar } from 'cli-progress';
 import type { Browser, Page } from 'puppeteer';
-import { launchAppBrowser } from './browserLaunch';
+import { browserModeToLaunchOptions, launchAppBrowser } from './browserLaunch';
 import Selectors from './selectors';
 import type { HypedditConfig, JobProgress, JobStage } from './types';
 import { loadCookies, REPO_URL, timeout } from './utils';
@@ -101,8 +101,7 @@ export class HypedditDownloader {
 
 	async initialize() {
 		this.browser = await launchAppBrowser({
-			headless: this.config.headless,
-			xvfb: this.config.xvfb,
+			...browserModeToLaunchOptions(this.config.browserMode),
 			userDataDir: this.config.userDataDir ?? './browser-data',
 		});
 

--- a/src/hypeddit.ts
+++ b/src/hypeddit.ts
@@ -102,6 +102,7 @@ export class HypedditDownloader {
 	async initialize() {
 		this.browser = await launchAppBrowser({
 			headless: this.config.headless,
+			xvfb: this.config.xvfb,
 			userDataDir: this.config.userDataDir ?? './browser-data',
 		});
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,6 +121,16 @@ try {
 					message: 'Run headless? (no browser window)',
 					default: true,
 				});
+	const xvfb =
+		!isBrowserless && headless
+			? config
+				? config.xvfb
+				: await confirm({
+						message:
+							'Use Xvfb for stronger anti-bot protection? (invisible headed browser)',
+						default: false,
+					})
+			: false;
 
 	const initializeLogins = isBrowserless
 		? false
@@ -137,6 +147,7 @@ try {
 		email: HYPEDDIT_EMAIL,
 		comment: SC_COMMENT,
 		headless,
+		xvfb,
 	};
 
 	let downloadFilename: string | null = null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,8 +146,11 @@ try {
 		name: HYPEDDIT_NAME,
 		email: HYPEDDIT_EMAIL,
 		comment: SC_COMMENT,
-		headless,
-		xvfb,
+		browserMode: xvfb
+			? ('xvfb' as const)
+			: headless
+				? ('headless' as const)
+				: ('headed' as const),
 	};
 
 	let downloadFilename: string | null = null;

--- a/src/jobStore.ts
+++ b/src/jobStore.ts
@@ -38,6 +38,7 @@ class JobStore {
 			},
 			downloadFilename: null,
 			outputFilename: null,
+			sourceIsLossless: null,
 			artworkBuffer: null,
 			artworkFileName: null,
 			error: null,

--- a/src/jobStore.ts
+++ b/src/jobStore.ts
@@ -24,8 +24,8 @@ class JobStore {
 			soundcloudUrl,
 			hypedditUrl: null,
 			bandcampAlbumTracks: null,
-			headless: process.env.BROWSER_HEADLESS !== 'false',
-			xvfb: false,
+			browserMode:
+				process.env.BROWSER_HEADLESS === 'false' ? 'headed' : 'headless',
 			outputFormat,
 			cancelled: false,
 			track: null,

--- a/src/jobStore.ts
+++ b/src/jobStore.ts
@@ -25,6 +25,7 @@ class JobStore {
 			hypedditUrl: null,
 			bandcampAlbumTracks: null,
 			headless: process.env.BROWSER_HEADLESS !== 'false',
+			xvfb: false,
 			outputFormat,
 			cancelled: false,
 			track: null,

--- a/src/server.ts
+++ b/src/server.ts
@@ -444,6 +444,12 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 		}
 
 		jobStore.update(jobId, { downloadFilename });
+		if (job.outputFormat === 'flac') {
+			const sourceIsLossless = await audioProcessor.isLosslessAudio(
+				join('./downloads', downloadFilename),
+			);
+			jobStore.update(jobId, { sourceIsLossless });
+		}
 
 		if (job.outputFormat === 'original') {
 			jobStore.update(jobId, { outputFilename: downloadFilename });
@@ -684,10 +690,13 @@ const server = Bun.serve({
 					if (
 						outputFormat !== undefined &&
 						outputFormat !== 'original' &&
-						outputFormat !== 'mp3-320'
+						outputFormat !== 'mp3-320' &&
+						outputFormat !== 'flac'
 					) {
 						return jsonResponse(
-							{ error: 'outputFormat must be "original" or "mp3-320"' },
+							{
+								error: 'outputFormat must be "original", "mp3-320", or "flac"',
+							},
 							{ status: 400 },
 						);
 					}
@@ -1099,6 +1108,7 @@ const server = Bun.serve({
 					progress: job.progress,
 					downloadFilename: job.downloadFilename,
 					outputFilename: job.outputFilename,
+					sourceIsLossless: job.sourceIsLossless,
 					hasArtwork: !!job.artworkBuffer,
 					error: job.error,
 				});
@@ -1265,6 +1275,7 @@ const server = Bun.serve({
 						metadata,
 						artwork,
 						'always',
+						job.outputFormat,
 					);
 
 					let outputFilename = basename(outputPath);
@@ -1272,7 +1283,11 @@ const server = Bun.serve({
 						outputFilename = await renameDownloadFile(
 							jobId,
 							outputFilename,
-							artistTitleFilename(metadata.artist, metadata.title, '.mp3'),
+							artistTitleFilename(
+								metadata.artist,
+								metadata.title,
+								job.outputFormat === 'flac' ? '.flac' : '.mp3',
+							),
 						);
 					}
 					jobStore.update(jobId, {

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,7 +12,12 @@ import { HypedditDownloader } from './hypeddit';
 import { HypedditHttpDownloader } from './hypedditHttp';
 import { jobStore } from './jobStore';
 import { SoundcloudClient } from './soundcloud';
-import type { Job, Metadata, OutputFormat } from './types';
+import {
+	isBrowserMode,
+	type Job,
+	type Metadata,
+	type OutputFormat,
+} from './types';
 import {
 	artistTitleFilename,
 	extractAndResolveGateUrl,
@@ -225,8 +230,7 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 			name: HYPEDDIT_NAME,
 			email: HYPEDDIT_EMAIL,
 			comment: SC_COMMENT,
-			headless: job.headless,
-			xvfb: job.xvfb,
+			browserMode: job.browserMode,
 		};
 
 		const prepareBrowserConfig = async () => {
@@ -630,7 +634,7 @@ const server = Bun.serve({
 						name: HYPEDDIT_NAME,
 						email: HYPEDDIT_EMAIL,
 						comment: SC_COMMENT,
-						headless: false,
+						browserMode: 'headed',
 					});
 
 					await loginDownloader.initialize();
@@ -898,16 +902,32 @@ const server = Bun.serve({
 					jobStore.clearCancelled(jobId);
 
 					try {
-						const body = (await req.json()) as {
-							headless?: boolean;
-							xvfb?: boolean;
-						};
-						if (typeof body.headless === 'boolean') {
-							jobStore.update(jobId, { headless: body.headless });
+						const body = (await req.json()) as Record<string, unknown>;
+						let browserMode: Job['browserMode'] | undefined;
+						if (body.browserMode !== undefined) {
+							if (!isBrowserMode(body.browserMode)) {
+								return jsonResponse(
+									{ error: 'Invalid browser mode' },
+									{ status: 400 },
+								);
+							}
+							browserMode = body.browserMode;
+						} else if (
+							typeof body.headless === 'boolean' &&
+							body.xvfb === undefined
+						) {
+							// Backward compatibility for clients predating the mode selector.
+							browserMode = body.headless ? 'headless' : 'headed';
+						} else if (body.headless !== undefined || body.xvfb !== undefined) {
+							return jsonResponse(
+								{
+									error:
+										'Use browserMode instead of headless/xvfb combinations',
+								},
+								{ status: 400 },
+							);
 						}
-						if (typeof body.xvfb === 'boolean') {
-							jobStore.update(jobId, { xvfb: body.xvfb });
-						}
+						if (browserMode) jobStore.update(jobId, { browserMode });
 					} catch {
 						// No/empty JSON body — keep job default / BROWSER_HEADLESS
 					}
@@ -1075,6 +1095,7 @@ const server = Bun.serve({
 					defaultMetadata: job.defaultMetadata,
 					existingMetadata: job.existingMetadata,
 					outputFormat: job.outputFormat,
+					browserMode: job.browserMode,
 					progress: job.progress,
 					downloadFilename: job.downloadFilename,
 					outputFilename: job.outputFilename,

--- a/src/server.ts
+++ b/src/server.ts
@@ -226,6 +226,7 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 			email: HYPEDDIT_EMAIL,
 			comment: SC_COMMENT,
 			headless: job.headless,
+			xvfb: job.xvfb,
 		};
 
 		const prepareBrowserConfig = async () => {
@@ -897,9 +898,15 @@ const server = Bun.serve({
 					jobStore.clearCancelled(jobId);
 
 					try {
-						const body = (await req.json()) as { headless?: boolean };
+						const body = (await req.json()) as {
+							headless?: boolean;
+							xvfb?: boolean;
+						};
 						if (typeof body.headless === 'boolean') {
 							jobStore.update(jobId, { headless: body.headless });
+						}
+						if (typeof body.xvfb === 'boolean') {
+							jobStore.update(jobId, { xvfb: body.xvfb });
 						}
 					} catch {
 						// No/empty JSON body — keep job default / BROWSER_HEADLESS

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,15 +9,19 @@ export interface LocalCookieData {
 	sameSite?: string;
 }
 
+export type BrowserMode = 'headless' | 'xvfb' | 'headed';
+
+export function isBrowserMode(value: unknown): value is BrowserMode {
+	return value === 'headless' || value === 'xvfb' || value === 'headed';
+}
+
 export interface HypedditConfig {
 	/** Optional — only needed for Hypeddit/GateRush email gates that ask for a name. */
 	name?: string;
 	/** Optional — only needed for Hypeddit/GateRush email gates. */
 	email?: string;
 	comment: string;
-	headless: boolean;
-	/** Use headed Chromium in an invisible Xvfb display. */
-	xvfb?: boolean;
+	browserMode: BrowserMode;
 	/** Persistent Chromium profile. Defaults to `./browser-data`. */
 	userDataDir?: string;
 }
@@ -74,10 +78,7 @@ export interface Job {
 	hypedditUrl: string | null;
 	/** Candidates when Bandcamp album auto-match fails (cleared after pick). */
 	bandcampAlbumTracks: BandcampAlbumTrackChoice[] | null;
-	/** Whether browser automation runs headless. Defaults to true. */
-	headless: boolean;
-	/** Whether headed Chromium runs in an invisible Xvfb display. */
-	xvfb: boolean;
+	browserMode: BrowserMode;
 	outputFormat: OutputFormat;
 	/** Set when the user cancels; download loop should stop and close the browser. */
 	cancelled: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,8 @@ export interface HypedditConfig {
 	email?: string;
 	comment: string;
 	headless: boolean;
+	/** Use headed Chromium in an invisible Xvfb display. */
+	xvfb?: boolean;
 	/** Persistent Chromium profile. Defaults to `./browser-data`. */
 	userDataDir?: string;
 }
@@ -74,6 +76,8 @@ export interface Job {
 	bandcampAlbumTracks: BandcampAlbumTrackChoice[] | null;
 	/** Whether browser automation runs headless. Defaults to true. */
 	headless: boolean;
+	/** Whether headed Chromium runs in an invisible Xvfb display. */
+	xvfb: boolean;
 	outputFormat: OutputFormat;
 	/** Set when the user cancels; download loop should stop and close the browser. */
 	cancelled: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,7 @@ export interface Metadata {
 	genre?: string;
 }
 
-export type OutputFormat = 'original' | 'mp3-320';
+export type OutputFormat = 'original' | 'mp3-320' | 'flac';
 
 // Job system types for Web UI
 export type JobStage =
@@ -103,6 +103,8 @@ export interface Job {
 	progress: JobProgress;
 	downloadFilename: string | null;
 	outputFilename: string | null;
+	/** Whether the downloaded source codec is lossless, when probed for FLAC output. */
+	sourceIsLossless: boolean | null;
 	artworkBuffer: ArrayBuffer | null;
 	artworkFileName: string | null;
 	error: string | null;

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -131,6 +131,7 @@ describe('resolveGateProviderUrl', () => {
 describe('findKnownGateInHtml', () => {
 	test('follows a smart-link Bandcamp homepage to its newest album', () => {
 		const smartLinkHtml = `
+			<a href="https://unrelated.bandcamp.com/">Unrelated</a>
 			<script>
 				window.preloadLink = {"services":[{"url":"https:\\/\\/underzoneco.bandcamp.com\\/","service_name":"bandcamp"}]};
 			</script>
@@ -143,6 +144,28 @@ describe('findKnownGateInHtml', () => {
 			<a href="/album/club-anthems-vol-4">Club Anthems Vol. 4</a>
 		`;
 		expect(findKnownGateInHtml(bandcampHtml, homepage ?? undefined)).toEqual({
+			url: 'https://underzoneco.bandcamp.com/album/club-anthems-vol-4',
+			provider: 'bandcamp',
+		});
+	});
+
+	test('does not fall back to an unrelated Bandcamp track', () => {
+		expect(
+			findKnownGateInHtml(
+				'<a href="/track/unrelated-featured-track">Featured track</a>',
+				'https://underzoneco.bandcamp.com/',
+			),
+		).toBeNull();
+	});
+
+	test('scans links when a meta refresh is not a known gate', () => {
+		const html = `
+			<meta http-equiv="refresh" content="0;url=/news">
+			<a href="/album/club-anthems-vol-4">Album</a>
+		`;
+		expect(
+			findKnownGateInHtml(html, 'https://underzoneco.bandcamp.com/'),
+		).toEqual({
 			url: 'https://underzoneco.bandcamp.com/album/club-anthems-vol-4',
 			provider: 'bandcamp',
 		});

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -158,6 +158,19 @@ describe('findKnownGateInHtml', () => {
 		).toBeNull();
 	});
 
+	test('prefers a relative album over an earlier absolute featured track', () => {
+		const html = `
+			<a href="https://underzoneco.bandcamp.com/track/unrelated-featured-track">Featured</a>
+			<a href="/album/club-anthems-vol-4">Album</a>
+		`;
+		expect(
+			findKnownGateInHtml(html, 'https://underzoneco.bandcamp.com/'),
+		).toEqual({
+			url: 'https://underzoneco.bandcamp.com/album/club-anthems-vol-4',
+			provider: 'bandcamp',
+		});
+	});
+
 	test('scans links when a meta refresh is not a known gate', () => {
 		const html = `
 			<meta http-equiv="refresh" content="0;url=/news">
@@ -322,5 +335,22 @@ describe('previewProcessedFilename', () => {
 		expect(
 			previewProcessedFilename('song.mp3', { nameAsArtistTitle: false }),
 		).toBe('song.mp3');
+	});
+
+	test('always previews a flac extension for flac output', () => {
+		expect(
+			previewProcessedFilename('song.mp3', {
+				nameAsArtistTitle: false,
+				outputFormat: 'flac',
+			}),
+		).toBe('song.flac');
+		expect(
+			previewProcessedFilename('song.m4a', {
+				nameAsArtistTitle: true,
+				artist: 'Artist',
+				title: 'Title',
+				outputFormat: 'flac',
+			}),
+		).toBe('Artist - Title.flac');
 	});
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import {
 	artistTitleFilename,
 	cookiesToNetscape,
+	findBandcampHomepageInHtml,
 	findKnownGateInHtml,
 	previewProcessedFilename,
 	resolveGateProviderUrl,
@@ -128,6 +129,25 @@ describe('resolveGateProviderUrl', () => {
 });
 
 describe('findKnownGateInHtml', () => {
+	test('follows a smart-link Bandcamp homepage to its newest album', () => {
+		const smartLinkHtml = `
+			<script>
+				window.preloadLink = {"services":[{"url":"https:\\/\\/underzoneco.bandcamp.com\\/","service_name":"bandcamp"}]};
+			</script>
+		`;
+		const homepage = findBandcampHomepageInHtml(smartLinkHtml);
+		expect(homepage).toBe('https://underzoneco.bandcamp.com/');
+
+		const bandcampHtml = `
+			<a href="/track/unrelated-featured-track">Featured track</a>
+			<a href="/album/club-anthems-vol-4">Club Anthems Vol. 4</a>
+		`;
+		expect(findKnownGateInHtml(bandcampHtml, homepage ?? undefined)).toEqual({
+			url: 'https://underzoneco.bandcamp.com/album/club-anthems-vol-4',
+			provider: 'bandcamp',
+		});
+	});
+
 	test('finds embedded Hypeddit destination in smart-link HTML', () => {
 		const html = `
 			<script>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -511,7 +511,7 @@ export function findKnownGateInHtml(
 ): { url: string; provider: GateProvider } | null {
 	const normalized = html.replace(/\\\//g, '/');
 	const direct = matchKnownDownloadGateUrl(normalized);
-	if (direct) return direct;
+	if (direct && direct.provider !== 'bandcamp') return direct;
 
 	const refresh =
 		normalized.match(
@@ -549,6 +549,8 @@ export function findKnownGateInHtml(
 				}
 			});
 
+		if (direct?.provider === 'bandcamp') relativeMatches.push(direct);
+
 		const traditional = relativeMatches.find((match) =>
 			['hypeddit', 'droploud', 'gaterush', 'downloadgater'].includes(
 				match.provider,
@@ -565,7 +567,7 @@ export function findKnownGateInHtml(
 			relativeMatches.find((match) => match.provider !== 'bandcamp') ?? null
 		);
 	}
-	return null;
+	return direct;
 }
 
 /**
@@ -826,6 +828,10 @@ export function toMp3Filename(filename: string): string {
 	return filename.replace(MP3_CONVERTIBLE_EXT_PATTERN, '.mp3');
 }
 
+export function toFlacFilename(filename: string): string {
+	return filename.replace(/\.[^.]+$/i, '.flac');
+}
+
 /** @deprecated Prefer toMp3Filename */
 export function losslessToMp3Filename(filename: string): string {
 	return toMp3Filename(filename);
@@ -858,10 +864,15 @@ export function previewProcessedFilename(
 		nameAsArtistTitle: boolean;
 		artist?: string;
 		title?: string;
+		outputFormat?: 'mp3-320' | 'flac';
 	},
 ): string {
+	const extension = options.outputFormat === 'flac' ? '.flac' : '.mp3';
 	if (options.nameAsArtistTitle) {
-		return artistTitleFilename(options.artist, options.title, '.mp3');
+		return artistTitleFilename(options.artist, options.title, extension);
+	}
+	if (options.outputFormat === 'flac') {
+		return toFlacFilename(downloadFilename);
 	}
 	if (needsMp3Conversion(downloadFilename)) {
 		return toMp3Filename(downloadFilename);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -397,6 +397,26 @@ function matchBandcampUrl(
 	return null;
 }
 
+/** Find an artist's bare Bandcamp homepage embedded in a smart-link page. */
+export function findBandcampHomepageInHtml(html: string): string | null {
+	const normalized = html.replace(/\\\//g, '/');
+	for (const match of normalized.match(ANY_HTTP_URL_RE) ?? []) {
+		try {
+			const url = new URL(trimExtractedUrl(match).replace(/&amp;/g, '&'));
+			if (
+				url.hostname !== 'bandcamp.com' &&
+				url.hostname.endsWith('.bandcamp.com') &&
+				(url.pathname === '' || url.pathname === '/')
+			) {
+				return `${url.protocol}//${url.host}/`;
+			}
+		} catch {
+			// Ignore malformed URLs embedded in page scripts.
+		}
+	}
+	return null;
+}
+
 function matchDirectDownloadUrl(
 	value: string,
 ): { url: string; provider: GateProvider } | null {
@@ -421,6 +441,7 @@ function matchDirectDownloadUrl(
  */
 export function findKnownGateInHtml(
 	html: string,
+	baseUrl?: string,
 ): { url: string; provider: GateProvider } | null {
 	const normalized = html.replace(/\\\//g, '/');
 	const direct = matchKnownDownloadGateUrl(normalized);
@@ -434,8 +455,45 @@ export function findKnownGateInHtml(
 			/content=["'][^"']*url=([^"'>\s]+)[^"']*["'][^>]*http-equiv=["']refresh["']/i,
 		);
 	if (refresh?.[1]) {
-		const target = refresh[1].replace(/&amp;/g, '&');
+		const rawTarget = refresh[1].replace(/&amp;/g, '&');
+		let target = rawTarget;
+		if (baseUrl) {
+			try {
+				target = new URL(rawTarget, baseUrl).toString();
+			} catch {
+				return null;
+			}
+		}
 		return matchKnownDownloadGateUrl(target);
+	}
+
+	if (baseUrl) {
+		const relativeMatches = [...normalized.matchAll(/href=["']([^"']+)["']/gi)]
+			.map((match) => match[1])
+			.filter((target): target is string => Boolean(target))
+			.flatMap((target) => {
+				try {
+					const resolved = matchKnownDownloadGateUrl(
+						new URL(target.replace(/&amp;/g, '&'), baseUrl).toString(),
+					);
+					return resolved ? [resolved] : [];
+				} catch {
+					return [];
+				}
+			});
+
+		const traditional = relativeMatches.find((match) =>
+			['hypeddit', 'droploud', 'gaterush', 'downloadgater'].includes(
+				match.provider,
+			),
+		);
+		if (traditional) return traditional;
+
+		// Artist homepages often feature an unrelated track before their albums.
+		const album = relativeMatches.find(
+			(match) => match.provider === 'bandcamp' && isBandcampAlbumUrl(match.url),
+		);
+		return album ?? relativeMatches[0] ?? null;
 	}
 	return null;
 }
@@ -495,7 +553,15 @@ export async function resolveUnknownGateUrl(
 			}
 
 			const html = await response.text();
-			return findKnownGateInHtml(html);
+			const fromHtml = findKnownGateInHtml(html, current);
+			if (fromHtml) return fromHtml;
+
+			const bandcampHomepage = findBandcampHomepageInHtml(html);
+			if (bandcampHomepage && bandcampHomepage !== current) {
+				current = bandcampHomepage;
+				continue;
+			}
+			return null;
 		}
 	} catch {
 		return null;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -397,19 +397,85 @@ function matchBandcampUrl(
 	return null;
 }
 
+function normalizeBandcampHomepageUrl(value: string): string | null {
+	try {
+		const url = new URL(trimExtractedUrl(value).replace(/&amp;/g, '&'));
+		if (
+			url.hostname !== 'bandcamp.com' &&
+			url.hostname.endsWith('.bandcamp.com') &&
+			!url.port &&
+			(url.pathname === '' || url.pathname === '/')
+		) {
+			return `https://${url.hostname}/`;
+		}
+	} catch {
+		// Not a valid Bandcamp artist homepage.
+	}
+	return null;
+}
+
+function extractAssignedJsonObject(html: string, assignment: RegExp): unknown {
+	const assignmentMatch = assignment.exec(html);
+	if (!assignmentMatch) return null;
+	const start = html.indexOf(
+		'{',
+		assignmentMatch.index + assignmentMatch[0].length,
+	);
+	if (start < 0) return null;
+
+	let depth = 0;
+	let inString = false;
+	let escaped = false;
+	for (let index = start; index < html.length; index++) {
+		const char = html[index];
+		if (inString) {
+			if (escaped) escaped = false;
+			else if (char === '\\') escaped = true;
+			else if (char === '"') inString = false;
+			continue;
+		}
+		if (char === '"') inString = true;
+		else if (char === '{') depth += 1;
+		else if (char === '}' && --depth === 0) {
+			try {
+				return JSON.parse(html.slice(start, index + 1));
+			} catch {
+				return null;
+			}
+		}
+	}
+	return null;
+}
+
 /** Find an artist's bare Bandcamp homepage embedded in a smart-link page. */
 export function findBandcampHomepageInHtml(html: string): string | null {
 	const normalized = html.replace(/\\\//g, '/');
+	const preloadLink = extractAssignedJsonObject(
+		normalized,
+		/window\.preloadLink\s*=/i,
+	);
+	if (preloadLink && typeof preloadLink === 'object') {
+		const services = (preloadLink as { services?: unknown }).services;
+		if (Array.isArray(services)) {
+			for (const service of services) {
+				if (
+					service &&
+					typeof service === 'object' &&
+					(service as { service_name?: unknown }).service_name === 'bandcamp'
+				) {
+					const url = (service as { url?: unknown }).url;
+					const homepage =
+						typeof url === 'string' ? normalizeBandcampHomepageUrl(url) : null;
+					if (homepage) return homepage;
+				}
+			}
+		}
+	}
+
 	for (const match of normalized.match(ANY_HTTP_URL_RE) ?? []) {
 		try {
-			const url = new URL(trimExtractedUrl(match).replace(/&amp;/g, '&'));
-			if (
-				url.hostname !== 'bandcamp.com' &&
-				url.hostname.endsWith('.bandcamp.com') &&
-				(url.pathname === '' || url.pathname === '/')
-			) {
-				return `${url.protocol}//${url.host}/`;
-			}
+			const homepage = normalizeBandcampHomepageUrl(match);
+			if (homepage) return homepage;
 		} catch {
 			// Ignore malformed URLs embedded in page scripts.
 		}
@@ -461,10 +527,11 @@ export function findKnownGateInHtml(
 			try {
 				target = new URL(rawTarget, baseUrl).toString();
 			} catch {
-				return null;
+				target = rawTarget;
 			}
 		}
-		return matchKnownDownloadGateUrl(target);
+		const refreshMatch = matchKnownDownloadGateUrl(target);
+		if (refreshMatch) return refreshMatch;
 	}
 
 	if (baseUrl) {
@@ -493,7 +560,10 @@ export function findKnownGateInHtml(
 		const album = relativeMatches.find(
 			(match) => match.provider === 'bandcamp' && isBandcampAlbumUrl(match.url),
 		);
-		return album ?? relativeMatches[0] ?? null;
+		if (album) return album;
+		return (
+			relativeMatches.find((match) => match.provider !== 'bandcamp') ?? null
+		);
 	}
 	return null;
 }

--- a/src/ytdlp.test.ts
+++ b/src/ytdlp.test.ts
@@ -1,5 +1,37 @@
 import { describe, expect, test } from 'bun:test';
-import { parseYtDlpProgressLine } from './ytdlp';
+import { parseYtDlpProgressLine, readProcessLines } from './ytdlp';
+
+const streamChunks = (...chunks: string[]) =>
+	new ReadableStream<Uint8Array>({
+		start(controller) {
+			for (const chunk of chunks) {
+				controller.enqueue(new TextEncoder().encode(chunk));
+			}
+			controller.close();
+		},
+	});
+
+describe('readProcessLines', () => {
+	test('splits chunked output and filters handled progress lines', async () => {
+		const handled: string[] = [];
+		const output = await readProcessLines(
+			streamChunks('SC_GATE_', 'PROGRESS\n./downloads/', 'track.flac\n'),
+			(line) => {
+				handled.push(line);
+				return !line.startsWith('SC_GATE_PROGRESS');
+			},
+		);
+
+		expect(handled).toEqual(['SC_GATE_PROGRESS', './downloads/track.flac']);
+		expect(output).toEqual(['./downloads/track.flac']);
+	});
+
+	test('preserves a final line without a newline', async () => {
+		expect(await readProcessLines(streamChunks('metadata json'))).toEqual([
+			'metadata json',
+		]);
+	});
+});
 
 describe('parseYtDlpProgressLine', () => {
 	test('calculates byte progress using the exact total', () => {

--- a/src/ytdlp.test.ts
+++ b/src/ytdlp.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'bun:test';
+import { parseYtDlpProgressLine } from './ytdlp';
+
+describe('parseYtDlpProgressLine', () => {
+	test('calculates byte progress using the exact total', () => {
+		expect(
+			parseYtDlpProgressLine('SC_GATE_DL_PROGRESS:31161266:62322532:NA:NA:NA'),
+		).toEqual({
+			downloadBytes: 31161266,
+			totalBytes: 62322532,
+			percent: 50,
+		});
+	});
+
+	test('uses an estimated total when yt-dlp has no exact size', () => {
+		expect(
+			parseYtDlpProgressLine('SC_GATE_DL_PROGRESS:25:NA:100:NA:NA'),
+		).toEqual({ downloadBytes: 25, totalBytes: 100, percent: 25 });
+	});
+
+	test('uses fragment progress for HLS downloads without byte totals', () => {
+		expect(parseYtDlpProgressLine('SC_GATE_DL_PROGRESS:NA:NA:NA:3:12')).toEqual(
+			{ downloadBytes: undefined, totalBytes: undefined, percent: 25 },
+		);
+	});
+
+	test('ignores regular yt-dlp output', () => {
+		expect(parseYtDlpProgressLine('./downloads/track.m4a')).toBeNull();
+	});
+});

--- a/src/ytdlp.ts
+++ b/src/ytdlp.ts
@@ -30,6 +30,7 @@ const DOWNLOADS_DIR = './downloads';
 const YTDLP_DOWNLOAD_TIMEOUT_MS = 10 * 60_000;
 const YTDLP_METADATA_TIMEOUT_MS = 60_000;
 const ALBUM_MATCH_THRESHOLD = 0.5;
+const PROGRESS_PREFIX = 'SC_GATE_DL_PROGRESS:';
 
 type FlatEntry = {
 	id?: string;
@@ -37,6 +38,57 @@ type FlatEntry = {
 	url?: string;
 	webpage_url?: string;
 };
+
+export type YtDlpProgress = {
+	downloadBytes?: number;
+	totalBytes?: number;
+	percent: number;
+};
+
+function parseProgressNumber(value: string | undefined): number | undefined {
+	if (!value || value === 'NA') return undefined;
+	const parsed = Number(value);
+	return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+/** Parse the stable, machine-readable progress template passed to yt-dlp. */
+export function parseYtDlpProgressLine(line: string): YtDlpProgress | null {
+	if (!line.startsWith(PROGRESS_PREFIX)) return null;
+
+	const [
+		downloadedValue,
+		totalValue,
+		estimateValue,
+		fragmentValue,
+		fragmentsValue,
+	] = line.slice(PROGRESS_PREFIX.length).split(':');
+	const downloadBytes = parseProgressNumber(downloadedValue);
+	const totalBytes =
+		parseProgressNumber(totalValue) ?? parseProgressNumber(estimateValue);
+	const fragment = parseProgressNumber(fragmentValue);
+	const fragments = parseProgressNumber(fragmentsValue);
+
+	let percent = 0;
+	if (
+		downloadBytes !== undefined &&
+		totalBytes !== undefined &&
+		totalBytes > 0
+	) {
+		percent = (downloadBytes / totalBytes) * 100;
+	} else if (
+		fragment !== undefined &&
+		fragments !== undefined &&
+		fragments > 0
+	) {
+		percent = (fragment / fragments) * 100;
+	}
+
+	return {
+		downloadBytes,
+		totalBytes,
+		percent: Math.min(100, Math.max(0, percent)),
+	};
+}
 
 /** Thrown when a Bandcamp album cannot be auto-matched to a single track. */
 export class BandcampAlbumMatchError extends Error {
@@ -134,6 +186,7 @@ export class YtDlpDownloader {
 		ytDlpBin: string,
 		args: string[],
 		timeout: number,
+		onStdoutLine?: (line: string) => boolean,
 	): Promise<string> {
 		if (this.closed) {
 			throw new Error('yt-dlp downloader is closed');
@@ -144,6 +197,14 @@ export class YtDlpDownloader {
 		});
 		this.activeProcess = subprocess;
 		try {
+			if (onStdoutLine) {
+				const outputLines: string[] = [];
+				for await (const line of subprocess) {
+					if (onStdoutLine(line)) outputLines.push(line);
+				}
+				await subprocess;
+				return outputLines.join('\n');
+			}
 			const { stdout } = await subprocess;
 			return stdout;
 		} finally {
@@ -187,6 +248,12 @@ export class YtDlpDownloader {
 		const args = [
 			'--no-mtime',
 			'--no-playlist',
+			'--newline',
+			'--progress',
+			'--progress-delta',
+			'0.5',
+			'--progress-template',
+			`${PROGRESS_PREFIX}%(progress.downloaded_bytes)s:%(progress.total_bytes)s:%(progress.total_bytes_estimate)s:%(progress.fragment_index)s:%(progress.fragment_count)s`,
 			'-f',
 			format,
 			'-o',
@@ -215,7 +282,27 @@ export class YtDlpDownloader {
 
 		let stdout: string;
 		try {
-			stdout = await this.runYtDlp(ytDlpBin, args, YTDLP_DOWNLOAD_TIMEOUT_MS);
+			stdout = await this.runYtDlp(
+				ytDlpBin,
+				args,
+				YTDLP_DOWNLOAD_TIMEOUT_MS,
+				(line) => {
+					const progress = parseYtDlpProgressLine(line);
+					if (!progress) return true;
+
+					this.progressCallback?.(
+						'downloading',
+						`Downloading from ${this.sourceLabel} via yt-dlp...`,
+						progress.percent,
+						{
+							downloadBytes: progress.downloadBytes,
+							totalBytes: progress.totalBytes,
+							browserless: true,
+						},
+					);
+					return false;
+				},
+			);
 		} finally {
 			if (cookiesPath) await rm(cookiesPath, { force: true });
 		}

--- a/src/ytdlp.ts
+++ b/src/ytdlp.ts
@@ -1,6 +1,5 @@
 import { mkdir, rm } from 'node:fs/promises';
 import { basename, join } from 'node:path';
-import { execa } from 'execa';
 import { lookpath } from 'find-bin';
 import type { BandcampAlbumTrackChoice, JobProgress } from './types';
 import {
@@ -44,6 +43,36 @@ export type YtDlpProgress = {
 	totalBytes?: number;
 	percent: number;
 };
+
+export async function readProcessLines(
+	stdout: ReadableStream<Uint8Array>,
+	onLine?: (line: string) => boolean,
+): Promise<string[]> {
+	const reader = stdout.getReader();
+	const decoder = new TextDecoder();
+	const outputLines: string[] = [];
+	let buffered = '';
+
+	const handleLine = (line: string) => {
+		if (!onLine || onLine(line)) outputLines.push(line);
+	};
+
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			buffered += decoder.decode(value, { stream: true });
+			const lines = buffered.split(/\r?\n/);
+			buffered = lines.pop() ?? '';
+			for (const line of lines) handleLine(line);
+		}
+		buffered += decoder.decode();
+		if (buffered) handleLine(buffered);
+		return outputLines;
+	} finally {
+		reader.releaseLock();
+	}
+}
 
 function parseProgressNumber(value: string | undefined): number | undefined {
 	if (!value || value === 'NA') return undefined;
@@ -164,7 +193,7 @@ export function titleMatchScore(candidate: string, wanted: string): number {
 export class YtDlpDownloader {
 	private progressCallback: ProgressCallback | null = null;
 	private sourceLabel: string;
-	private activeProcess: ReturnType<typeof execa> | null = null;
+	private activeProcess: Bun.Subprocess<'ignore', 'pipe', 'pipe'> | null = null;
 	private closed = false;
 
 	constructor(sourceLabel = 'yt-dlp') {
@@ -191,22 +220,36 @@ export class YtDlpDownloader {
 		if (this.closed) {
 			throw new Error('yt-dlp downloader is closed');
 		}
-		const subprocess = execa(ytDlpBin, args, {
+		const subprocess = Bun.spawn([ytDlpBin, ...args], {
+			stdin: 'ignore',
+			stdout: 'pipe',
+			stderr: 'pipe',
 			timeout,
 			killSignal: 'SIGTERM',
 		});
 		this.activeProcess = subprocess;
+		const stderrPromise = new Response(subprocess.stderr).text();
 		try {
-			if (onStdoutLine) {
-				const outputLines: string[] = [];
-				for await (const line of subprocess) {
-					if (onStdoutLine(line)) outputLines.push(line);
-				}
-				await subprocess;
-				return outputLines.join('\n');
+			const outputLines = await readProcessLines(
+				subprocess.stdout,
+				onStdoutLine,
+			);
+			const exitCode = await subprocess.exited;
+			const stderr = await stderrPromise;
+			if (exitCode !== 0) {
+				const reason = subprocess.signalCode
+					? `signal ${subprocess.signalCode}`
+					: `code ${exitCode}`;
+				throw new Error(
+					`yt-dlp exited with ${reason}${stderr.trim() ? `: ${stderr.trim().slice(-1_000)}` : ''}`,
+				);
 			}
-			const { stdout } = await subprocess;
-			return stdout;
+			return outputLines.join('\n');
+		} catch (error) {
+			if (subprocess.exitCode === null) subprocess.kill('SIGTERM');
+			await subprocess.exited.catch(() => {});
+			await stderrPromise.catch(() => '');
+			throw error;
 		} finally {
 			if (this.activeProcess === subprocess) {
 				this.activeProcess = null;

--- a/userscript/sc-gate-dl.user.js
+++ b/userscript/sc-gate-dl.user.js
@@ -145,14 +145,14 @@
 		try {
 			if (typeof GM_getValue === 'function') {
 				const gm = GM_getValue(OUTPUT_FORMAT_KEY, null);
-				if (gm === 'original' || gm === 'mp3-320') return gm;
+				if (gm === 'original' || gm === 'mp3-320' || gm === 'flac') return gm;
 			}
 		} catch {
 			// ignore
 		}
 		try {
 			const v = localStorage.getItem(OUTPUT_FORMAT_KEY);
-			if (v === 'original' || v === 'mp3-320') return v;
+			if (v === 'original' || v === 'mp3-320' || v === 'flac') return v;
 		} catch {
 			// ignore
 		}
@@ -165,7 +165,7 @@
 	}
 
 	function setOutputFormat(value) {
-		if (value !== 'original' && value !== 'mp3-320') return;
+		if (value !== 'original' && value !== 'mp3-320' && value !== 'flac') return;
 		try {
 			if (typeof GM_setValue === 'function') GM_setValue(OUTPUT_FORMAT_KEY, value);
 		} catch {
@@ -923,6 +923,10 @@
 				<label class="sc-gate-dl-format-option">
 					<input type="radio" name="sc-gate-dl-fmt" value="mp3-320"${current === 'mp3-320' ? ' checked' : ''}/>
 					<span>MP3 320kbps</span>
+				</label>
+				<label class="sc-gate-dl-format-option">
+					<input type="radio" name="sc-gate-dl-fmt" value="flac"${current === 'flac' ? ' checked' : ''}/>
+					<span>FLAC</span>
 				</label>
 				<label class="sc-gate-dl-format-option">
 					<input type="radio" name="sc-gate-dl-fmt" value="original"${current === 'original' ? ' checked' : ''}/>
@@ -1898,6 +1902,7 @@ button[${BUTTON_ATTR}="mui"] svg {
 						<label>
 							<select class="sc-gate-dl-format" aria-label="Output format" title="Output format">
 								<option value="mp3-320"${format === 'mp3-320' ? ' selected' : ''}>MP3 320</option>
+								<option value="flac"${format === 'flac' ? ' selected' : ''}>FLAC</option>
 								<option value="original"${format === 'original' ? ' selected' : ''}>Original</option>
 							</select>
 						</label>

--- a/webui/src/components/App.css
+++ b/webui/src/components/App.css
@@ -525,6 +525,10 @@
 		opacity: 0.65;
 		animation: none;
 	}
+
+	.progress-fill-indeterminate::after {
+		animation: none;
+	}
 }
 
 .progress-stats {

--- a/webui/src/components/App.css
+++ b/webui/src/components/App.css
@@ -503,6 +503,30 @@
 	animation: shimmer 2s infinite;
 }
 
+.progress-fill-indeterminate {
+	width: 40%;
+	transition: none;
+	animation: progress-indeterminate 1.4s ease-in-out infinite;
+}
+
+@keyframes progress-indeterminate {
+	from {
+		transform: translateX(-100%);
+	}
+
+	to {
+		transform: translateX(250%);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.progress-fill-indeterminate {
+		width: 100%;
+		opacity: 0.65;
+		animation: none;
+	}
+}
+
 .progress-stats {
 	display: flex;
 	justify-content: space-between;

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -4,6 +4,7 @@ import './App.css';
 
 type Step = 'url' | 'gate' | 'download' | 'metadata' | 'complete';
 type OutputFormat = 'original' | 'mp3-320';
+type BrowserMode = 'headless' | 'xvfb' | 'headed';
 
 interface Metadata {
 	title?: string;
@@ -198,7 +199,7 @@ export default function App() {
 	const [hypedditUrlInput, setHypedditUrlInput] = useState('');
 	const [skipAutomaticHypedditFetch, setSkipAutomaticHypedditFetch] =
 		useState(false);
-	const [headfulMode, setHeadfulMode] = useState(false);
+	const [browserMode, setBrowserMode] = useState<BrowserMode>('headless');
 	const [outputFormat, setOutputFormat] = useState<OutputFormat>('mp3-320');
 	const [job, setJob] = useState<JobState>({
 		jobId: null,
@@ -313,7 +314,10 @@ export default function App() {
 				const response = await fetch(`${API_BASE}/api/job/${jobId}/start`, {
 					method: 'POST',
 					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify({ headless: !headfulMode }),
+					body: JSON.stringify({
+						headless: browserMode !== 'headed',
+						xvfb: browserMode === 'xvfb',
+					}),
 				});
 
 				if (!response.ok) {
@@ -417,7 +421,7 @@ export default function App() {
 				}));
 			}
 		},
-		[headfulMode, showCleanupSoundcloudToast],
+		[browserMode, showCleanupSoundcloudToast],
 	);
 
 	const cancelDownload = useCallback(async () => {
@@ -775,7 +779,7 @@ export default function App() {
 		setSoundcloudUrl('');
 		setHypedditUrlInput('');
 		setSkipAutomaticHypedditFetch(false);
-		setHeadfulMode(false);
+		setBrowserMode('headless');
 		setJob({
 			jobId: null,
 			track: null,
@@ -954,6 +958,21 @@ export default function App() {
 									<option value="original">Original file</option>
 								</select>
 							</div>
+							<div className="form-group url-settings-format">
+								<label htmlFor="browser-mode">Browser Mode</label>
+								<select
+									id="browser-mode"
+									value={browserMode}
+									onChange={(e) =>
+										setBrowserMode(e.target.value as BrowserMode)
+									}
+									disabled={isLoading}
+								>
+									<option value="headless">Headless</option>
+									<option value="xvfb">Invisible headed (Xvfb)</option>
+									<option value="headed">Visible headed window</option>
+								</select>
+							</div>
 							<div className="checkbox-settings">
 								<label className="checkbox-row" htmlFor="skip-hypeddit-fetch">
 									<input
@@ -966,16 +985,6 @@ export default function App() {
 										disabled={isLoading}
 									/>
 									<span>Skip automatic gate link fetching</span>
-								</label>
-								<label className="checkbox-row" htmlFor="headful-mode">
-									<input
-										id="headful-mode"
-										type="checkbox"
-										checked={headfulMode}
-										onChange={(e) => setHeadfulMode(e.target.checked)}
-										disabled={isLoading}
-									/>
-									<span>Show browser window (headful)</span>
 								</label>
 							</div>
 						</div>
@@ -1018,16 +1027,21 @@ export default function App() {
 									disabled={isLoading}
 								/>
 							</div>
-							<label className="checkbox-row" htmlFor="headful-mode-gate">
-								<input
-									id="headful-mode-gate"
-									type="checkbox"
-									checked={headfulMode}
-									onChange={(e) => setHeadfulMode(e.target.checked)}
+							<div className="form-group url-settings-format">
+								<label htmlFor="browser-mode-gate">Browser Mode</label>
+								<select
+									id="browser-mode-gate"
+									value={browserMode}
+									onChange={(e) =>
+										setBrowserMode(e.target.value as BrowserMode)
+									}
 									disabled={isLoading}
-								/>
-								<span>Show browser window (headful)</span>
-							</label>
+								>
+									<option value="headless">Headless</option>
+									<option value="xvfb">Invisible headed (Xvfb)</option>
+									<option value="headed">Visible headed window</option>
+								</select>
+							</div>
 							<button
 								type="submit"
 								className="btn-primary"

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -1132,6 +1132,16 @@ export default function App() {
 										</span>
 									)}
 								</div>
+								{isHandlingGate && (
+									<div
+										className="progress-bar"
+										role="progressbar"
+										aria-label="Gate progress"
+										aria-valuetext={job.progress?.message || 'Handling gate'}
+									>
+										<div className="progress-fill progress-fill-indeterminate" />
+									</div>
+								)}
 								{step === 'download' && (
 									<>
 										<div className="progress-bar">

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -58,6 +58,11 @@ interface JobState {
 }
 
 const API_BASE = 'http://localhost:3000';
+const BROWSER_MODE_STORAGE_KEY = 'sc-gate-dl-browser-mode';
+
+function isBrowserMode(value: string | null): value is BrowserMode {
+	return value === 'headless' || value === 'xvfb' || value === 'headed';
+}
 
 const ALLOWED_HOST_ORIGINS = new Set([
 	'https://soundcloud.com',
@@ -219,6 +224,24 @@ export default function App() {
 		album: '',
 		genre: '',
 	});
+
+	useEffect(() => {
+		try {
+			const storedMode = localStorage.getItem(BROWSER_MODE_STORAGE_KEY);
+			if (isBrowserMode(storedMode)) setBrowserMode(storedMode);
+		} catch {
+			// Storage may be blocked when the Web UI is embedded cross-origin.
+		}
+	}, []);
+
+	const updateBrowserMode = (mode: BrowserMode) => {
+		setBrowserMode(mode);
+		try {
+			localStorage.setItem(BROWSER_MODE_STORAGE_KEY, mode);
+		} catch {
+			// Keep the in-memory selection when persistent storage is unavailable.
+		}
+	};
 	const [customArtwork, setCustomArtwork] = useState<File | null>(null);
 	const [nameAsArtistTitle, setNameAsArtistTitle] = useState(false);
 	const [isLoading, setIsLoading] = useState(false);
@@ -315,8 +338,7 @@ export default function App() {
 					method: 'POST',
 					headers: { 'Content-Type': 'application/json' },
 					body: JSON.stringify({
-						headless: browserMode !== 'headed',
-						xvfb: browserMode === 'xvfb',
+						browserMode,
 					}),
 				});
 
@@ -779,7 +801,6 @@ export default function App() {
 		setSoundcloudUrl('');
 		setHypedditUrlInput('');
 		setSkipAutomaticHypedditFetch(false);
-		setBrowserMode('headless');
 		setJob({
 			jobId: null,
 			track: null,
@@ -964,7 +985,7 @@ export default function App() {
 									id="browser-mode"
 									value={browserMode}
 									onChange={(e) =>
-										setBrowserMode(e.target.value as BrowserMode)
+										updateBrowserMode(e.target.value as BrowserMode)
 									}
 									disabled={isLoading}
 								>
@@ -1033,7 +1054,7 @@ export default function App() {
 									id="browser-mode-gate"
 									value={browserMode}
 									onChange={(e) =>
-										setBrowserMode(e.target.value as BrowserMode)
+										updateBrowserMode(e.target.value as BrowserMode)
 									}
 									disabled={isLoading}
 								>

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Toaster, toast } from 'sonner';
+import { type BrowserMode, isBrowserMode } from '../../../src/types';
 import './App.css';
+import { shouldAutoStartDeepLink } from './deepLink';
 
 type Step = 'url' | 'gate' | 'download' | 'metadata' | 'complete';
-type OutputFormat = 'original' | 'mp3-320';
-type BrowserMode = 'headless' | 'xvfb' | 'headed';
+type OutputFormat = 'original' | 'mp3-320' | 'flac';
 
 interface Metadata {
 	title?: string;
@@ -54,15 +55,12 @@ interface JobState {
 	progress: JobProgress | null;
 	downloadFilename: string | null;
 	outputFilename: string | null;
+	sourceIsLossless: boolean | null;
 	error: string | null;
 }
 
 const API_BASE = 'http://localhost:3000';
 const BROWSER_MODE_STORAGE_KEY = 'sc-gate-dl-browser-mode';
-
-function isBrowserMode(value: string | null): value is BrowserMode {
-	return value === 'headless' || value === 'xvfb' || value === 'headed';
-}
 
 const ALLOWED_HOST_ORIGINS = new Set([
 	'https://soundcloud.com',
@@ -81,8 +79,7 @@ function notifyParent(
 }
 
 /** Promo fluff often glued onto SoundCloud / gate titles. */
-const PROMO_TAG =
-	String.raw`free\s*d(?:own)?l(?:oad)?s?|free[\s._-]*dl|freedl|out\s*now|premiere|exclusive`;
+const PROMO_TAG = String.raw`free\s*d(?:own)?l(?:oad)?s?|free[\s._-]*dl|freedl|out\s*now|premiere|exclusive`;
 
 function cleanPromoTags(value: string): string {
 	if (!value) return value;
@@ -93,18 +90,15 @@ function cleanPromoTags(value: string): string {
 		' ',
 	);
 	result = result.replace(
-		new RegExp(
-			String.raw`(?:\s*[-–—|/·•]+\s*|\s+)(?:${PROMO_TAG})\s*$`,
-			'gi',
-		),
+		new RegExp(String.raw`(?:\s*[-–—|/·•]+\s*|\s+)(?:${PROMO_TAG})\s*$`, 'gi'),
 		'',
 	);
-	result = result.replace(new RegExp(String.raw`(?:${PROMO_TAG})\s*$`, 'gi'), '');
 	result = result.replace(
-		new RegExp(
-			String.raw`^\s*(?:${PROMO_TAG})(?:\s*[-–—|/·•]+\s*|\s+)`,
-			'gi',
-		),
+		new RegExp(String.raw`(?:${PROMO_TAG})\s*$`, 'gi'),
+		'',
+	);
+	result = result.replace(
+		new RegExp(String.raw`^\s*(?:${PROMO_TAG})(?:\s*[-–—|/·•]+\s*|\s+)`, 'gi'),
 		'',
 	);
 	result = result.replace(/\s{2,}/g, ' ');
@@ -156,10 +150,14 @@ function sanitizeFilenamePart(value: string): string {
 		.trim();
 }
 
-function artistTitleFilename(artist?: string, title?: string): string {
+function artistTitleFilename(
+	artist?: string,
+	title?: string,
+	extension = '.mp3',
+): string {
 	const safeArtist = sanitizeFilenamePart(artist || '') || 'Unknown Artist';
 	const safeTitle = sanitizeFilenamePart(title || '') || 'Unknown Title';
-	return `${safeArtist} - ${safeTitle}.mp3`;
+	return `${safeArtist} - ${safeTitle}${extension}`;
 }
 
 function needsMp3Conversion(filename: string): boolean {
@@ -183,11 +181,16 @@ function previewProcessedFilename(
 		nameAsArtistTitle: boolean;
 		artist?: string;
 		title?: string;
+		outputFormat: OutputFormat;
 	},
 ): string {
 	if (!downloadFilename) return '';
+	const extension = options.outputFormat === 'flac' ? '.flac' : '.mp3';
 	if (options.nameAsArtistTitle) {
-		return artistTitleFilename(options.artist, options.title);
+		return artistTitleFilename(options.artist, options.title, extension);
+	}
+	if (options.outputFormat === 'flac') {
+		return downloadFilename.replace(/\.[^.]+$/i, '.flac');
 	}
 	if (needsMp3Conversion(downloadFilename)) {
 		return downloadFilename.replace(
@@ -205,6 +208,7 @@ export default function App() {
 	const [skipAutomaticHypedditFetch, setSkipAutomaticHypedditFetch] =
 		useState(false);
 	const [browserMode, setBrowserMode] = useState<BrowserMode>('headless');
+	const [browserModeHydrated, setBrowserModeHydrated] = useState(false);
 	const [outputFormat, setOutputFormat] = useState<OutputFormat>('mp3-320');
 	const [job, setJob] = useState<JobState>({
 		jobId: null,
@@ -216,6 +220,7 @@ export default function App() {
 		progress: null,
 		downloadFilename: null,
 		outputFilename: null,
+		sourceIsLossless: null,
 		error: null,
 	});
 	const [metadata, setMetadata] = useState<Metadata>({
@@ -231,6 +236,8 @@ export default function App() {
 			if (isBrowserMode(storedMode)) setBrowserMode(storedMode);
 		} catch {
 			// Storage may be blocked when the Web UI is embedded cross-origin.
+		} finally {
+			setBrowserModeHydrated(true);
 		}
 	}, []);
 
@@ -390,6 +397,7 @@ export default function App() {
 									outputFilename: data.outputFilename,
 									existingMetadata: data.existingMetadata,
 									outputFormat: data.outputFormat,
+									sourceIsLossless: data.sourceIsLossless,
 								}));
 								setStep(
 									data.outputFormat === 'original' ? 'complete' : 'metadata',
@@ -466,8 +474,7 @@ export default function App() {
 		} catch (err) {
 			setJob((prev) => ({
 				...prev,
-				error:
-					err instanceof Error ? err.message : 'Failed to cancel download',
+				error: err instanceof Error ? err.message : 'Failed to cancel download',
 			}));
 			return;
 		}
@@ -569,10 +576,17 @@ export default function App() {
 
 	// Userscript / deep-link: ?url=&outputFormat= pre-fills and starts a job
 	useEffect(() => {
-		if (autoStartedFromQueryRef.current) return;
 		const params = new URLSearchParams(window.location.search);
 		let queryUrl = params.get('url') || params.get('soundcloudUrl');
-		if (!queryUrl) return;
+		if (
+			!shouldAutoStartDeepLink(
+				browserModeHydrated,
+				autoStartedFromQueryRef.current,
+				queryUrl,
+			)
+		) {
+			return;
+		}
 		autoStartedFromQueryRef.current = true;
 
 		// New SC listen layout may pass /n/artist/track — normalize to /artist/track
@@ -591,7 +605,9 @@ export default function App() {
 
 		const formatParam = params.get('outputFormat');
 		const format: OutputFormat | undefined =
-			formatParam === 'original' || formatParam === 'mp3-320'
+			formatParam === 'original' ||
+			formatParam === 'mp3-320' ||
+			formatParam === 'flac'
 				? formatParam
 				: undefined;
 		if (format) {
@@ -599,7 +615,7 @@ export default function App() {
 		}
 		setSoundcloudUrl(queryUrl);
 		void createJob(queryUrl, format);
-	}, [createJob]);
+	}, [browserModeHydrated, createJob]);
 
 	// Set Hypeddit URL and start download
 	const handleHypedditSubmit = async (e: React.FormEvent) => {
@@ -777,6 +793,7 @@ export default function App() {
 		nameAsArtistTitle,
 		artist: metadata.artist,
 		title: metadata.title,
+		outputFormat: job.outputFormat,
 	});
 	const isHandlingGate =
 		step === 'gate' && GATE_PROGRESS_STAGES.has(job.progress?.stage ?? '');
@@ -811,6 +828,7 @@ export default function App() {
 			progress: null,
 			downloadFilename: null,
 			outputFilename: null,
+			sourceIsLossless: null,
 			error: null,
 		});
 		setMetadata({ title: '', artist: '', album: '', genre: '' });
@@ -976,6 +994,7 @@ export default function App() {
 									disabled={isLoading}
 								>
 									<option value="mp3-320">MP3 320 kbps</option>
+									<option value="flac">FLAC</option>
 									<option value="original">Original file</option>
 								</select>
 							</div>
@@ -1118,9 +1137,13 @@ export default function App() {
 												type="button"
 												className="bandcamp-track-option"
 												disabled={isLoading}
-												onClick={() => void handleBandcampTrackSelect(track.url)}
+												onClick={() =>
+													void handleBandcampTrackSelect(track.url)
+												}
 											>
-												<span className="bandcamp-track-title">{track.title}</span>
+												<span className="bandcamp-track-title">
+													{track.title}
+												</span>
 												{track.score > 0 ? (
 													<span className="bandcamp-track-score">
 														{Math.round(track.score * 100)}% match
@@ -1176,9 +1199,12 @@ export default function App() {
 											{job.progress?.downloadBytes !== undefined &&
 												job.progress?.totalBytes !== undefined && (
 													<span>
-														{(job.progress.downloadBytes / 1024 / 1024).toFixed(1)}{' '}
+														{(job.progress.downloadBytes / 1024 / 1024).toFixed(
+															1,
+														)}{' '}
 														/{' '}
-														{(job.progress.totalBytes / 1024 / 1024).toFixed(1)} MB
+														{(job.progress.totalBytes / 1024 / 1024).toFixed(1)}{' '}
+														MB
 													</span>
 												)}
 										</div>
@@ -1209,6 +1235,16 @@ export default function App() {
 						onSubmit={handleMetadataSubmit}
 						className="form metadata-form animate-slide-up"
 					>
+						{job.outputFormat === 'flac' && job.sourceIsLossless === false ? (
+							<div className="notice">
+								<span className="notice-icon">i</span>
+								<p>
+									The downloaded source is lossy. It will be converted to FLAC
+									as selected, but the conversion cannot restore lost audio
+									quality.
+								</p>
+							</div>
+						) : null}
 						{existingTagRows.length > 0 ? (
 							<div className="existing-metadata">
 								<div>
@@ -1447,7 +1483,9 @@ export default function App() {
 							>
 								{job.outputFormat === 'original'
 									? 'Download Original'
-									: 'Download MP3'}
+									: job.outputFormat === 'flac'
+										? 'Download FLAC'
+										: 'Download MP3'}
 							</a>
 							<button
 								type="button"

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Toaster, toast } from 'sonner';
-import { type BrowserMode, isBrowserMode } from '../../../src/types';
+import type { BrowserMode } from '../../../src/types';
 import './App.css';
-import { shouldAutoStartDeepLink } from './deepLink';
+import { readStoredBrowserMode, shouldAutoStartDeepLink } from './deepLink';
 
 type Step = 'url' | 'gate' | 'download' | 'metadata' | 'complete';
 type OutputFormat = 'original' | 'mp3-320' | 'flac';
@@ -232,8 +232,11 @@ export default function App() {
 
 	useEffect(() => {
 		try {
-			const storedMode = localStorage.getItem(BROWSER_MODE_STORAGE_KEY);
-			if (isBrowserMode(storedMode)) setBrowserMode(storedMode);
+			const storedMode = readStoredBrowserMode(
+				localStorage,
+				BROWSER_MODE_STORAGE_KEY,
+			);
+			if (storedMode) setBrowserMode(storedMode);
 		} catch {
 			// Storage may be blocked when the Web UI is embedded cross-origin.
 		} finally {

--- a/webui/src/components/deepLink.ts
+++ b/webui/src/components/deepLink.ts
@@ -1,3 +1,13 @@
+import { type BrowserMode, isBrowserMode } from '../../../src/types';
+
+export function readStoredBrowserMode(
+	storage: Pick<Storage, 'getItem'>,
+	key: string,
+): BrowserMode | null {
+	const storedMode = storage.getItem(key);
+	return isBrowserMode(storedMode) ? storedMode : null;
+}
+
 export function shouldAutoStartDeepLink(
 	browserModeHydrated: boolean,
 	alreadyStarted: boolean,

--- a/webui/src/components/deepLink.ts
+++ b/webui/src/components/deepLink.ts
@@ -1,0 +1,7 @@
+export function shouldAutoStartDeepLink(
+	browserModeHydrated: boolean,
+	alreadyStarted: boolean,
+	queryUrl: string | null,
+): queryUrl is string {
+	return browserModeHydrated && !alreadyStarted && Boolean(queryUrl);
+}


### PR DESCRIPTION
## Summary

- add an on-demand, shared Xvfb display that runs CloakBrowser headed without showing a window
- expose Headless, Invisible headed (Xvfb), and Visible headed modes through the CLI config and Web UI
- enable CloakBrowser proxy GeoIP matching by default, retain humanized input, and install `mmdb-lib`
- keep existing config files backward compatible and document setup on Arch and Debian/Ubuntu
- follow smart-link destinations that point at a bare Bandcamp artist homepage, then resolve relative album links while avoiding unrelated featured tracks
- force Chromium onto X11 in Xvfb mode so Plasma Wayland cannot open the window on the real compositor
- show an accessible indeterminate progress bar while browser gate handling is active
- use one mutually exclusive runtime browser-mode contract and persist the Web UI selection
- harden Xvfb lifecycle concurrency and smart-link parsing based on review feedback

## Why

Some anti-bot providers detect Chromium's native headless rendering path. Xvfb provides headed browser signals while preserving an unattended, windowless workflow.

## Validation

- `bun test` — 40 tests passed
- `bun run lint`
- `cd webui && bunx tsc --noEmit`
- live Xvfb launch confirmed no `HeadlessChrome` user agent, `navigator.webdriver === false`, and clean Xvfb shutdown
- verified the Chromium window appears in the Xvfb window tree and not through the inherited Wayland display
- verified `soundcloud.com/underzoneco/bostjan-boogie-frecuency` resolves through Streamlink to `club-anthems-vol-4`, where the existing title matcher selects `boogie-frecuency`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added FLAC output support with metadata, artwork, filename previews, and lossless-source warnings.
  - Added browser mode selection: headless, invisible headed, or visible headed, with saved preferences.
  - Added residential proxy GeoIP matching, with an option to disable it.
  - Improved Bandcamp artist and album detection.
  - Added download progress reporting and animated gate progress indicators.

- **Bug Fixes**
  - Improved handling of relative gate links and redirects.

- **Documentation**
  - Expanded Xvfb, proxy, GeoIP, and FLAC setup guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->