### PR TITLE
Improve the SoundCloud download workflow

### DIFF
--- a/src/browserLaunch.test.ts
+++ b/src/browserLaunch.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import {
 	buildXvfbBrowserEnv,
 	createXvfbManager,
+	isXvfbSupported,
 	readXvfbDisplay,
 	type XvfbSession,
 } from './browserLaunch';
@@ -94,5 +95,13 @@ describe('buildXvfbBrowserEnv', () => {
 			OZONE_PLATFORM: 'x11',
 			PATH: '/usr/bin',
 		});
+	});
+});
+
+describe('isXvfbSupported', () => {
+	test('only enables Xvfb on Linux', () => {
+		expect(isXvfbSupported('linux')).toBeTrue();
+		expect(isXvfbSupported('darwin')).toBeFalse();
+		expect(isXvfbSupported('win32')).toBeFalse();
 	});
 });

--- a/src/browserLaunch.ts
+++ b/src/browserLaunch.ts
@@ -47,6 +47,10 @@ export function browserModeToLaunchOptions(
 	};
 }
 
+export function isXvfbSupported(platform = process.platform): boolean {
+	return platform === 'linux';
+}
+
 export function launchConfiguredBrowser(
 	config: HypedditConfig,
 ): Promise<Browser> {
@@ -209,6 +213,9 @@ export async function launchAppBrowser(
 
 	const geoip = Boolean(proxy) && process.env.CLOAKBROWSER_GEOIP !== 'false';
 	const useXvfb = options.xvfb ?? false;
+	if (useXvfb && !isXvfbSupported()) {
+		throw new Error('Xvfb browser mode is only available on Linux');
+	}
 	const xvfb = useXvfb ? await acquireXvfb() : null;
 
 	const args = [

--- a/src/deepLink.test.ts
+++ b/src/deepLink.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from 'bun:test';
 import {
+	parseAvailableBrowserModes,
 	readStoredBrowserMode,
 	shouldAutoStartDeepLink,
+	shouldUseEmbeddedLayout,
 } from '../webui/src/components/deepLink';
 
 describe('deep-link startup predicate', () => {
@@ -26,6 +28,14 @@ describe('deep-link startup predicate', () => {
 	});
 });
 
+describe('embedded layout query parameter', () => {
+	test('enables the compact layout only for embedded=1', () => {
+		expect(shouldUseEmbeddedLayout('?url=track&embedded=1')).toBeTrue();
+		expect(shouldUseEmbeddedLayout('?url=track')).toBeFalse();
+		expect(shouldUseEmbeddedLayout('?embedded=0')).toBeFalse();
+	});
+});
+
 describe('browser-mode preference hydration', () => {
 	test('reads stored Xvfb through the same helper used by the UI', () => {
 		const storage = { getItem: () => 'xvfb' };
@@ -35,5 +45,23 @@ describe('browser-mode preference hydration', () => {
 	test('ignores invalid stored modes', () => {
 		const storage = { getItem: () => 'invalid' };
 		expect(readStoredBrowserMode(storage, 'browser-mode')).toBeNull();
+	});
+});
+
+describe('browser-mode capabilities', () => {
+	test('accepts the browser modes advertised by a Linux server', () => {
+		expect(
+			parseAvailableBrowserModes({
+				browserModes: ['headless', 'xvfb', 'headed'],
+			}),
+		).toEqual(['headless', 'xvfb', 'headed']);
+	});
+
+	test('falls back to portable modes for an invalid response', () => {
+		expect(parseAvailableBrowserModes(null)).toEqual(['headless', 'headed']);
+		expect(parseAvailableBrowserModes({ browserModes: ['invalid'] })).toEqual([
+			'headless',
+			'headed',
+		]);
 	});
 });

--- a/src/jobQueue.test.ts
+++ b/src/jobQueue.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'bun:test';
+import { JobQueue } from './jobQueue';
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve = () => {};
+	const promise = new Promise<void>((done) => {
+		resolve = done;
+	});
+	return { promise, resolve };
+}
+
+describe('JobQueue', () => {
+	test('runs one job and advances waiting jobs across clients', async () => {
+		const first = deferred();
+		const third = deferred();
+		const started: string[] = [];
+		const positions = new Map<string, number>();
+		const errors: unknown[] = [];
+		const queue = new JobQueue({
+			onQueued: (id, position) => positions.set(id, position),
+			onTaskError: (_id, error) => errors.push(error),
+		});
+
+		expect(
+			queue.enqueue('first', () => {
+				started.push('first');
+				return first.promise;
+			}),
+		).toEqual({
+			queued: false,
+			position: 0,
+		});
+		expect(
+			queue.enqueue('second', async () => {
+				started.push('second');
+			}),
+		).toEqual({
+			queued: true,
+			position: 1,
+		});
+		expect(
+			queue.enqueue('third', () => {
+				started.push('third');
+				return third.promise;
+			}),
+		).toEqual({
+			queued: true,
+			position: 2,
+		});
+		expect(started).toEqual(['first']);
+
+		expect(queue.cancel('second')).toBe(true);
+		expect(positions.get('third')).toBe(1);
+
+		first.resolve();
+		await Bun.sleep(0);
+		expect(started).toEqual(['first', 'third']);
+		expect(errors).toEqual([]);
+		third.resolve();
+	});
+
+	test('continues after a job fails', async () => {
+		const errors: Array<{ id: string; error: unknown }> = [];
+		const started: string[] = [];
+		const queue = new JobQueue({
+			onQueued: () => {},
+			onTaskError: (id, error) => errors.push({ id, error }),
+		});
+
+		queue.enqueue('broken', async () => {
+			started.push('broken');
+			throw new Error('broken');
+		});
+		queue.enqueue('next', async () => {
+			started.push('next');
+		});
+		await Bun.sleep(0);
+
+		expect(started).toEqual(['broken', 'next']);
+		expect(errors[0]?.id).toBe('broken');
+	});
+});

--- a/src/jobQueue.ts
+++ b/src/jobQueue.ts
@@ -1,0 +1,82 @@
+type QueueTask = () => Promise<void>;
+
+interface QueuedJob {
+	id: string;
+	run: QueueTask;
+}
+
+interface JobQueueHooks {
+	onQueued(id: string, position: number): void;
+	onTaskError(id: string, error: unknown): void;
+}
+
+export interface EnqueueResult {
+	queued: boolean;
+	position: number;
+}
+
+/** Serializes download jobs shared by every Web UI tab connected to the server. */
+export class JobQueue {
+	private activeJobId: string | null = null;
+	private waiting: QueuedJob[] = [];
+
+	constructor(private readonly hooks: JobQueueHooks) {}
+
+	enqueue(id: string, run: QueueTask): EnqueueResult {
+		if (this.activeJobId === id) return { queued: false, position: 0 };
+		const existingPosition = this.getPosition(id);
+		if (existingPosition > 0) {
+			return { queued: true, position: existingPosition };
+		}
+
+		const queuedJob = { id, run };
+		if (!this.activeJobId) {
+			this.start(queuedJob);
+			return { queued: false, position: 0 };
+		}
+
+		this.waiting.push(queuedJob);
+		this.notifyPositions();
+		return { queued: true, position: this.waiting.length };
+	}
+
+	/** Removes a waiting job. Active jobs are cancelled by their downloader. */
+	cancel(id: string): boolean {
+		const index = this.waiting.findIndex((job) => job.id === id);
+		if (index === -1) return false;
+		this.waiting.splice(index, 1);
+		this.notifyPositions();
+		return true;
+	}
+
+	getPosition(id: string): number {
+		const index = this.waiting.findIndex((job) => job.id === id);
+		return index === -1 ? 0 : index + 1;
+	}
+
+	private start(job: QueuedJob): void {
+		this.activeJobId = job.id;
+
+		let task: Promise<void>;
+		try {
+			task = job.run();
+		} catch (error) {
+			task = Promise.reject(error);
+		}
+
+		void task
+			.catch((error) => this.hooks.onTaskError(job.id, error))
+			.finally(() => {
+				if (this.activeJobId === job.id) this.activeJobId = null;
+				const next = this.waiting.shift();
+				this.notifyPositions();
+				if (next) this.start(next);
+			});
+	}
+
+	private notifyPositions(): void {
+		this.waiting.forEach((job, index) => {
+			this.hooks.onQueued(job.id, index + 1);
+		});
+	}
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import { cp, mkdir, rm } from 'node:fs/promises';
 import { basename, extname, join } from 'node:path';
 import type { SoundcloudTrack } from 'soundcloud.ts';
 import { AudioProcessor } from './audioProcessor';
+import { isXvfbSupported } from './browserLaunch';
 import { DirectDownloader } from './directDownload';
 import { DownloadgaterDownloader } from './downloadgater';
 import { renameDownloadFileExclusive } from './downloadRename';
@@ -10,9 +11,11 @@ import { DroploudDownloader } from './droploud';
 import { GaterushDownloader } from './gaterush';
 import { HypedditDownloader } from './hypeddit';
 import { HypedditHttpDownloader } from './hypedditHttp';
+import { JobQueue } from './jobQueue';
 import { jobStore } from './jobStore';
 import { SoundcloudClient } from './soundcloud';
 import {
+	type BrowserMode,
 	isBrowserMode,
 	type Job,
 	type Metadata,
@@ -59,6 +62,9 @@ const HYPEDDIT_EMAIL = getOptionalEnv('HYPEDDIT_EMAIL');
 
 const soundcloudClient = new SoundcloudClient();
 const audioProcessor = new AudioProcessor(ffmpegBin, ffprobeBin);
+const availableBrowserModes: BrowserMode[] = isXvfbSupported()
+	? ['headless', 'xvfb', 'headed']
+	: ['headless', 'headed'];
 
 async function renameDownloadFile(
 	jobId: string,
@@ -91,6 +97,28 @@ const activeDownloaders = new Map<string, AnyDownloader>();
 const jobProfileDirs = new Map<string, string>();
 /** In-flight close+profile cleanup so SIGINT cannot delete a profile mid-close. */
 const closingJobs = new Map<string, Promise<void>>();
+
+const jobQueue = new JobQueue({
+	onQueued: (jobId, position) => {
+		if (jobStore.isCancelled(jobId)) return;
+		jobStore.updateProgress(
+			jobId,
+			'queued',
+			position === 1
+				? 'Waiting for the active download — next in queue'
+				: `Waiting for the active download — queue position ${position}`,
+			0,
+			{ queuePosition: position },
+		);
+	},
+	onTaskError: (jobId, error) => {
+		if (jobStore.isCancelled(jobId)) return;
+		jobStore.setError(
+			jobId,
+			error instanceof Error ? error.message : 'Download queue task failed',
+		);
+	},
+});
 
 /**
  * Job profiles start empty, which drops the SoundCloud session from Initialize
@@ -186,16 +214,6 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 	const job = jobStore.get(jobId);
 	if (!job?.hypedditUrl) return;
 
-	const resolved = await resolveGateUrlOrFollow(job.hypedditUrl);
-	if (!resolved) {
-		jobStore.setError(jobId, 'Unsupported gate URL');
-		return;
-	}
-	if (resolved.url !== job.hypedditUrl) {
-		jobStore.update(jobId, { hypedditUrl: resolved.url });
-	}
-	const { url: downloadSourceUrl, provider } = resolved;
-
 	const throwIfCancelled = () => {
 		if (jobStore.isCancelled(jobId)) {
 			throw new Error('Download cancelled');
@@ -203,6 +221,24 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 	};
 
 	try {
+		throwIfCancelled();
+		jobStore.updateProgress(
+			jobId,
+			'handling_gates',
+			'Resolving download source...',
+			0,
+		);
+		const resolved = await resolveGateUrlOrFollow(job.hypedditUrl);
+		throwIfCancelled();
+		if (!resolved) {
+			jobStore.setError(jobId, 'Unsupported gate URL');
+			return;
+		}
+		if (resolved.url !== job.hypedditUrl) {
+			jobStore.update(jobId, { hypedditUrl: resolved.url });
+		}
+		const { url: downloadSourceUrl, provider } = resolved;
+
 		const emitProgress = (
 			stage: Job['progress']['stage'],
 			message: string,
@@ -609,6 +645,10 @@ const server = Bun.serve({
 			new Response('sc-gate-dl API is running!', {
 				headers: corsHeaders(),
 			}),
+		'/api/capabilities': () =>
+			jsonResponse({
+				browserModes: availableBrowserModes,
+			}),
 
 		'/api/soundcloud/cleanup': {
 			POST: async () => {
@@ -920,6 +960,12 @@ const server = Bun.serve({
 									{ status: 400 },
 								);
 							}
+							if (!availableBrowserModes.includes(body.browserMode)) {
+								return jsonResponse(
+									{ error: 'Xvfb browser mode is only available on Linux' },
+									{ status: 400 },
+								);
+							}
 							browserMode = body.browserMode;
 						} else if (
 							typeof body.headless === 'boolean' &&
@@ -941,9 +987,18 @@ const server = Bun.serve({
 						// No/empty JSON body — keep job default / BROWSER_HEADLESS
 					}
 
-					runDownloadProcess(jobId);
+					const queueResult = jobQueue.enqueue(jobId, () =>
+						runDownloadProcess(jobId),
+					);
 
-					return jsonResponse({ success: true, message: 'Download started' });
+					return jsonResponse({
+						success: true,
+						queued: queueResult.queued,
+						queuePosition: queueResult.position || undefined,
+						message: queueResult.queued
+							? `Download queued at position ${queueResult.position}`
+							: 'Download started',
+					});
 				} catch (error) {
 					return jsonResponse(
 						{
@@ -966,6 +1021,13 @@ const server = Bun.serve({
 					}
 
 					const stage = job.progress.stage;
+					if (stage === 'queued' && jobQueue.cancel(jobId)) {
+						jobStore.cancel(jobId);
+						return jsonResponse({
+							success: true,
+							message: 'Queued download cancelled',
+						});
+					}
 					if (stage === 'ready' || stage === 'cancelled') {
 						jobStore.cancel(jobId);
 						await closeJobDownloader(jobId);

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,7 @@ export type OutputFormat = 'original' | 'mp3-320' | 'flac';
 // Job system types for Web UI
 export type JobStage =
 	| 'pending'
+	| 'queued'
 	| 'fetching_track'
 	| 'waiting_hypeddit'
 	| 'waiting_bandcamp_track'
@@ -70,6 +71,8 @@ export interface JobProgress {
 	browserless?: boolean;
 	/** Present while stage is `waiting_bandcamp_track`. */
 	bandcampAlbumTracks?: BandcampAlbumTrackChoice[];
+	/** One-based position among jobs waiting for the server's download slot. */
+	queuePosition?: number;
 }
 
 export interface Job {

--- a/userscript/sc-gate-dl.user.js
+++ b/userscript/sc-gate-dl.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         sc-gate-dl
 // @namespace    https://github.com/D3SOX/sc-gate-dl
-// @version      1.10.2
+// @version      1.10.3
 // @description  Add sc-gate-dl download controls and remember your position in the SoundCloud feed
 // @author       D3SOX
 // @match        https://soundcloud.com/*
@@ -107,6 +107,25 @@
   <path fill="currentColor" d="M12 3.25a.75.75 0 0 1 .75.75v9.19l3.22-3.22a.75.75 0 1 1 1.06 1.06l-4.5 4.5a.75.75 0 0 1-1.06 0l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.22 3.22V4A.75.75 0 0 1 12 3.25Z"/>
   <path fill="currentColor" d="M4.5 15.25a.75.75 0 0 1 .75.75v2.25h13.5V16a.75.75 0 0 1 1.5 0v2.5A1.75 1.75 0 0 1 18.5 20.25h-13A1.75 1.75 0 0 1 3.75 18.5V16a.75.75 0 0 1 .75-.75Z"/>
 </svg>`;
+
+	const STORE_SERVICE_ATTR = 'data-sc-gate-dl-store-service';
+	const STORE_SERVICES = {
+		hypeddit: {
+			icon: 'https://hypeddit.com/images/favicon.ico',
+		},
+		droploud: {
+			icon: 'https://droploud.com/favicon.ico',
+		},
+		gaterush: {
+			icon: 'https://gaterush.me/icons/logo-icon-large.png',
+		},
+		downloadgater: {
+			icon: 'https://downloadgater.com/favicon.png',
+		},
+		bandcamp: {
+			icon: 'https://s4.bcbits.com/client-bundle/1/PageLayout_1/favicon-78ff127104384a042453aca8d73be7dc.static/favicon/favicon-32x32.png',
+		},
+	};
 
 	function getAutoClose() {
 		try {
@@ -229,6 +248,82 @@
 				return document.URL || '';
 			}
 		}
+	}
+
+	function unwrapStoreUrl(href) {
+		try {
+			const url = new URL(href, currentHref() || 'https://soundcloud.com/');
+			if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
+			if (url.hostname.toLowerCase().replace(/^www\./, '') !== 'gate.sc') {
+				return url.href;
+			}
+			const wrapped = url.searchParams.get('url');
+			if (!wrapped) return url.href;
+			const destination = new URL(wrapped);
+			if (
+				destination.protocol !== 'https:' &&
+				destination.protocol !== 'http:'
+			) {
+				return url.href;
+			}
+			return destination.href;
+		} catch {
+			return null;
+		}
+	}
+
+	function storeServiceForUrl(href) {
+		try {
+			const url = new URL(href);
+			const host = url.hostname.toLowerCase().replace(/^www\./, '');
+			const path = url.pathname;
+			if (host === 'hypeddit.com' && path.startsWith('/')) return 'hypeddit';
+			if (
+				host === 'droploud.com' &&
+				/^\/(?:gate|track)\/[0-9a-f-]+\/?$/i.test(path)
+			) {
+				return 'droploud';
+			}
+			if (host === 'gaterush.me' && /^\/[A-Za-z0-9_-]+\/?$/.test(path)) {
+				return 'gaterush';
+			}
+			if (
+				host === 'downloadgater.com' &&
+				/^\/g\/[A-Za-z0-9_-]+\/?$/.test(path)
+			) {
+				return 'downloadgater';
+			}
+			if (
+				(host === 'bandcamp.com' || host.endsWith('.bandcamp.com')) &&
+				/^\/(?:track|album)\/[^/]+\/?$/i.test(path)
+			) {
+				return 'bandcamp';
+			}
+		} catch {
+			// Ignore malformed store URLs.
+		}
+		return null;
+	}
+
+	function decorateStoreLink(anchor) {
+		if (!(anchor instanceof HTMLAnchorElement) || isOurNode(anchor)) return;
+		const destination = unwrapStoreUrl(anchor.href);
+		if (!destination) return;
+		if (destination !== anchor.href) anchor.href = destination;
+		const serviceKey = storeServiceForUrl(destination);
+		if (!serviceKey) {
+			anchor.removeAttribute(STORE_SERVICE_ATTR);
+			anchor.style.removeProperty('--sc-gate-dl-store-icon');
+			return;
+		}
+		const service = STORE_SERVICES[serviceKey];
+		if (!service) return;
+
+		anchor.setAttribute(STORE_SERVICE_ATTR, serviceKey);
+		anchor.style.setProperty(
+			'--sc-gate-dl-store-icon',
+			`url("${service.icon}")`,
+		);
 	}
 
 	function normalizeTrackUrl(href) {
@@ -1365,6 +1460,31 @@ a[${BUTTON_ATTR}="classic"] svg {
 	width: 16px;
 	height: 16px;
 }
+a[${STORE_SERVICE_ATTR}] svg,
+a[${STORE_SERVICE_ATTR}] .sc-button-icon {
+	opacity: 0 !important;
+}
+a.soundActions__purchaseLink[${STORE_SERVICE_ATTR}],
+a.sc-button-buy[${STORE_SERVICE_ATTR}] {
+	position: relative !important;
+	background-image: none !important;
+}
+a.soundActions__purchaseLink[${STORE_SERVICE_ATTR}]::before,
+a.sc-button-buy[${STORE_SERVICE_ATTR}]::before {
+	opacity: 0 !important;
+}
+a.soundActions__purchaseLink[${STORE_SERVICE_ATTR}]::after,
+a.sc-button-buy[${STORE_SERVICE_ATTR}]::after {
+	content: "";
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	width: 16px;
+	height: 16px;
+	transform: translate(-50%, -50%);
+	background: var(--sc-gate-dl-store-icon) center / contain no-repeat;
+	pointer-events: none;
+}
 
 /* MUI listen page */
 div[${WRAP_ATTR}="mui"] {
@@ -1375,6 +1495,20 @@ button[${BUTTON_ATTR}="mui"] svg {
 	display: block;
 	width: 24px;
 	height: 24px;
+}
+a[${STORE_SERVICE_ATTR}] > button {
+	position: relative;
+}
+a[${STORE_SERVICE_ATTR}] > button::after {
+	content: "";
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	width: 24px;
+	height: 24px;
+	transform: translate(-50%, -50%);
+	background: var(--sc-gate-dl-store-icon) center / contain no-repeat;
+	pointer-events: none;
 }
 `;
 		document.documentElement.appendChild(style);
@@ -1560,11 +1694,12 @@ button[${BUTTON_ATTR}="mui"] svg {
 		panel.addEventListener('pointercancel', endResize);
 	}
 
-	function buildWebuiSrc(trackUrl) {
+	function buildWebuiSrc(trackUrl, embedded = false) {
 		const params = new URLSearchParams({
 			url: trackUrl,
 			outputFormat: getOutputFormat(),
 		});
+		if (embedded) params.set('embedded', '1');
 		return `${getWebuiBase()}/?${params.toString()}`;
 	}
 
@@ -1574,11 +1709,12 @@ button[${BUTTON_ATTR}="mui"] svg {
 			void cancelActiveJob(panel);
 		}
 		panel.dataset.trackUrl = trackUrl;
-		const src = buildWebuiSrc(trackUrl);
+		const iframeSrc = buildWebuiSrc(trackUrl, true);
+		const tabSrc = buildWebuiSrc(trackUrl);
 		const iframe = panel.querySelector('iframe');
 		const openTab = panel.querySelector('.sc-gate-dl-open-tab');
-		if (iframe) iframe.src = src;
-		if (openTab instanceof HTMLAnchorElement) openTab.href = src;
+		if (iframe) iframe.src = iframeSrc;
+		if (openTab instanceof HTMLAnchorElement) openTab.href = tabSrc;
 	}
 
 	function getApiBase() {
@@ -1638,11 +1774,13 @@ button[${BUTTON_ATTR}="mui"] svg {
 		window.clearTimeout(autoCloseTimer);
 		const panel = document.getElementById(PANEL_ID);
 		if (!panel) return;
-		await cancelActiveJob(panel);
+		const cancellation = cancelActiveJob(panel);
 		const iframe = panel.querySelector('iframe');
 		if (iframe) iframe.src = 'about:blank';
 		delete panel.dataset.trackUrl;
+		delete panel.dataset.jobId;
 		panel.hidden = true;
+		await cancellation;
 	}
 
 	function applyQueueGeom(el) {
@@ -1917,6 +2055,12 @@ button[${BUTTON_ATTR}="mui"] svg {
 					void closePanel();
 				});
 			panel
+				.querySelector('.sc-gate-dl-open-tab')
+				?.addEventListener('click', () => {
+					// Let the target=_blank navigation happen, then tear down this job.
+					void closePanel();
+				});
+			panel
 				.querySelector('.sc-gate-dl-format')
 				?.addEventListener('change', (e) => {
 					const select = e.target;
@@ -2055,6 +2199,20 @@ button[${BUTTON_ATTR}="mui"] svg {
 		);
 	}
 
+	function injectMuiWithoutBuy(moreButton) {
+		if (!(moreButton instanceof HTMLButtonElement)) return;
+		if (isOurNode(moreButton)) return;
+		if (!moreButton.closest('section[aria-label="Track header"]')) return;
+		if (isPlaylistOrAlbumContext(moreButton)) return;
+		if (alreadyInjectedNear(moreButton)) return;
+		const trackUrl = pageTrackUrl();
+		if (!trackUrl) return;
+		moreButton.insertAdjacentElement(
+			'beforebegin',
+			makeMuiControl(trackUrl, moreButton),
+		);
+	}
+
 	function isClassicPurchase(el) {
 		if (!(el instanceof Element) || isOurNode(el)) return false;
 		if (el.classList.contains('purchaseLink__container')) return true;
@@ -2069,6 +2227,13 @@ button[${BUTTON_ATTR}="mui"] svg {
 		// Drop buttons that landed on playlist/album cards (e.g. before class hydrated)
 		for (const wrap of scope.querySelectorAll?.(`[${WRAP_ATTR}]`) || []) {
 			if (isPlaylistOrAlbumContext(wrap)) wrap.remove();
+		}
+
+		// Brand supported purchase links without loading third-party icon assets.
+		for (const anchor of scope.querySelectorAll?.(
+			'a.soundActions__purchaseLink, a.sc-button-buy, a[aria-label="Buy This Track"], a[target="_blank"][aria-label]',
+		) || []) {
+			decorateStoreLink(anchor);
 		}
 
 		// Classic layout only — one control per purchaseLink__container
@@ -2091,6 +2256,12 @@ button[${BUTTON_ATTR}="mui"] svg {
 			'a[aria-label="Buy This Track"], a[target="_blank"][aria-label]',
 		) || []) {
 			injectMui(el);
+		}
+		// Tracks without a purchase link still have the action row's More button.
+		for (const el of scope.querySelectorAll?.(
+			'section[aria-label="Track header"] button[aria-label="More menu"]',
+		) || []) {
+			injectMuiWithoutBuy(el);
 		}
 	}
 
@@ -2115,6 +2286,10 @@ button[${BUTTON_ATTR}="mui"] svg {
 	const observer = new MutationObserver((mutations) => {
 		let shouldScan = false;
 		for (const m of mutations) {
+			if (m.type === 'attributes') {
+				shouldScan = true;
+				break;
+			}
 			for (const node of m.addedNodes) {
 				if (!(node instanceof Element)) continue;
 				if (isOurNode(node)) continue;
@@ -2125,7 +2300,12 @@ button[${BUTTON_ATTR}="mui"] svg {
 		}
 		if (shouldScan) scan();
 	});
-	observer.observe(document.documentElement, { childList: true, subtree: true });
+	observer.observe(document.documentElement, {
+		childList: true,
+		subtree: true,
+		attributes: true,
+		attributeFilter: ['href'],
+	});
 
 	let lastHref = location.href;
 	setInterval(() => {

--- a/userscript/sc-gate-dl.user.js
+++ b/userscript/sc-gate-dl.user.js
@@ -309,13 +309,13 @@
 		if (!(anchor instanceof HTMLAnchorElement) || isOurNode(anchor)) return;
 		const destination = unwrapStoreUrl(anchor.href);
 		if (!destination) return;
-		if (destination !== anchor.href) anchor.href = destination;
 		const serviceKey = storeServiceForUrl(destination);
 		if (!serviceKey) {
 			anchor.removeAttribute(STORE_SERVICE_ATTR);
 			anchor.style.removeProperty('--sc-gate-dl-store-icon');
 			return;
 		}
+		if (destination !== anchor.href) anchor.href = destination;
 		const service = STORE_SERVICES[serviceKey];
 		if (!service) return;
 
@@ -2233,6 +2233,14 @@ a[${STORE_SERVICE_ATTR}] > button::after {
 		for (const anchor of scope.querySelectorAll?.(
 			'a.soundActions__purchaseLink, a.sc-button-buy, a[aria-label="Buy This Track"], a[target="_blank"][aria-label]',
 		) || []) {
+			const label = anchor.getAttribute('aria-label') || '';
+			if (
+				!anchor.classList.contains('soundActions__purchaseLink') &&
+				!anchor.classList.contains('sc-button-buy') &&
+				!/buy|store|purchase|free\s*download/i.test(label)
+			) {
+				continue;
+			}
 			decorateStoreLink(anchor);
 		}
 
@@ -2283,6 +2291,15 @@ a[${STORE_SERVICE_ATTR}] > button::after {
 		true,
 	);
 
+	let scanTimer = 0;
+	function scheduleScan() {
+		if (scanTimer) return;
+		scanTimer = window.setTimeout(() => {
+			scanTimer = 0;
+			scan();
+		}, 0);
+	}
+
 	const observer = new MutationObserver((mutations) => {
 		let shouldScan = false;
 		for (const m of mutations) {
@@ -2298,7 +2315,7 @@ a[${STORE_SERVICE_ATTR}] > button::after {
 			}
 			if (shouldScan) break;
 		}
-		if (shouldScan) scan();
+		if (shouldScan) scheduleScan();
 	});
 	observer.observe(document.documentElement, {
 		childList: true,

--- a/webui/astro.config.mjs
+++ b/webui/astro.config.mjs
@@ -5,6 +5,9 @@ import react from '@astrojs/react';
 
 // https://astro.build/config
 export default defineConfig({
+	devToolbar: {
+		enabled: false,
+	},
 	integrations: [react()],
 	vite: {
 		server: {

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -2,7 +2,12 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Toaster, toast } from 'sonner';
 import type { BrowserMode } from '../../../src/types';
 import './App.css';
-import { readStoredBrowserMode, shouldAutoStartDeepLink } from './deepLink';
+import {
+	parseAvailableBrowserModes,
+	readStoredBrowserMode,
+	shouldAutoStartDeepLink,
+	shouldUseEmbeddedLayout,
+} from './deepLink';
 
 type Step = 'url' | 'gate' | 'download' | 'metadata' | 'complete';
 type OutputFormat = 'original' | 'mp3-320' | 'flac';
@@ -30,13 +35,25 @@ interface JobProgress {
 	totalBytes?: number;
 	browserless?: boolean;
 	bandcampAlbumTracks?: BandcampAlbumTrackChoice[];
+	queuePosition?: number;
 }
 
 const GATE_PROGRESS_STAGES = new Set([
+	'queued',
 	'initializing_browser',
 	'preparing_logins',
 	'handling_gates',
 	'waiting_bandcamp_track',
+]);
+
+const ACTIVE_JOB_STAGES = new Set([
+	'queued',
+	'initializing_browser',
+	'preparing_logins',
+	'handling_gates',
+	'waiting_bandcamp_track',
+	'downloading',
+	'processing_audio',
 ]);
 
 interface BandcampAlbumTrackChoice {
@@ -61,6 +78,11 @@ interface JobState {
 
 const API_BASE = 'http://localhost:3000';
 const BROWSER_MODE_STORAGE_KEY = 'sc-gate-dl-browser-mode';
+const BROWSER_MODE_LABELS: Record<BrowserMode, string> = {
+	headless: 'Headless',
+	xvfb: 'Invisible headed (Xvfb)',
+	headed: 'Visible headed window',
+};
 
 const ALLOWED_HOST_ORIGINS = new Set([
 	'https://soundcloud.com',
@@ -208,7 +230,11 @@ export default function App() {
 	const [skipAutomaticHypedditFetch, setSkipAutomaticHypedditFetch] =
 		useState(false);
 	const [browserMode, setBrowserMode] = useState<BrowserMode>('headless');
+	const [availableBrowserModes, setAvailableBrowserModes] = useState<
+		BrowserMode[]
+	>(['headless', 'headed']);
 	const [browserModeHydrated, setBrowserModeHydrated] = useState(false);
+	const [embedded, setEmbedded] = useState(false);
 	const [outputFormat, setOutputFormat] = useState<OutputFormat>('mp3-320');
 	const [job, setJob] = useState<JobState>({
 		jobId: null,
@@ -231,17 +257,41 @@ export default function App() {
 	});
 
 	useEffect(() => {
-		try {
-			const storedMode = readStoredBrowserMode(
-				localStorage,
-				BROWSER_MODE_STORAGE_KEY,
-			);
-			if (storedMode) setBrowserMode(storedMode);
-		} catch {
-			// Storage may be blocked when the Web UI is embedded cross-origin.
-		} finally {
-			setBrowserModeHydrated(true);
-		}
+		let cancelled = false;
+		setEmbedded(shouldUseEmbeddedLayout(window.location.search));
+
+		const hydrateBrowserModes = async () => {
+			let modes: BrowserMode[] = ['headless', 'headed'];
+			try {
+				const response = await fetch(`${API_BASE}/api/capabilities`);
+				if (response.ok) {
+					modes = parseAvailableBrowserModes(await response.json());
+				}
+			} catch {
+				// Keep the portable modes when the API is unavailable.
+			}
+
+			if (cancelled) return;
+			setAvailableBrowserModes(modes);
+			try {
+				const storedMode = readStoredBrowserMode(
+					localStorage,
+					BROWSER_MODE_STORAGE_KEY,
+				);
+				if (storedMode && modes.includes(storedMode)) {
+					setBrowserMode(storedMode);
+				}
+			} catch {
+				// Storage may be blocked when the Web UI is embedded cross-origin.
+			} finally {
+				setBrowserModeHydrated(true);
+			}
+		};
+
+		void hydrateBrowserModes();
+		return () => {
+			cancelled = true;
+		};
 	}, []);
 
 	const updateBrowserMode = (mode: BrowserMode) => {
@@ -258,7 +308,36 @@ export default function App() {
 	const cleanupToastShownRef = useRef(false);
 	const autoStartedFromQueryRef = useRef(false);
 	const eventSourceRef = useRef<EventSource | null>(null);
+	const cancelRequestedRef = useRef(false);
+	const unloadJobRef = useRef<{ jobId: string | null; stage?: string }>({
+		jobId: null,
+	});
 	const formatPercent = (value?: number) => Math.round(value ?? 0);
+
+	useEffect(() => {
+		unloadJobRef.current = {
+			jobId: job.jobId,
+			stage: job.progress?.stage,
+		};
+	}, [job.jobId, job.progress?.stage]);
+
+	useEffect(() => {
+		const cancelJobOnUnload = () => {
+			if (cancelRequestedRef.current) return;
+			const { jobId, stage } = unloadJobRef.current;
+			if (!jobId || !stage || !ACTIVE_JOB_STAGES.has(stage)) return;
+			cancelRequestedRef.current = true;
+			const url = `${API_BASE}/api/job/${encodeURIComponent(jobId)}/cancel`;
+			try {
+				if (navigator.sendBeacon(url)) return;
+			} catch {
+				// Fall back to a keepalive request below.
+			}
+			void fetch(url, { method: 'POST', keepalive: true }).catch(() => {});
+		};
+		window.addEventListener('beforeunload', cancelJobOnUnload);
+		return () => window.removeEventListener('beforeunload', cancelJobOnUnload);
+	}, []);
 
 	const showCleanupSoundcloudToast = useCallback(() => {
 		toast('Cleanup your SoundCloud account?', {
@@ -329,6 +408,7 @@ export default function App() {
 	// Start download process
 	const startDownload = useCallback(
 		async (jobId: string) => {
+			cancelRequestedRef.current = false;
 			setStep('gate');
 			setJob((prev) => ({
 				...prev,
@@ -460,12 +540,14 @@ export default function App() {
 	const cancelDownload = useCallback(async () => {
 		const jobId = job.jobId;
 		if (!jobId) return;
+		cancelRequestedRef.current = true;
 
 		try {
 			const response = await fetch(`${API_BASE}/api/job/${jobId}/cancel`, {
 				method: 'POST',
 			});
 			if (!response.ok) {
+				cancelRequestedRef.current = false;
 				const data = await response.json().catch(() => ({}));
 				setJob((prev) => ({
 					...prev,
@@ -475,6 +557,7 @@ export default function App() {
 				return;
 			}
 		} catch (err) {
+			cancelRequestedRef.current = false;
 			setJob((prev) => ({
 				...prev,
 				error: err instanceof Error ? err.message : 'Failed to cancel download',
@@ -817,6 +900,7 @@ export default function App() {
 
 	// Reset and start over
 	const handleReset = () => {
+		cancelRequestedRef.current = false;
 		notifyParent('new-download');
 		setSoundcloudUrl('');
 		setHypedditUrlInput('');
@@ -882,16 +966,18 @@ export default function App() {
 	return (
 		<div className="app">
 			<Toaster richColors closeButton theme="dark" />
-			<header className="header">
-				<div className="logo">
-					<span className="logo-icon">&#9654;</span>
-					<h1>sc-gate-dl</h1>
-				</div>
-				<p className="tagline">
-					Download & tag SoundCloud tracks from Hypeddit, Droploud, GateRush,
-					DownloadGater, Bandcamp, or a direct download link
-				</p>
-			</header>
+			{!embedded && (
+				<header className="header">
+					<div className="logo">
+						<span className="logo-icon">&#9654;</span>
+						<h1>sc-gate-dl</h1>
+					</div>
+					<p className="tagline">
+						Download & tag SoundCloud tracks from Hypeddit, Droploud, GateRush,
+						DownloadGater, Bandcamp, or a direct download link
+					</p>
+				</header>
+			)}
 
 			{/* Step indicator */}
 			<div className="steps">
@@ -1011,9 +1097,11 @@ export default function App() {
 									}
 									disabled={isLoading}
 								>
-									<option value="headless">Headless</option>
-									<option value="xvfb">Invisible headed (Xvfb)</option>
-									<option value="headed">Visible headed window</option>
+									{availableBrowserModes.map((mode) => (
+										<option key={mode} value={mode}>
+											{BROWSER_MODE_LABELS[mode]}
+										</option>
+									))}
 								</select>
 							</div>
 							<div className="checkbox-settings">
@@ -1070,7 +1158,7 @@ export default function App() {
 									disabled={isLoading}
 								/>
 							</div>
-							<div className="form-group url-settings-format">
+							<div className="form-group">
 								<label htmlFor="browser-mode-gate">Browser Mode</label>
 								<select
 									id="browser-mode-gate"
@@ -1080,9 +1168,11 @@ export default function App() {
 									}
 									disabled={isLoading}
 								>
-									<option value="headless">Headless</option>
-									<option value="xvfb">Invisible headed (Xvfb)</option>
-									<option value="headed">Visible headed window</option>
+									{availableBrowserModes.map((mode) => (
+										<option key={mode} value={mode}>
+											{BROWSER_MODE_LABELS[mode]}
+										</option>
+									))}
 								</select>
 							</div>
 							<button
@@ -1502,34 +1592,36 @@ export default function App() {
 				)}
 			</div>
 
-			<footer className="footer">
-				<div className="footer-buttons">
-					<button
-						type="button"
-						className="btn-secondary btn-cleanup"
-						onClick={handleInitializeLogins}
-					>
-						Initialize Logins
-					</button>
-					<button
-						type="button"
-						className="btn-secondary btn-cleanup"
-						onClick={showCleanupSoundcloudToast}
-					>
-						Cleanup SoundCloud
-					</button>
-				</div>
-				<p>
-					Built for personal use &middot;{' '}
-					<a
-						href="https://github.com/D3SOX/sc-gate-dl"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						GitHub
-					</a>
-				</p>
-			</footer>
+			{!embedded && (
+				<footer className="footer">
+					<div className="footer-buttons">
+						<button
+							type="button"
+							className="btn-secondary btn-cleanup"
+							onClick={handleInitializeLogins}
+						>
+							Initialize Logins
+						</button>
+						<button
+							type="button"
+							className="btn-secondary btn-cleanup"
+							onClick={showCleanupSoundcloudToast}
+						>
+							Cleanup SoundCloud
+						</button>
+					</div>
+					<p>
+						Built for personal use &middot;{' '}
+						<a
+							href="https://github.com/D3SOX/sc-gate-dl"
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							GitHub
+						</a>
+					</p>
+				</footer>
+			)}
 		</div>
 	);
 }

--- a/webui/src/components/deepLink.ts
+++ b/webui/src/components/deepLink.ts
@@ -15,3 +15,15 @@ export function shouldAutoStartDeepLink(
 ): queryUrl is string {
 	return browserModeHydrated && !alreadyStarted && Boolean(queryUrl);
 }
+
+export function shouldUseEmbeddedLayout(search: string): boolean {
+	return new URLSearchParams(search).get('embedded') === '1';
+}
+
+export function parseAvailableBrowserModes(value: unknown): BrowserMode[] {
+	if (!value || typeof value !== 'object') return ['headless', 'headed'];
+	const browserModes = (value as { browserModes?: unknown }).browserModes;
+	if (!Array.isArray(browserModes)) return ['headless', 'headed'];
+	const parsed = browserModes.filter(isBrowserMode);
+	return parsed.length > 0 ? parsed : ['headless', 'headed'];
+}


### PR DESCRIPTION
## Summary

- support download controls on the new SoundCloud track layout, including tracks without a store icon
- unwrap gate.sc links and show supported services using their website favicons without mutating React-owned DOM nodes
- serialize jobs across tabs, support cancellation when an embedded panel or browser tab closes, and keep normal tab switches alive
- hide embedded UI chrome, remove excess form spacing, disable the Astro toolbar by default, and expose Xvfb only on Linux

## Validation

- bun test
- bun run lint
- bunx tsc --noEmit -p webui/tsconfig.json
- git diff --check
- userscript syntax check
- Puppeteer checks for new-layout injection, favicon mapping, gate.sc unwrapping, non-destructive DOM updates, embedded/open-tab behavior, and cancellation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added download queuing with visible queue positions for simultaneous downloads.
  - Browser mode options now reflect platform capabilities and support embedded layouts.
  - Expanded recognition for Gate.sc, Hypeddit, Droploud, Gaterush, Downloadgater, and Bandcamp links.
  - Added download controls for track headers and improved iframe Web UI behavior.

- **Bug Fixes**
  - Improved cancellation during queued and active downloads.
  - Downloads now continue reliably after individual task failures.
  - Updated the userscript to version 1.10.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->