### PR TITLE
fix: impersonate Chrome for Bandcamp downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Download and tag SoundCloud tracks unlocked via Hypeddit, Droploud, GateRush, Do
 
 - [**Bun**](https://bun.sh) - JavaScript runtime and package manager
 - [**ffmpeg**](https://ffmpeg.org) - Must be installed and available in your `PATH`
-- [**yt-dlp**](https://github.com/yt-dlp/yt-dlp) - Required for Bandcamp purchase/download links and for downloading a SoundCloud track directly when no gate is found
+- [**yt-dlp**](https://github.com/yt-dlp/yt-dlp) - Required for Bandcamp purchase/download links and for downloading a SoundCloud track directly when no gate is found. Bandcamp support requires the optional `curl_cffi` backend (`python-curl-cffi` on Arch Linux or `yt-dlp[default,curl-cffi]` with pip) for Chrome impersonation.
 - **SoundCloud account** - It is recommended to create a throwaway account for this. Even though there were no reports of accounts getting banned I can't guarantee it. Also most gate downloads require reposts/likes/follows which you might not want to do with your main account
 - **Spotify account** (optional) - Required when a Hypeddit post has an unskippable Spotify gate. I also recommend creating a throwaway account as most Hypeddit downloads require saving playlists/songs to your library or following artists which you might not want on your main account.
 

--- a/src/ytdlp.ts
+++ b/src/ytdlp.ts
@@ -4,6 +4,7 @@ import { lookpath } from 'find-bin';
 import type { BandcampAlbumTrackChoice, JobProgress } from './types';
 import {
 	isBandcampAlbumUrl,
+	isBandcampUrl,
 	isSoundcloudUrl,
 	writeSoundcloudNetscapeCookies,
 } from './utils';
@@ -30,6 +31,8 @@ const YTDLP_DOWNLOAD_TIMEOUT_MS = 10 * 60_000;
 const YTDLP_METADATA_TIMEOUT_MS = 60_000;
 const ALBUM_MATCH_THRESHOLD = 0.5;
 const PROGRESS_PREFIX = 'SC_GATE_DL_PROGRESS:';
+// Work around Bandcamp's client challenge: https://github.com/yt-dlp/yt-dlp/issues/17356
+const BANDCAMP_IMPERSONATION_ARGS = ['--impersonate', 'chrome'];
 
 type FlatEntry = {
 	id?: string;
@@ -284,11 +287,13 @@ export class YtDlpDownloader {
 		await mkdir(DOWNLOADS_DIR, { recursive: true });
 
 		const outputTemplate = join(DOWNLOADS_DIR, '%(title)s [%(id)s].%(ext)s');
+		const bandcamp = isBandcampUrl(downloadUrl);
 		const soundcloud = isSoundcloudUrl(downloadUrl);
 		// Prefer SoundCloud's original upload (`download`) when the track allows it.
 		// That format is only listed for registered users — pass cookies when available.
 		const format = soundcloud ? 'download/bestaudio/best' : 'bestaudio/best';
 		const args = [
+			...(bandcamp ? BANDCAMP_IMPERSONATION_ARGS : []),
 			'--no-mtime',
 			'--no-playlist',
 			'--newline',
@@ -415,7 +420,13 @@ export class YtDlpDownloader {
 
 		const stdout = await this.runYtDlp(
 			ytDlpBin,
-			['--flat-playlist', '-J', '--no-warnings', albumUrl],
+			[
+				...BANDCAMP_IMPERSONATION_ARGS,
+				'--flat-playlist',
+				'-J',
+				'--no-warnings',
+				albumUrl,
+			],
 			YTDLP_METADATA_TIMEOUT_MS,
 		);
 


### PR DESCRIPTION
## Summary

- pass `--impersonate chrome` to Bandcamp track downloads
- use the same impersonation arguments when resolving Bandcamp album metadata
- document the workaround for yt-dlp issue #17356

## Why

Bandcamp may return a client-challenge page to yt-dlp instead of track or album metadata. Chrome impersonation works around that response so Bandcamp downloads can proceed.

## Validation

- `bun test src/ytdlp.test.ts`
- `bun run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bandcamp URL handling for metadata lookups and audio downloads.
  * Enhanced compatibility with sites requiring Chrome-like browser identification.
  * Preserved existing SoundCloud format selection, cookie handling, progress reporting, and output processing.

* **Documentation**
  * Updated prerequisites with installation guidance for the optional `curl_cffi` backend required for Bandcamp support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->