### PR TITLE
Prefer authenticated SoundCloud original downloads

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,7 @@ import { HypedditHttpDownloader } from './hypedditHttp';
 import { JobQueue } from './jobQueue';
 import { jobStore } from './jobStore';
 import { SoundcloudClient } from './soundcloud';
+import { isSoundcloudDownloadEnabled } from './soundcloudDownload';
 import {
 	type BrowserMode,
 	isBrowserMode,
@@ -32,7 +33,7 @@ import {
 	validateGateUrl,
 	validateSoundcloudUrl,
 } from './utils';
-import { YtDlpDownloader } from './ytdlp';
+import { canAccessSoundcloudOriginalDownload, YtDlpDownloader } from './ytdlp';
 
 const ffmpegBin = await getFfmpegBin();
 const ffprobeBin = await getFfprobeBin();
@@ -766,9 +767,21 @@ const server = Bun.serve({
 						);
 					}
 
-					const hypedditUrl = skipAutomaticHypedditFetch
-						? null
-						: await extractAndResolveGateUrl(track);
+					// A creator-enabled SoundCloud download is the preferred source: it
+					// bypasses gates and lets yt-dlp select the original `download` format.
+					const creatorDownloadAvailable = isSoundcloudDownloadEnabled(track);
+					const soundcloudDownloadEnabled =
+						creatorDownloadAvailable &&
+						(await canAccessSoundcloudOriginalDownload(soundcloudUrl));
+					const soundcloudDownloadWarning =
+						creatorDownloadAvailable && !soundcloudDownloadEnabled
+							? 'This track has a creator-enabled SoundCloud download, but yt-dlp could not access it. Add or refresh soundcloud-cookies.json to use the original download; continuing with the gate instead.'
+							: null;
+					const hypedditUrl = soundcloudDownloadEnabled
+						? { url: soundcloudUrl, provider: 'soundcloud' as const }
+						: skipAutomaticHypedditFetch
+							? null
+							: await extractAndResolveGateUrl(track);
 					const defaultMetadata = getDefaultMetadata(track);
 
 					const updatedJob = jobStore.update(job.id, {
@@ -778,7 +791,9 @@ const server = Bun.serve({
 						progress: {
 							stage: hypedditUrl ? 'pending' : 'waiting_hypeddit',
 							message: hypedditUrl
-								? 'Ready to start download'
+								? soundcloudDownloadEnabled
+									? 'Creator-enabled SoundCloud download ready'
+									: 'Ready to start download'
 								: skipAutomaticHypedditFetch
 									? 'Automatic gate lookup skipped - manual input required'
 									: 'Gate URL not found - manual input required',
@@ -799,6 +814,7 @@ const server = Bun.serve({
 						hypedditUrl: updatedJob.hypedditUrl,
 						defaultMetadata: updatedJob.defaultMetadata,
 						outputFormat: updatedJob.outputFormat,
+						soundcloudDownloadWarning,
 						needsHypedditUrl: !hypedditUrl,
 					});
 				} catch (error) {

--- a/src/soundcloudDownload.test.ts
+++ b/src/soundcloudDownload.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test';
+import { isSoundcloudDownloadEnabled } from './soundcloudDownload';
+
+describe('isSoundcloudDownloadEnabled', () => {
+	test('accepts tracks with creator-enabled downloads remaining', () => {
+		expect(
+			isSoundcloudDownloadEnabled({
+				downloadable: true,
+				has_downloads_left: true,
+			}),
+		).toBe(true);
+	});
+
+	test('rejects tracks without an available SoundCloud download', () => {
+		expect(
+			isSoundcloudDownloadEnabled({
+				downloadable: false,
+				has_downloads_left: true,
+			}),
+		).toBe(false);
+		expect(
+			isSoundcloudDownloadEnabled({
+				downloadable: true,
+				has_downloads_left: false,
+			}),
+		).toBe(false);
+	});
+});

--- a/src/soundcloudDownload.ts
+++ b/src/soundcloudDownload.ts
@@ -1,0 +1,8 @@
+import type { SoundcloudTrack } from 'soundcloud.ts';
+
+/** Whether SoundCloud currently exposes the creator-enabled download button. */
+export function isSoundcloudDownloadEnabled(
+	track: Pick<SoundcloudTrack, 'downloadable' | 'has_downloads_left'>,
+): boolean {
+	return track.downloadable && track.has_downloads_left;
+}

--- a/src/ytdlp.test.ts
+++ b/src/ytdlp.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'bun:test';
-import { parseYtDlpProgressLine, readProcessLines } from './ytdlp';
+import {
+	canAccessSoundcloudOriginalDownload,
+	parseYtDlpProgressLine,
+	readProcessLines,
+} from './ytdlp';
 
 const streamChunks = (...chunks: string[]) =>
 	new ReadableStream<Uint8Array>({
@@ -58,5 +62,16 @@ describe('parseYtDlpProgressLine', () => {
 
 	test('ignores regular yt-dlp output', () => {
 		expect(parseYtDlpProgressLine('./downloads/track.m4a')).toBeNull();
+	});
+});
+
+describe('canAccessSoundcloudOriginalDownload', () => {
+	test('does not allow automatic direct download without exported cookies', async () => {
+		expect(
+			await canAccessSoundcloudOriginalDownload(
+				'https://soundcloud.com/artist/track',
+				'./missing-soundcloud-cookies.json',
+			),
+		).toBe(false);
 	});
 });

--- a/src/ytdlp.ts
+++ b/src/ytdlp.ts
@@ -152,6 +152,69 @@ export async function getYtDlpBin(): Promise<string> {
 	return ytDlpBin;
 }
 
+/**
+ * Check that yt-dlp can resolve SoundCloud's authenticated original-download
+ * format with the locally exported cookies. This performs extraction and the
+ * format availability HEAD request, but does not download the audio.
+ */
+export async function canAccessSoundcloudOriginalDownload(
+	url: string,
+	cookiesJsonPath = 'soundcloud-cookies.json',
+): Promise<boolean> {
+	const cookiesPath = await writeSoundcloudNetscapeCookies(cookiesJsonPath);
+	if (!cookiesPath) return false;
+
+	try {
+		const ytDlpBin = await getYtDlpBin();
+		const subprocess = Bun.spawn(
+			[
+				ytDlpBin,
+				'--simulate',
+				'--no-playlist',
+				'--no-warnings',
+				'--cookies',
+				cookiesPath,
+				'-f',
+				'download',
+				'--print',
+				'%(format_id)s',
+				url,
+			],
+			{
+				stdin: 'ignore',
+				stdout: 'pipe',
+				stderr: 'pipe',
+				timeout: YTDLP_METADATA_TIMEOUT_MS,
+				killSignal: 'SIGTERM',
+			},
+		);
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(subprocess.stdout).text(),
+			new Response(subprocess.stderr).text(),
+			subprocess.exited,
+		]);
+		const available =
+			exitCode === 0 &&
+			stdout
+				.split(/\r?\n/)
+				.map((line) => line.trim())
+				.includes('download');
+		if (!available) {
+			console.warn(
+				`SoundCloud original download preflight failed${stderr.trim() ? `: ${stderr.trim().slice(-500)}` : ''}`,
+			);
+		}
+		return available;
+	} catch (error) {
+		console.warn(
+			`SoundCloud original download preflight failed: ${error instanceof Error ? error.message : String(error)}`,
+		);
+		return false;
+	} finally {
+		await rm(cookiesPath, { force: true });
+	}
+}
+
 /** Strip (Clip)/(Preview)/brackets and normalize for fuzzy title compare. */
 export function normalizeTrackTitle(title: string): string {
 	return title

--- a/src/ytdlp.ts
+++ b/src/ytdlp.ts
@@ -1,4 +1,4 @@
-import { mkdir, rm } from 'node:fs/promises';
+import { mkdir } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 import { lookpath } from 'find-bin';
 import type { BandcampAlbumTrackChoice, JobProgress } from './types';
@@ -31,6 +31,17 @@ const YTDLP_DOWNLOAD_TIMEOUT_MS = 10 * 60_000;
 const YTDLP_METADATA_TIMEOUT_MS = 60_000;
 const ALBUM_MATCH_THRESHOLD = 0.5;
 const PROGRESS_PREFIX = 'SC_GATE_DL_PROGRESS:';
+
+async function deleteTemporaryFile(path: string): Promise<void> {
+	try {
+		await Bun.file(path).delete();
+	} catch (error) {
+		if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+			return;
+		}
+		throw error;
+	}
+}
 // Work around Bandcamp's client challenge: https://github.com/yt-dlp/yt-dlp/issues/17356
 const BANDCAMP_IMPERSONATION_ARGS = ['--impersonate', 'chrome'];
 
@@ -211,7 +222,7 @@ export async function canAccessSoundcloudOriginalDownload(
 		);
 		return false;
 	} finally {
-		await rm(cookiesPath, { force: true });
+		await deleteTemporaryFile(cookiesPath);
 	}
 }
 
@@ -415,7 +426,7 @@ export class YtDlpDownloader {
 				},
 			);
 		} finally {
-			if (cookiesPath) await rm(cookiesPath, { force: true });
+			if (cookiesPath) await deleteTemporaryFile(cookiesPath);
 		}
 
 		const filepaths = stdout

--- a/webui/src/components/App.css
+++ b/webui/src/components/App.css
@@ -164,6 +164,51 @@
 	background: rgba(255, 50, 50, 0.2);
 }
 
+/* Warning banner */
+.warning-banner {
+	display: flex;
+	align-items: center;
+	gap: var(--space-md);
+	padding: var(--space-md) var(--space-lg);
+	background: rgba(255, 174, 0, 0.1);
+	border: 1px solid rgba(255, 174, 0, 0.35);
+	border-radius: 8px;
+}
+
+.warning-icon {
+	width: 24px;
+	height: 24px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: #ffae00;
+	color: var(--bg-deep);
+	border-radius: 50%;
+	font-weight: 700;
+	font-size: 0.875rem;
+	flex-shrink: 0;
+}
+
+.warning-banner span:nth-child(2) {
+	flex: 1;
+	font-size: 0.9rem;
+}
+
+.warning-banner button {
+	padding: var(--space-xs) var(--space-md);
+	background: transparent;
+	border: 1px solid rgba(255, 174, 0, 0.5);
+	color: #ffc44d;
+	font-size: 0.8rem;
+	border-radius: 4px;
+	cursor: pointer;
+	transition: all var(--transition-fast);
+}
+
+.warning-banner button:hover {
+	background: rgba(255, 174, 0, 0.15);
+}
+
 /* Track preview */
 .track-preview {
 	display: flex;

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -608,7 +608,7 @@ export default function App() {
 			const format = formatOverride ?? outputFormat;
 
 			setIsLoading(true);
-			setJob((prev) => ({ ...prev, error: null }));
+			setJob((prev) => ({ ...prev, warning: null, error: null }));
 
 			try {
 				const response = await fetch(`${API_BASE}/api/job`, {

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -73,6 +73,7 @@ interface JobState {
 	downloadFilename: string | null;
 	outputFilename: string | null;
 	sourceIsLossless: boolean | null;
+	warning: string | null;
 	error: string | null;
 }
 
@@ -250,6 +251,7 @@ export default function App() {
 		downloadFilename: null,
 		outputFilename: null,
 		sourceIsLossless: null,
+		warning: null,
 		error: null,
 	});
 	const [metadata, setMetadata] = useState<Metadata>({
@@ -633,6 +635,7 @@ export default function App() {
 					defaultMetadata: data.defaultMetadata,
 					existingMetadata: null,
 					outputFormat: format,
+					warning: data.soundcloudDownloadWarning ?? null,
 					error: null,
 				}));
 
@@ -919,6 +922,7 @@ export default function App() {
 			downloadFilename: null,
 			outputFilename: null,
 			sourceIsLossless: null,
+			warning: null,
 			error: null,
 		});
 		setMetadata({ title: '', artist: '', album: '', genre: '' });
@@ -1028,6 +1032,19 @@ export default function App() {
 					<button
 						type="button"
 						onClick={() => setJob((prev) => ({ ...prev, error: null }))}
+					>
+						Dismiss
+					</button>
+				</div>
+			)}
+
+			{job.warning && (
+				<div className="warning-banner" role="status">
+					<span className="warning-icon">!</span>
+					<span>{job.warning}</span>
+					<button
+						type="button"
+						onClick={() => setJob((prev) => ({ ...prev, warning: null }))}
 					>
 						Dismiss
 					</button>


### PR DESCRIPTION
## Summary

- detect tracks with creator-enabled SoundCloud downloads before resolving gates
- verify that yt-dlp can access the authenticated `download` format with exported SoundCloud cookies
- download directly only when that preflight succeeds; otherwise retain the normal gate fallback
- show a persistent, dismissible warning when the original download exists but cookies cannot access it

## Root cause

Job creation only inspected gate URLs. It did not prioritize SoundCloud's creator-enabled original download, and the API availability flags alone could not prove that the local yt-dlp session had usable authentication cookies.

## Impact

Eligible tracks now skip unnecessary gates and use SoundCloud's original upload. Missing, expired, or rejected cookies no longer cause an incorrect direct-download decision, and the UI explains why the app is falling back to the gate.

## Validation

- `bun test` — 62 tests passed
- `bun run lint`
- `bunx tsc --noEmit -p webui/tsconfig.json`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for downloading SoundCloud tracks directly when creator-enabled downloads are available.
  * Job status now identifies creator-enabled downloads as ready.

* **Bug Fixes**
  * Added fallback handling when direct downloads cannot be accessed.
  * Added clearer warnings when creator access is available but cookies prevent the download.

* **UI Improvements**
  * Added a dismissible warning banner for job creation issues.
  * Warnings are cleared when starting or resetting a job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->