### PR TITLE
Improve download recovery and feed tracking

### DIFF
--- a/userscript/sc-gate-dl.test.ts
+++ b/userscript/sc-gate-dl.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+type UpdateFeedPlaybackOrigin = (
+	currentOrigin: string | null,
+	feedCardUrl: string | null,
+	outsidePlaybackSelection: boolean,
+) => string | null;
+
+const source = readFileSync(
+	new URL('./sc-gate-dl.user.js', import.meta.url),
+	'utf8',
+);
+const start = source.indexOf('\tfunction updateFeedPlaybackOrigin(');
+const end = source.indexOf('\n\n\tlet lastRecordedPlayingUrl', start);
+if (start < 0 || end < 0) throw new Error('Playback-origin helper not found');
+const helperSource = source.slice(start, end).trim();
+const updateFeedPlaybackOrigin = Function(
+	`"use strict"; ${helperSource}; return updateFeedPlaybackOrigin;`,
+)() as UpdateFeedPlaybackOrigin;
+
+describe('feed playback origin', () => {
+	test('clears feed provenance when another track is selected outside the feed', () => {
+		expect(
+			updateFeedPlaybackOrigin(
+				'https://soundcloud.com/feed/track',
+				null,
+				true,
+			),
+		).toBeNull();
+	});
+
+	test('preserves feed provenance through unrelated page clicks', () => {
+		const origin = 'https://soundcloud.com/feed/track';
+		expect(updateFeedPlaybackOrigin(origin, null, false)).toBe(origin);
+	});
+});

--- a/userscript/sc-gate-dl.test.ts
+++ b/userscript/sc-gate-dl.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, test } from 'bun:test';
-import { readFileSync } from 'node:fs';
 
 type UpdateFeedPlaybackOrigin = (
 	currentOrigin: string | null,
@@ -7,10 +6,9 @@ type UpdateFeedPlaybackOrigin = (
 	outsidePlaybackSelection: boolean,
 ) => string | null;
 
-const source = readFileSync(
+const source = await Bun.file(
 	new URL('./sc-gate-dl.user.js', import.meta.url),
-	'utf8',
-);
+).text();
 const start = source.indexOf('\tfunction updateFeedPlaybackOrigin(');
 const end = source.indexOf('\n\n\tlet lastRecordedPlayingUrl', start);
 if (start < 0 || end < 0) throw new Error('Playback-origin helper not found');
@@ -22,11 +20,7 @@ const updateFeedPlaybackOrigin = Function(
 describe('feed playback origin', () => {
 	test('clears feed provenance when another track is selected outside the feed', () => {
 		expect(
-			updateFeedPlaybackOrigin(
-				'https://soundcloud.com/feed/track',
-				null,
-				true,
-			),
+			updateFeedPlaybackOrigin('https://soundcloud.com/feed/track', null, true),
 		).toBeNull();
 	});
 

--- a/userscript/sc-gate-dl.user.js
+++ b/userscript/sc-gate-dl.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         sc-gate-dl
 // @namespace    https://github.com/D3SOX/sc-gate-dl
-// @version      1.10.7
+// @version      1.10.9
 // @description  Add sc-gate-dl download controls and remember your position in the SoundCloud feed
 // @author       D3SOX
 // @match        https://soundcloud.com/*
@@ -81,6 +81,7 @@
 		'about',
 		'stations',
 		'feed',
+		'tags',
 	]);
 
 	const TRAILING_SEGMENTS = new Set([
@@ -379,6 +380,14 @@
 
 	/** Feed/search cards only — track pages use the current URL. */
 	function trackUrlFromCard(el) {
+		const trackItem = el?.closest?.('.trackItem');
+		const trackItemTitle = trackItem?.querySelector(
+			'a.trackItem__trackTitle[href]',
+		);
+		if (trackItemTitle instanceof HTMLAnchorElement) {
+			const trackItemUrl = normalizeTrackUrl(trackItemTitle.href);
+			if (trackItemUrl) return trackItemUrl;
+		}
 		const closest = el?.closest?.(
 			'.sound, .soundList__item, .userStreamItem, .searchItem__trackItem, .listenContext',
 		);
@@ -428,7 +437,13 @@
 		const normalized = normalizeTrackUrl(trackUrl);
 		if (!normalized) return null;
 		return (
-			feedCards().find((card) => trackUrlFromCard(card) === normalized) || null
+			feedCards().find(
+				(card) =>
+					trackUrlFromCard(card) === normalized ||
+					Array.from(card.querySelectorAll('a.trackItem__trackTitle[href]')).some(
+						(link) => normalizeTrackUrl(link.href) === normalized,
+					),
+			) || null
 		);
 	}
 
@@ -529,8 +544,14 @@
 			: trackLabelFromUrl(url);
 	}
 
-	function shouldAdvanceCheckpoint(saved, card, candidateTimestamp, direction) {
-		if (!saved || saved.url === trackUrlFromCard(card)) return true;
+	function shouldAdvanceCheckpoint(
+		saved,
+		card,
+		candidateTimestamp,
+		direction,
+		candidateUrl,
+	) {
+		if (!saved || saved.url === candidateUrl) return true;
 		if (saved.feedTimestamp != null && candidateTimestamp != null) {
 			return direction === 'newer'
 				? candidateTimestamp >= saved.feedTimestamp
@@ -547,12 +568,14 @@
 			: candidateIndex >= savedIndex;
 	}
 
-	function saveFeedCheckpointFromCard(card) {
+	function saveFeedCheckpointFromCard(card, playedUrl = null) {
 		if (!isFeedPage() || !(card instanceof Element)) return;
 		const feedCard = card.matches('.sound')
 			? card
 			: card.querySelector('.sound') || card;
-		const url = trackUrlFromCard(feedCard);
+		const url =
+			(playedUrl ? normalizeTrackUrl(playedUrl) : null) ||
+			trackUrlFromCard(feedCard);
 		if (!url) return;
 		const timestamp = feedTimestamp(feedCard);
 		const label = checkpointLabelFromCard(feedCard, url);
@@ -566,7 +589,11 @@
 		let changed = false;
 		for (const direction of ['newer', 'older']) {
 			const saved = checkpoints[direction];
-			if (!shouldAdvanceCheckpoint(saved, feedCard, timestamp, direction)) continue;
+			if (
+				!shouldAdvanceCheckpoint(saved, feedCard, timestamp, direction, url)
+			) {
+				continue;
+			}
 			if (saved?.url === url) {
 				if (saved.label !== label) {
 					checkpoints[direction] = { ...saved, label };
@@ -617,7 +644,7 @@
 		if (!url || url === lastRecordedPlayingUrl) return;
 		const card = url ? findFeedCard(url) : null;
 		if (card) {
-			saveFeedCheckpointFromCard(card);
+			saveFeedCheckpointFromCard(card, url);
 			lastRecordedPlayingUrl = url;
 			feedPlaybackOriginUrl = url;
 		}
@@ -643,17 +670,23 @@
 		const find = nav.querySelector('.sc-gate-dl-feed-find');
 		const resetNewer = nav.querySelector('.sc-gate-dl-feed-reset-newer');
 		const resetOlder = nav.querySelector('.sc-gate-dl-feed-reset-older');
-		const updateResumeButton = (button, checkpoint, label) => {
-			if (!(button instanceof HTMLButtonElement)) return;
-			button.hidden = feedSearchActive;
-			button.disabled = !checkpoint;
-			button.textContent = checkpoint
+		const updateResumeLink = (link, checkpoint, label) => {
+			if (!(link instanceof HTMLAnchorElement)) return;
+			link.hidden = feedSearchActive;
+			link.textContent = checkpoint
 				? `Resume ${label}: ${checkpoint.label}`
 				: 'No listened track saved yet';
-			button.title = checkpoint?.url || '';
+			link.title = checkpoint?.url || '';
+			if (checkpoint) {
+				link.removeAttribute('aria-disabled');
+				link.href = checkpoint.url;
+			} else {
+				link.setAttribute('aria-disabled', 'true');
+				link.removeAttribute('href');
+			}
 		};
-		updateResumeButton(resumeNewer, checkpoints?.newer, 'farthest up');
-		updateResumeButton(resumeOlder, checkpoints?.older, 'farthest down');
+		updateResumeLink(resumeNewer, checkpoints?.newer, 'farthest up');
+		updateResumeLink(resumeOlder, checkpoints?.older, 'farthest down');
 		if (resetNewer instanceof HTMLButtonElement) {
 			resetNewer.disabled = !checkpoints?.newer;
 		}
@@ -802,8 +835,8 @@
 					<span>Feed position</span>
 					<button type="button" class="sc-gate-dl-feed-close" aria-label="Close" title="Close">×</button>
 				</div>
-				<button type="button" class="sc-gate-dl-feed-resume-newer"></button>
-				<button type="button" class="sc-gate-dl-feed-resume-older"></button>
+				<a class="sc-gate-dl-feed-resume sc-gate-dl-feed-resume-newer"></a>
+				<a class="sc-gate-dl-feed-resume sc-gate-dl-feed-resume-older"></a>
 				<button type="button" class="sc-gate-dl-feed-cancel" hidden>Cancel scrolling</button>
 				<button type="button" class="sc-gate-dl-feed-find">Find track URL…</button>
 				<div class="sc-gate-dl-feed-reset-row">
@@ -818,7 +851,8 @@
 			for (const direction of ['newer', 'older']) {
 				nav
 					.querySelector(`.sc-gate-dl-feed-resume-${direction}`)
-					?.addEventListener('click', () => {
+					?.addEventListener('click', (event) => {
+						event.preventDefault();
 						if (feedSearchActive) {
 							cancelFeedSearch();
 							return;
@@ -1315,8 +1349,10 @@
 	color: #eee;
 	font-weight: 700;
 }
-#${FEED_NAV_ID} button {
+#${FEED_NAV_ID} button,
+#${FEED_NAV_ID} .sc-gate-dl-feed-resume {
 	appearance: none;
+	display: block;
 	box-sizing: border-box;
 	width: 100%;
 	min-height: 30px;
@@ -1328,6 +1364,7 @@
 	color: #eee;
 	font: inherit;
 	text-align: left;
+	text-decoration: none;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	cursor: pointer;
@@ -1342,8 +1379,17 @@
 	line-height: 1;
 }
 #${FEED_NAV_ID} button[hidden] { display: none !important; }
-#${FEED_NAV_ID} button:hover:not(:disabled) { border-color: #f50; color: #fff; }
+#${FEED_NAV_ID} .sc-gate-dl-feed-resume[hidden] { display: none !important; }
+#${FEED_NAV_ID} button:hover:not(:disabled),
+#${FEED_NAV_ID} .sc-gate-dl-feed-resume:hover:not([aria-disabled]) {
+	border-color: #f50;
+	color: #fff;
+}
 #${FEED_NAV_ID} button:disabled { color: #777; cursor: default; }
+#${FEED_NAV_ID} .sc-gate-dl-feed-resume[aria-disabled] {
+	color: #777;
+	cursor: default;
+}
 #${FEED_NAV_ID} .sc-gate-dl-feed-find { text-align: center; }
 #${FEED_NAV_ID} .sc-gate-dl-feed-reset-row {
 	display: flex;
@@ -2315,7 +2361,7 @@ a[${STORE_SERVICE_ATTR}] > button::after {
 				'button.playControl, button.sc-button-play, button.sc-button-pause, .soundTitle__playButton, .sound__coverArt .playButton',
 			);
 			const card = playControl?.closest(FEED_CARD_SELECTOR);
-			const cardUrl = card ? trackUrlFromCard(card) : null;
+			const cardUrl = card ? trackUrlFromCard(playControl) : null;
 			const outsidePlaybackSelection = Boolean(
 				!card &&
 					event.target.closest('.playControls, .playbackSoundBadge, .queue'),
@@ -2326,7 +2372,7 @@ a[${STORE_SERVICE_ATTR}] > button::after {
 				outsidePlaybackSelection,
 			);
 			if (card) {
-				saveFeedCheckpointFromCard(card);
+				saveFeedCheckpointFromCard(card, cardUrl);
 			}
 		},
 		true,

--- a/userscript/sc-gate-dl.user.js
+++ b/userscript/sc-gate-dl.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         sc-gate-dl
 // @namespace    https://github.com/D3SOX/sc-gate-dl
-// @version      1.10.6
+// @version      1.10.7
 // @description  Add sc-gate-dl download controls and remember your position in the SoundCloud feed
 // @author       D3SOX
 // @match        https://soundcloud.com/*
@@ -583,16 +583,25 @@
 		}
 	}
 
+	function updateFeedPlaybackOrigin(
+		currentOrigin,
+		feedCardUrl,
+		outsidePlaybackSelection,
+	) {
+		if (feedCardUrl) return feedCardUrl;
+		return outsidePlaybackSelection ? null : currentOrigin;
+	}
+
 	let lastRecordedPlayingUrl = null;
-	let feedPlaybackActive = false;
+	let feedPlaybackOriginUrl = null;
 
 	function recordPlayingFeedTrack() {
 		if (!isFeedPage()) {
-			feedPlaybackActive = false;
+			feedPlaybackOriginUrl = null;
 			lastRecordedPlayingUrl = null;
 			return;
 		}
-		if (!feedPlaybackActive) return;
+		if (!feedPlaybackOriginUrl) return;
 		const playing = document.querySelector(
 			'.playControls .playControl.playing, .playControls__play.playing, .playControls button[title^="Pause"], .playControls button[aria-label^="Pause"]',
 		);
@@ -610,6 +619,7 @@
 		if (card) {
 			saveFeedCheckpointFromCard(card);
 			lastRecordedPlayingUrl = url;
+			feedPlaybackOriginUrl = url;
 		}
 	}
 
@@ -2304,10 +2314,18 @@ a[${STORE_SERVICE_ATTR}] > button::after {
 			const playControl = event.target.closest(
 				'button.playControl, button.sc-button-play, button.sc-button-pause, .soundTitle__playButton, .sound__coverArt .playButton',
 			);
-			if (!playControl) return;
-			const card = playControl.closest(FEED_CARD_SELECTOR);
+			const card = playControl?.closest(FEED_CARD_SELECTOR);
+			const cardUrl = card ? trackUrlFromCard(card) : null;
+			const outsidePlaybackSelection = Boolean(
+				!card &&
+					event.target.closest('.playControls, .playbackSoundBadge, .queue'),
+			);
+			feedPlaybackOriginUrl = updateFeedPlaybackOrigin(
+				feedPlaybackOriginUrl,
+				cardUrl,
+				outsidePlaybackSelection,
+			);
 			if (card) {
-				feedPlaybackActive = true;
 				saveFeedCheckpointFromCard(card);
 			}
 		},

--- a/userscript/sc-gate-dl.user.js
+++ b/userscript/sc-gate-dl.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         sc-gate-dl
 // @namespace    https://github.com/D3SOX/sc-gate-dl
-// @version      1.10.4
+// @version      1.10.5
 // @description  Add sc-gate-dl download controls and remember your position in the SoundCloud feed
 // @author       D3SOX
 // @match        https://soundcloud.com/*
@@ -592,9 +592,15 @@
 	}
 
 	let lastRecordedPlayingUrl = null;
+	let feedPlaybackActive = false;
 
 	function recordPlayingFeedTrack() {
-		if (!isFeedPage()) return;
+		if (!isFeedPage()) {
+			feedPlaybackActive = false;
+			lastRecordedPlayingUrl = null;
+			return;
+		}
+		if (!feedPlaybackActive) return;
 		const playing = document.querySelector(
 			'.playControls .playControl.playing, .playControls__play.playing, .playControls button[title^="Pause"], .playControls button[aria-label^="Pause"]',
 		);
@@ -2286,7 +2292,10 @@ a[${STORE_SERVICE_ATTR}] > button::after {
 			);
 			if (!playControl) return;
 			const card = playControl.closest(FEED_CARD_SELECTOR);
-			if (card) saveFeedCheckpointFromCard(card);
+			if (card) {
+				feedPlaybackActive = true;
+				saveFeedCheckpointFromCard(card);
+			}
 		},
 		true,
 	);

--- a/userscript/sc-gate-dl.user.js
+++ b/userscript/sc-gate-dl.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         sc-gate-dl
 // @namespace    https://github.com/D3SOX/sc-gate-dl
-// @version      1.10.5
+// @version      1.10.6
 // @description  Add sc-gate-dl download controls and remember your position in the SoundCloud feed
 // @author       D3SOX
 // @match        https://soundcloud.com/*
@@ -498,22 +498,14 @@
 		}
 	}
 
-	function resetFeedCheckpoints() {
-		try {
-			if (typeof GM_deleteValue === 'function') {
-				GM_deleteValue(FEED_CHECKPOINT_KEY);
-			} else if (typeof GM_setValue === 'function') {
-				GM_setValue(FEED_CHECKPOINT_KEY, null);
-			}
-		} catch {
-			// ignore
-		}
-		try {
-			localStorage.removeItem(FEED_CHECKPOINT_KEY);
-		} catch {
-			// ignore
-		}
-		setFeedStatus('Positions reset. The next played track will seed both.');
+	function resetFeedCheckpoint(direction) {
+		if (direction !== 'newer' && direction !== 'older') return;
+		const checkpoints = loadFeedCheckpoints() ?? { newer: null, older: null };
+		checkpoints[direction] = null;
+		persistFeedCheckpoints(checkpoints);
+		setFeedStatus(
+			`${direction === 'newer' ? 'Up' : 'Down'} position reset. The next eligible played track will seed it.`,
+		);
 		updateFeedNavigator();
 	}
 
@@ -639,6 +631,8 @@
 		const resumeOlder = nav.querySelector('.sc-gate-dl-feed-resume-older');
 		const cancel = nav.querySelector('.sc-gate-dl-feed-cancel');
 		const find = nav.querySelector('.sc-gate-dl-feed-find');
+		const resetNewer = nav.querySelector('.sc-gate-dl-feed-reset-newer');
+		const resetOlder = nav.querySelector('.sc-gate-dl-feed-reset-older');
 		const updateResumeButton = (button, checkpoint, label) => {
 			if (!(button instanceof HTMLButtonElement)) return;
 			button.hidden = feedSearchActive;
@@ -650,6 +644,12 @@
 		};
 		updateResumeButton(resumeNewer, checkpoints?.newer, 'farthest up');
 		updateResumeButton(resumeOlder, checkpoints?.older, 'farthest down');
+		if (resetNewer instanceof HTMLButtonElement) {
+			resetNewer.disabled = !checkpoints?.newer;
+		}
+		if (resetOlder instanceof HTMLButtonElement) {
+			resetOlder.disabled = !checkpoints?.older;
+		}
 		if (cancel instanceof HTMLButtonElement) cancel.hidden = !feedSearchActive;
 		if (find instanceof HTMLButtonElement) find.disabled = feedSearchActive;
 	}
@@ -796,7 +796,10 @@
 				<button type="button" class="sc-gate-dl-feed-resume-older"></button>
 				<button type="button" class="sc-gate-dl-feed-cancel" hidden>Cancel scrolling</button>
 				<button type="button" class="sc-gate-dl-feed-find">Find track URL…</button>
-				<button type="button" class="sc-gate-dl-feed-reset">Reset saved positions</button>
+				<div class="sc-gate-dl-feed-reset-row">
+					<button type="button" class="sc-gate-dl-feed-reset-newer">Reset up</button>
+					<button type="button" class="sc-gate-dl-feed-reset-older">Reset down</button>
+				</div>
 				<div class="sc-gate-dl-feed-status" aria-live="polite"></div>
 			`;
 			nav
@@ -825,9 +828,11 @@
 					);
 					if (input?.trim()) void scrollToFeedTrack(input.trim());
 				});
-			nav
-				.querySelector('.sc-gate-dl-feed-reset')
-				?.addEventListener('click', resetFeedCheckpoints);
+			for (const direction of ['newer', 'older']) {
+				nav
+					.querySelector(`.sc-gate-dl-feed-reset-${direction}`)
+					?.addEventListener('click', () => resetFeedCheckpoint(direction));
+			}
 			document.documentElement.appendChild(nav);
 		}
 		nav.hidden = false;
@@ -1330,7 +1335,16 @@
 #${FEED_NAV_ID} button:hover:not(:disabled) { border-color: #f50; color: #fff; }
 #${FEED_NAV_ID} button:disabled { color: #777; cursor: default; }
 #${FEED_NAV_ID} .sc-gate-dl-feed-find { text-align: center; }
-#${FEED_NAV_ID} .sc-gate-dl-feed-reset { color: #aaa; text-align: center; }
+#${FEED_NAV_ID} .sc-gate-dl-feed-reset-row {
+	display: flex;
+	gap: 6px;
+}
+#${FEED_NAV_ID} .sc-gate-dl-feed-reset-row button {
+	flex: 1 1 50%;
+	width: 50%;
+	color: #aaa;
+	text-align: center;
+}
 #${FEED_NAV_ID} .sc-gate-dl-feed-status:empty { display: none; }
 #${FEED_NAV_ID} .sc-gate-dl-feed-status {
 	padding: 1px 2px;

--- a/webui/src/components/App.test.ts
+++ b/webui/src/components/App.test.ts
@@ -1,0 +1,15 @@
+/// <reference types="bun" />
+
+import { describe, expect, test } from 'bun:test';
+import { cleanPromoTags } from './App';
+
+describe('cleanPromoTags', () => {
+	test('removes a bracketed premiere prefix', () => {
+		expect(cleanPromoTags('[PREMIERE] Artist - Track')).toBe(
+			'Artist - Track',
+		);
+		expect(cleanPromoTags('[PREMIERE]: Artist - Track')).toBe(
+			'Artist - Track',
+		);
+	});
+});

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -104,12 +104,15 @@ function notifyParent(
 /** Promo fluff often glued onto SoundCloud / gate titles. */
 const PROMO_TAG = String.raw`free\s*d(?:own)?l(?:oad)?s?|free[\s._-]*dl|freedl|out\s*now|premiere|exclusive`;
 
-function cleanPromoTags(value: string): string {
+export function cleanPromoTags(value: string): string {
 	if (!value) return value;
 
 	let result = value;
 	result = result.replace(
-		new RegExp(String.raw`\s*[\[\(\{]\s*(?:${PROMO_TAG})\s*[\]\)\}]`, 'gi'),
+		new RegExp(
+			String.raw`\s*[\[\(\{]\s*(?:${PROMO_TAG})\s*[\]\)\}]\s*(?:[-–—|/:·•]+\s*)?`,
+			'gi',
+		),
 		' ',
 	);
 	result = result.replace(
@@ -412,7 +415,7 @@ export default function App() {
 
 	// Start download process
 	const startDownload = useCallback(
-		async (jobId: string) => {
+		async (jobId: string, retryBrowserMode?: BrowserMode) => {
 			cancelRequestedRef.current = false;
 			setStep('gate');
 			setJob((prev) => ({
@@ -433,7 +436,7 @@ export default function App() {
 					method: 'POST',
 					headers: { 'Content-Type': 'application/json' },
 					body: JSON.stringify({
-						browserMode,
+						browserMode: retryBrowserMode ?? browserMode,
 					}),
 				});
 
@@ -1029,6 +1032,22 @@ export default function App() {
 				<div className="error-banner">
 					<span className="error-icon">!</span>
 					<span>{job.error}</span>
+					{job.jobId && job.progress?.stage === 'error'
+						? availableBrowserModes
+								.filter((mode) => mode !== browserMode)
+								.map((mode) => (
+									<button
+										type="button"
+										key={mode}
+										onClick={() => {
+											updateBrowserMode(mode);
+											void startDownload(job.jobId as string, mode);
+										}}
+									>
+										Retry with {BROWSER_MODE_LABELS[mode]}
+									</button>
+								))
+						: null}
 					<button
 						type="button"
 						onClick={() => setJob((prev) => ({ ...prev, error: null }))}
@@ -1448,7 +1467,7 @@ export default function App() {
 										type="button"
 										className="btn-secondary btn-auto-cleanup"
 										disabled={isLoading}
-										title="Remove promo tags like [FREE DL] and duplicate Artist - / - Artist from the title"
+										title="Remove promo tags like [FREE DL] or [PREMIERE] and duplicate Artist - / - Artist from the title"
 										onClick={() =>
 											setMetadata((prev) => cleanMetadataFields(prev))
 										}

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -237,6 +237,8 @@ export default function App() {
 	const [skipAutomaticHypedditFetch, setSkipAutomaticHypedditFetch] =
 		useState(false);
 	const [browserMode, setBrowserMode] = useState<BrowserMode>('headless');
+	const [lastAttemptedBrowserMode, setLastAttemptedBrowserMode] =
+		useState<BrowserMode | null>(null);
 	const [availableBrowserModes, setAvailableBrowserModes] = useState<
 		BrowserMode[]
 	>(['headless', 'headed']);
@@ -416,10 +418,13 @@ export default function App() {
 	// Start download process
 	const startDownload = useCallback(
 		async (jobId: string, retryBrowserMode?: BrowserMode) => {
+			const effectiveBrowserMode = retryBrowserMode ?? browserMode;
+			setLastAttemptedBrowserMode(effectiveBrowserMode);
 			cancelRequestedRef.current = false;
 			setStep('gate');
 			setJob((prev) => ({
 				...prev,
+				error: null,
 				progress: {
 					stage: 'handling_gates',
 					message: 'Entering gate...',
@@ -436,7 +441,7 @@ export default function App() {
 					method: 'POST',
 					headers: { 'Content-Type': 'application/json' },
 					body: JSON.stringify({
-						browserMode: retryBrowserMode ?? browserMode,
+						browserMode: effectiveBrowserMode,
 					}),
 				});
 
@@ -539,6 +544,11 @@ export default function App() {
 				setJob((prev) => ({
 					...prev,
 					error: err instanceof Error ? err.message : 'Unknown error',
+					progress: {
+						stage: 'error',
+						message: err instanceof Error ? err.message : 'Unknown error',
+						percent: 0,
+					},
 				}));
 			}
 		},
@@ -1034,7 +1044,10 @@ export default function App() {
 					<span>{job.error}</span>
 					{job.jobId && job.progress?.stage === 'error'
 						? availableBrowserModes
-								.filter((mode) => mode !== browserMode)
+								.filter(
+									(mode) =>
+										mode !== (lastAttemptedBrowserMode ?? browserMode),
+								)
 								.map((mode) => (
 									<button
 										type="button"


### PR DESCRIPTION
## Summary

- offer one-click retries with alternative browser modes after gated download failures
- remove bracketed premiere prefixes during metadata cleanup
- only save feed checkpoints after playback was initiated from a feed card

## Root cause

The userscript polled SoundCloud's global player and treated any matching loaded feed card as feed-originated playback. Tracks started elsewhere could therefore overwrite a feed checkpoint.

## Validation

- 31 Bun tests passed
- source lint passed
- Web UI TypeScript check passed
- userscript parse check passed
- diff checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added retry buttons to error messages, allowing downloads to restart using available browser modes.
  * Improved metadata cleanup by removing premiere promotion tags and optional separators.
  * Updated cleanup guidance to mention premiere tags.
  * Added separate controls for resetting newer and older feed checkpoints.

* **Bug Fixes**
  * Improved track detection across supported feed layouts.
  * Feed checkpoints now track playback only after explicit activation and reset correctly outside feeds.
  * Prevented unrelated playback updates from overwriting saved feed information.
  * Improved feed navigation and click handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->