### PR TITLE
feat: show and reuse existing MP3 cover art

### DIFF
--- a/src/audioProcessor.ts
+++ b/src/audioProcessor.ts
@@ -106,6 +106,14 @@ export class AudioProcessor {
 			if (!(await file.exists()) || file.size === 0) {
 				return null;
 			}
+			// Bound memory: keep oversized embedded covers out of the job store.
+			const maxCoverBytes = 10 * 1024 * 1024;
+			if (file.size > maxCoverBytes) {
+				console.warn(
+					`Skipping embedded cover art: ${file.size} bytes exceeds ${maxCoverBytes}`,
+				);
+				return null;
+			}
 			return {
 				buffer: await file.arrayBuffer(),
 				fileName: `existing-cover.${extension}`,

--- a/src/audioProcessor.ts
+++ b/src/audioProcessor.ts
@@ -26,6 +26,7 @@ type FfprobeResult = {
 		codec_type?: string;
 		codec_name?: string;
 		bit_rate?: string;
+		disposition?: { attached_pic?: number };
 	}>;
 };
 
@@ -67,6 +68,58 @@ export class AudioProcessor {
 			album: getTag('album'),
 			genre: getTag('genre'),
 		};
+	}
+
+	/** Extract embedded cover art from an MP3 (APIC / attached picture). */
+	async extractMp3CoverArt(
+		inputPath: string,
+	): Promise<{ buffer: ArrayBuffer; fileName: string } | null> {
+		const probeData = await this.runFfprobe(inputPath);
+		const coverStream = (probeData?.streams ?? []).find(
+			(stream) =>
+				stream.codec_type === 'video' &&
+				(stream.disposition?.attached_pic === 1 ||
+					stream.codec_name === 'mjpeg' ||
+					stream.codec_name === 'png'),
+		);
+		if (!coverStream) {
+			return null;
+		}
+
+		const extension = coverStream.codec_name === 'png' ? 'png' : 'jpg';
+		const outputPath = join(
+			'./downloads',
+			`.existing-cover-${crypto.randomUUID()}.${extension}`,
+		);
+
+		try {
+			await execa(this.ffmpegBin, [
+				'-i',
+				inputPath,
+				'-an',
+				'-vcodec',
+				'copy',
+				'-y',
+				outputPath,
+			]);
+			const file = Bun.file(outputPath);
+			if (!(await file.exists()) || file.size === 0) {
+				return null;
+			}
+			return {
+				buffer: await file.arrayBuffer(),
+				fileName: `existing-cover.${extension}`,
+			};
+		} catch (error) {
+			console.warn(
+				`Failed to extract cover art: ${error instanceof Error ? error.message : String(error)}`,
+			);
+			return null;
+		} finally {
+			await Bun.file(outputPath)
+				.unlink()
+				.catch(() => {});
+		}
 	}
 
 	async promptForMetadata(

--- a/src/jobStore.ts
+++ b/src/jobStore.ts
@@ -41,6 +41,8 @@ class JobStore {
 			sourceIsLossless: null,
 			artworkBuffer: null,
 			artworkFileName: null,
+			existingArtworkBuffer: null,
+			existingArtworkFileName: null,
 			error: null,
 			createdAt: now,
 			updatedAt: now,

--- a/src/server.ts
+++ b/src/server.ts
@@ -519,10 +519,20 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 		}
 
 		if (isMp3Format(downloadFilename)) {
-			const existingMetadata = await audioProcessor.readMp3Metadata(
-				join('./downloads', downloadFilename),
-			);
-			jobStore.update(jobId, { existingMetadata: existingMetadata ?? {} });
+			const downloadedPath = join('./downloads', downloadFilename);
+			const existingMetadata =
+				await audioProcessor.readMp3Metadata(downloadedPath);
+			const existingArtwork =
+				await audioProcessor.extractMp3CoverArt(downloadedPath);
+			jobStore.update(jobId, {
+				existingMetadata: existingMetadata ?? {},
+				...(existingArtwork
+					? {
+							existingArtworkBuffer: existingArtwork.buffer,
+							existingArtworkFileName: existingArtwork.fileName,
+						}
+					: {}),
+			});
 		}
 
 		throwIfCancelled();
@@ -1212,6 +1222,7 @@ const server = Bun.serve({
 					outputFilename: job.outputFilename,
 					sourceIsLossless: job.sourceIsLossless,
 					hasArtwork: !!job.artworkBuffer,
+					hasExistingArtwork: !!job.existingArtworkBuffer,
 					error: job.error,
 				});
 			},
@@ -1239,6 +1250,33 @@ const server = Bun.serve({
 				return fileResponse(job.artworkBuffer, {
 					'Content-Type': mimeType,
 					'Content-Disposition': `inline; filename="${job.artworkFileName || 'artwork.jpg'}"`,
+				});
+			},
+		},
+
+		'/api/job/:id/existing-artwork': {
+			GET: (req) => {
+				const jobId = req.params.id;
+				const job = jobStore.get(jobId);
+
+				if (!job) {
+					return jsonResponse({ error: 'Job not found' }, { status: 404 });
+				}
+
+				if (!job.existingArtworkBuffer) {
+					return jsonResponse(
+						{ error: 'Existing artwork not available' },
+						{ status: 404 },
+					);
+				}
+
+				const extension =
+					job.existingArtworkFileName?.split('.').pop() || 'jpg';
+				const mimeType = extension === 'png' ? 'image/png' : 'image/jpeg';
+
+				return fileResponse(job.existingArtworkBuffer, {
+					'Content-Type': mimeType,
+					'Content-Disposition': `inline; filename="${job.existingArtworkFileName || 'existing-cover.jpg'}"`,
 				});
 			},
 		},

--- a/src/server.ts
+++ b/src/server.ts
@@ -526,12 +526,14 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 				await audioProcessor.extractMp3CoverArt(downloadedPath);
 			jobStore.update(jobId, {
 				existingMetadata: existingMetadata ?? {},
-				...(existingArtwork
-					? {
-							existingArtworkBuffer: existingArtwork.buffer,
-							existingArtworkFileName: existingArtwork.fileName,
-						}
-					: {}),
+				existingArtworkBuffer: existingArtwork?.buffer ?? null,
+				existingArtworkFileName: existingArtwork?.fileName ?? null,
+			});
+		} else {
+			jobStore.update(jobId, {
+				existingMetadata: null,
+				existingArtworkBuffer: null,
+				existingArtworkFileName: null,
 			});
 		}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,6 +110,9 @@ export interface Job {
 	sourceIsLossless: boolean | null;
 	artworkBuffer: ArrayBuffer | null;
 	artworkFileName: string | null;
+	/** Cover art embedded in the downloaded MP3, when present. */
+	existingArtworkBuffer: ArrayBuffer | null;
+	existingArtworkFileName: string | null;
 	error: string | null;
 	createdAt: Date;
 	updatedAt: Date;

--- a/webui/src/components/App.css
+++ b/webui/src/components/App.css
@@ -718,6 +718,15 @@
 	min-width: 0;
 }
 
+.existing-metadata-cover {
+	display: block;
+	width: 4.5rem;
+	height: 4.5rem;
+	object-fit: cover;
+	border-radius: 4px;
+	border: 1px solid var(--border-subtle);
+}
+
 .btn-copy-existing {
 	display: inline-flex;
 	align-items: center;

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -68,6 +68,7 @@ interface JobState {
 	hypedditUrl: string | null;
 	defaultMetadata: Metadata | null;
 	existingMetadata: Metadata | null;
+	hasExistingArtwork: boolean;
 	outputFormat: OutputFormat;
 	progress: JobProgress | null;
 	downloadFilename: string | null;
@@ -251,6 +252,7 @@ export default function App() {
 		hypedditUrl: null,
 		defaultMetadata: null,
 		existingMetadata: null,
+		hasExistingArtwork: false,
 		outputFormat: 'mp3-320',
 		progress: null,
 		downloadFilename: null,
@@ -315,6 +317,7 @@ export default function App() {
 	const [customArtwork, setCustomArtwork] = useState<File | null>(null);
 	const [nameAsArtistTitle, setNameAsArtistTitle] = useState(false);
 	const [isLoading, setIsLoading] = useState(false);
+	const artworkInputRef = useRef<HTMLInputElement>(null);
 	const cleanupToastShownRef = useRef(false);
 	const autoStartedFromQueryRef = useRef(false);
 	const eventSourceRef = useRef<EventSource | null>(null);
@@ -492,6 +495,7 @@ export default function App() {
 									downloadFilename: data.downloadFilename,
 									outputFilename: data.outputFilename,
 									existingMetadata: data.existingMetadata,
+									hasExistingArtwork: !!data.hasExistingArtwork,
 									outputFormat: data.outputFormat,
 									sourceIsLossless: data.sourceIsLossless,
 								}));
@@ -647,6 +651,7 @@ export default function App() {
 					hypedditUrl: data.hypedditUrl,
 					defaultMetadata: data.defaultMetadata,
 					existingMetadata: null,
+					hasExistingArtwork: false,
 					outputFormat: format,
 					warning: data.soundcloudDownloadWarning ?? null,
 					error: null,
@@ -916,6 +921,31 @@ export default function App() {
 			existingValue: job.existingMetadata?.[key]?.trim() || '',
 		}))
 		.filter(({ existingValue }) => existingValue);
+	const hasExistingMetadata =
+		existingTagRows.length > 0 || job.hasExistingArtwork;
+
+	const copyExistingArtwork = async () => {
+		if (!job.jobId || !job.hasExistingArtwork) return;
+		try {
+			const response = await fetch(
+				`${API_BASE}/api/job/${job.jobId}/existing-artwork`,
+			);
+			if (!response.ok) {
+				throw new Error('Failed to load existing cover art');
+			}
+			const blob = await response.blob();
+			const extension = blob.type === 'image/png' ? 'png' : 'jpg';
+			setCustomArtwork(
+				new File([blob], `existing-cover.${extension}`, {
+					type: blob.type || 'image/jpeg',
+				}),
+			);
+		} catch (err) {
+			toast.error('Could not copy cover art', {
+				description: err instanceof Error ? err.message : 'Unknown error',
+			});
+		}
+	};
 
 	// Reset and start over
 	const handleReset = () => {
@@ -930,6 +960,7 @@ export default function App() {
 			hypedditUrl: null,
 			defaultMetadata: null,
 			existingMetadata: null,
+			hasExistingArtwork: false,
 			outputFormat,
 			progress: null,
 			downloadFilename: null,
@@ -940,6 +971,9 @@ export default function App() {
 		});
 		setMetadata({ title: '', artist: '', album: '', genre: '' });
 		setCustomArtwork(null);
+		if (artworkInputRef.current) {
+			artworkInputRef.current.value = '';
+		}
 		setNameAsArtistTitle(false);
 		setStep('url');
 	};
@@ -1390,13 +1424,13 @@ export default function App() {
 								</p>
 							</div>
 						) : null}
-						{existingTagRows.length > 0 ? (
+						{hasExistingMetadata ? (
 							<div className="existing-metadata">
 								<div>
 									<h3>Existing MP3 Metadata</h3>
 									<p>
-										Copy a tag into the form, or keep the file’s tags unchanged
-										for the whole download.
+										Copy a tag or cover into the form, or keep the file’s tags
+										unchanged for the whole download.
 									</p>
 								</div>
 								<ul className="existing-metadata-list">
@@ -1436,6 +1470,41 @@ export default function App() {
 											</button>
 										</li>
 									))}
+									{job.hasExistingArtwork && job.jobId ? (
+										<li className="existing-metadata-row">
+											<span className="existing-metadata-label">Cover</span>
+											<span className="existing-metadata-value">
+												<img
+													src={`${API_BASE}/api/job/${job.jobId}/existing-artwork`}
+													alt="Existing cover art"
+													className="existing-metadata-cover"
+												/>
+											</span>
+											<button
+												type="button"
+												className="btn-copy-existing"
+												disabled={isLoading}
+												title="Copy cover art into the form"
+												aria-label="Copy cover art into the form"
+												onClick={() => void copyExistingArtwork()}
+											>
+												<svg
+													viewBox="0 0 24 24"
+													width="14"
+													height="14"
+													aria-hidden="true"
+													fill="none"
+													stroke="currentColor"
+													strokeWidth="2"
+													strokeLinecap="round"
+													strokeLinejoin="round"
+												>
+													<rect x="9" y="9" width="13" height="13" rx="2" />
+													<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+												</svg>
+											</button>
+										</li>
+									) : null}
 								</ul>
 								<button
 									type="button"
@@ -1466,6 +1535,7 @@ export default function App() {
 								</div>
 								<label className="artwork-upload">
 									<input
+										ref={artworkInputRef}
 										type="file"
 										accept="image/*"
 										disabled={isLoading}
@@ -1475,6 +1545,21 @@ export default function App() {
 									/>
 									<span>Change Artwork</span>
 								</label>
+								{customArtwork ? (
+									<button
+										type="button"
+										className="btn-artwork-action"
+										disabled={isLoading}
+										onClick={() => {
+											setCustomArtwork(null);
+											if (artworkInputRef.current) {
+												artworkInputRef.current.value = '';
+											}
+										}}
+									>
+										Reset Artwork
+									</button>
+								) : null}
 								{canCleanupMetadata ? (
 									<button
 										type="button"


### PR DESCRIPTION
## Summary
- Extract embedded cover art from downloaded MP3s and expose it via `/api/job/:id/existing-artwork`
- Show existing cover in the metadata alert with a copy button, same as text tags
- Add a Reset Artwork control to restore the default track artwork after a custom/copied cover

## Test plan
- [ ] Download an MP3 that already has cover art and reach the metadata step
- [ ] Confirm the existing-metadata alert shows a Cover thumbnail
- [ ] Click copy on Cover and verify the form artwork preview updates
- [ ] Click Reset Artwork and verify the default SoundCloud artwork returns
- [ ] Confirm the alert still appears when only cover art exists (no text tags)
- [ ] Confirm files without embedded cover behave as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedded MP3 cover art is now detected and retained during downloads.
  * Existing artwork is displayed when editing metadata and can be copied into custom artwork.
  * Added an endpoint to retrieve embedded artwork with the correct filename and media type.
  * Job status now indicates whether embedded artwork is available.
* **Bug Fixes**
  * Artwork and metadata states now reset correctly when starting over or removing custom artwork.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->