### PR TITLE
feat: support MyPressKit download gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # sc-gate-dl
 
-Download and tag SoundCloud tracks unlocked via Hypeddit, Droploud, GateRush, DownloadGater, StillHype, PumpYourSound, Bandcamp, or a direct download link.
+Download and tag SoundCloud tracks unlocked via Hypeddit, Droploud, GateRush, DownloadGater, StillHype, PumpYourSound, MyPressKit, Bandcamp, or a direct download link.
 
 ## Features
 
-- 🎵 Automatically download audio from Hypeddit, Droploud, GateRush, DownloadGater, StillHype, PumpYourSound, Bandcamp, and direct file links (e.g. Dropbox `dl=1`)
+- 🎵 Automatically download audio from Hypeddit, Droploud, GateRush, DownloadGater, StillHype, PumpYourSound, MyPressKit, Bandcamp, and direct file links (e.g. Dropbox `dl=1`)
 - ⚡ Browserless fast path that skips the browser for gates that don't need real verification (see [How It Works](#how-it-works))
 - 🔄 Handles multiple gate types (see [How It Works](#how-it-works))
 - 📝 Fetches metadata from the provided SoundCloud link
@@ -291,7 +291,7 @@ Panel size/position is remembered in `localStorage` (`sc-gate-dl-panel-geom`).
 - Spotify gate: Authorizes Spotify access
 - Download gate: Triggers the audio download
 
-Droploud, GateRush, DownloadGater, StillHype, and PumpYourSound gates are handled via their own downloaders with similar email / social unlock flows. StillHype and PumpYourSound require a real SoundCloud OAuth connection (follow / like / repost / comment are verified server-side). Traditional gate URLs in the track description are preferred over Bandcamp/SoundCloud store links in `purchase_url`.
+Droploud, GateRush, DownloadGater, StillHype, PumpYourSound, and MyPressKit gates are handled via their own downloaders with similar email / social unlock flows. StillHype, PumpYourSound, and MyPressKit require a real SoundCloud OAuth connection (follow / like / repost / comment are verified server-side). Traditional gate URLs in the track description are preferred over Bandcamp/SoundCloud store links in `purchase_url`.
 
 **Bandcamp / yt-dlp**: When a SoundCloud track’s purchase URL (or description) points at Bandcamp instead of a gate, the file is downloaded with [yt-dlp](https://github.com/yt-dlp/yt-dlp) (browserless). For Bandcamp album links, the matching track is selected from the SoundCloud title; if auto-match fails, the CLI and Web UI let you pick a track from the album. Traditional unlock gates still take priority if both are present. If no gate or Bandcamp URL is found, the CLI and Web UI can fall back to downloading the SoundCloud track itself via yt-dlp.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { DroploudDownloader } from './droploud';
 import { GaterushDownloader } from './gaterush';
 import { HypedditDownloader } from './hypeddit';
 import { HypedditHttpDownloader } from './hypedditHttp';
+import { MypresskitDownloader } from './mypresskit';
 import { PumpyoursoundDownloader } from './pumpyoursound';
 import { SoundcloudClient } from './soundcloud';
 import { StillhypeDownloader } from './stillhype';
@@ -80,11 +81,11 @@ try {
 		} else {
 			gateUrl = await input({
 				message:
-					'Enter a Hypeddit, Droploud, GateRush, DownloadGater, StillHype, PumpYourSound, Bandcamp, direct download, or smart-link URL',
+					'Enter a Hypeddit, Droploud, GateRush, DownloadGater, StillHype, PumpYourSound, MyPressKit, Bandcamp, direct download, or smart-link URL',
 				validate: async (value) => {
 					const resolved = await resolveGateUrlOrFollow(value);
 					if (!resolved || resolved.provider === 'soundcloud') {
-						return 'A valid Hypeddit, Droploud, GateRush, DownloadGater, StillHype, PumpYourSound, Bandcamp, direct download, or resolvable gate URL is required';
+						return 'A valid Hypeddit, Droploud, GateRush, DownloadGater, StillHype, PumpYourSound, MyPressKit, Bandcamp, direct download, or resolvable gate URL is required';
 					}
 					return true;
 				},
@@ -106,7 +107,7 @@ try {
 
 	if (!gateUrl || !gate) {
 		throw new Error(
-			'A valid Hypeddit, Droploud, GateRush, DownloadGater, StillHype, PumpYourSound, Bandcamp, direct download, or SoundCloud URL is required',
+			'A valid Hypeddit, Droploud, GateRush, DownloadGater, StillHype, PumpYourSound, MyPressKit, Bandcamp, direct download, or SoundCloud URL is required',
 		);
 	}
 
@@ -262,6 +263,22 @@ try {
 			downloadFilename = await pumpyoursoundDownloader.downloadAudio(gateUrl);
 		} finally {
 			await pumpyoursoundDownloader.close();
+		}
+	} else if (gate.provider === 'mypresskit') {
+		usedBrowser = true;
+		const mypresskitDownloader = new MypresskitDownloader(gateConfig);
+		try {
+			await mypresskitDownloader.initialize();
+			if (initializeLogins) {
+				await mypresskitDownloader.prepareLogins();
+				if (config) {
+					await saveConfig({ ...config, initializeLogins: false });
+					console.log('✓ Updated config.json: initializeLogins set to false');
+				}
+			}
+			downloadFilename = await mypresskitDownloader.downloadAudio(gateUrl);
+		} finally {
+			await mypresskitDownloader.close();
 		}
 	} else {
 		// Hypeddit: always try plain HTTP first (email + social skip gates).

--- a/src/mypresskit.ts
+++ b/src/mypresskit.ts
@@ -1,0 +1,694 @@
+import { mkdir, rm } from 'node:fs/promises';
+import { basename, join } from 'node:path';
+import { Presets, SingleBar } from 'cli-progress';
+import type { Browser, Page } from 'puppeteer';
+import { browserModeToLaunchOptions, launchAppBrowser } from './browserLaunch';
+import type { ProgressCallback } from './hypeddit';
+import { safeFetch } from './safeOutboundUrl';
+import Selectors from './selectors';
+import { waitForSoundcloudLogin } from './soundcloudLogin';
+import type { HypedditConfig } from './types';
+import { loadCookies, sanitizeFilenamePart, timeout } from './utils';
+
+const SC_AUTHORIZE_RE = /secure\.soundcloud\.com\/authorize/i;
+const MAX_DOWNLOAD_BYTES = 512 * 1024 * 1024;
+const USER_AGENT =
+	'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36';
+
+type GateStep = {
+	index: number;
+	type: string;
+	targetUrl: string | null;
+	required: boolean;
+};
+
+type VerifyBody = {
+	unlockState?: { unlocked?: boolean; remaining?: number[]; total?: number };
+	completedStepIndexes?: number[];
+	downloadToken?: string | null;
+	capturedEmail?: string | null;
+};
+
+function filenameFromContentDisposition(value: string | null): string | null {
+	if (!value) return null;
+	const star = value.match(/filename\*=(?:UTF-8'')?([^;]+)/i)?.[1];
+	if (star) {
+		return decodeURIComponent(star.replace(/["']/g, ''));
+	}
+	const plain = value.match(/filename=["']?([^"';]+)["']?/i)?.[1];
+	return plain ? plain.trim() : null;
+}
+
+function safePageUrl(page: Page): string {
+	try {
+		if (page.isClosed()) return '';
+		return page.url();
+	} catch {
+		return '';
+	}
+}
+
+export class MypresskitDownloader {
+	private browser!: Browser;
+	private config: HypedditConfig;
+	private progressCallback: ProgressCallback | null = null;
+
+	constructor(config: HypedditConfig) {
+		this.config = config;
+	}
+
+	setProgressCallback(callback: ProgressCallback): void {
+		this.progressCallback = callback;
+	}
+
+	private emitProgress(
+		stage: Parameters<ProgressCallback>[0],
+		message: string,
+		percent: number,
+		extra?: Parameters<ProgressCallback>[3],
+	): void {
+		this.progressCallback?.(stage, message, percent, extra);
+	}
+
+	async initialize() {
+		this.browser = await launchAppBrowser({
+			...browserModeToLaunchOptions(this.config.browserMode),
+			userDataDir: this.config.userDataDir ?? './browser-data',
+			// SC OAuth authorize popup shares session cookies more reliably with this.
+			args: ['--fingerprint-allow-3p-cookies'],
+		});
+
+		const browserContext = this.browser.defaultBrowserContext();
+		const soundCloudCookies = await loadCookies('soundcloud-cookies.json');
+		await browserContext.setCookie(...soundCloudCookies);
+	}
+
+	async prepareLogins() {
+		const soundCloudPage = await this.browser.newPage();
+		await soundCloudPage.setViewport({ width: 1920, height: 1080 });
+		await soundCloudPage.goto('https://soundcloud.com/messages');
+
+		try {
+			await soundCloudPage.waitForSelector(
+				Selectors.SOUNDCLOUD_CAPTCHA_CONTAINER,
+				{ timeout: 5_000 },
+			);
+			console.log(
+				'MyPressKit: SoundCloud captcha present during login warm-up; solve it in the browser window if needed.',
+			);
+			await soundCloudPage.waitForSelector(
+				Selectors.SOUNDCLOUD_CAPTCHA_CONTAINER,
+				{ hidden: true, timeout: 120_000 },
+			);
+		} catch {
+			// no captcha
+		}
+
+		await soundCloudPage.waitForSelector(Selectors.SOUNDCLOUD_LIBRARY_LINK, {
+			timeout: 30_000,
+		});
+		await Promise.all([
+			soundCloudPage.click(Selectors.SOUNDCLOUD_LIBRARY_LINK),
+			soundCloudPage.waitForNavigation({ waitUntil: 'domcontentloaded' }),
+		]);
+		await soundCloudPage.waitForFunction(() =>
+			window.location.href.includes('/you/library'),
+		);
+		await soundCloudPage.close();
+	}
+
+	async downloadAudio(url: string): Promise<string | null> {
+		console.log('Navigating to MyPressKit gate...');
+		this.emitProgress('handling_gates', 'Navigating to MyPressKit gate...', 25);
+
+		const page = await this.browser.newPage();
+		try {
+			await page.setViewport({ width: 1920, height: 1080 });
+			await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+			try {
+				await page.waitForNetworkIdle({ timeout: 15_000, idleTime: 10 });
+			} catch {
+				// continue
+			}
+
+			await this.dismissCookies(page);
+			const gate = await this.parseGate(page);
+			if (!gate.id) {
+				throw new Error('MyPressKit: could not determine gate id from page.');
+			}
+			console.log(
+				`MyPressKit gate ${gate.id} (${gate.handle ?? 'unknown'}) — ${gate.steps.length} steps`,
+			);
+
+			const stepsByIndex = new Map(gate.steps.map((s) => [s.index, s]));
+			for (let round = 0; round < 12; round++) {
+				const verify = await this.readVerify(page, gate.id);
+				if (verify.downloadToken && verify.unlockState?.unlocked) {
+					console.log('MyPressKit unlocked');
+					return await this.downloadWithToken(
+						page,
+						gate.id,
+						verify.downloadToken,
+						url,
+					);
+				}
+
+				const remaining = (verify.unlockState?.remaining ?? []).map(Number);
+				if (remaining.length === 0) {
+					if (verify.downloadToken) {
+						return await this.downloadWithToken(
+							page,
+							gate.id,
+							verify.downloadToken,
+							url,
+						);
+					}
+					break;
+				}
+
+				const stepIndex = remaining[0];
+				if (stepIndex === undefined) break;
+				const step = stepsByIndex.get(stepIndex) ?? {
+					index: stepIndex,
+					type: 'soundcloud-follow',
+					targetUrl: null,
+					required: true,
+				};
+				console.log(
+					`MyPressKit remaining=${JSON.stringify(remaining)} → step ${step.index} (${step.type})`,
+				);
+				this.emitProgress(
+					'handling_gates',
+					`MyPressKit: ${step.type}...`,
+					35 + Math.min(40, round * 5),
+					{
+						currentGate: step.type.startsWith('soundcloud-') ? 'sc' : 'social',
+					},
+				);
+
+				await this.runStep(page, gate.id, step);
+				await this.waitForStepProgress(page, gate.id, step.index, verify);
+			}
+
+			const finalVerify = await this.readVerify(page, gate.id);
+			if (finalVerify.downloadToken) {
+				return await this.downloadWithToken(
+					page,
+					gate.id,
+					finalVerify.downloadToken,
+					url,
+				);
+			}
+			throw new Error(
+				'MyPressKit download never unlocked after completing gate steps.',
+			);
+		} finally {
+			if (!page.isClosed()) {
+				await page.close().catch(() => {});
+			}
+		}
+	}
+
+	async close() {
+		await this.browser?.close();
+	}
+
+	private async dismissCookies(page: Page) {
+		await page
+			.evaluate(() => {
+				const buttons = Array.from(document.querySelectorAll('button'));
+				const accept = buttons.find((b) =>
+					/accept all/i.test((b.textContent || '').trim()),
+				);
+				accept?.click();
+			})
+			.catch(() => {});
+	}
+
+	private async parseGate(page: Page): Promise<{
+		id: string | null;
+		handle: string | null;
+		steps: GateStep[];
+	}> {
+		await page
+			.waitForFunction(
+				() =>
+					!!document.querySelector('audio[src*="/api/download-gates/"]') ||
+					Array.from(document.querySelectorAll('button')).some((b) =>
+						/follow on soundcloud|repost track|like track|comment on track|complete all steps/i.test(
+							(b.textContent || '').trim(),
+						),
+					),
+				{ timeout: 30_000 },
+			)
+			.catch(() => {});
+
+		return page.evaluate(() => {
+			const html = document.documentElement.innerHTML;
+			const handle = location.pathname.match(/\/gate\/([^/?#]+)/)?.[1] ?? null;
+			const fromAudio = document
+				.querySelector('audio[src*="/api/download-gates/"]')
+				?.getAttribute('src')
+				?.match(/\/api\/download-gates\/(\d+)\//)?.[1];
+			const fromHtml = html.match(/\/api\/download-gates\/(\d+)\//)?.[1];
+			const fromJson = html.match(/"id":(\d+),"handle":"[^"]+","title":/)?.[1];
+			const id = fromAudio || fromHtml || fromJson || null;
+
+			let steps: GateStep[] = [];
+			const rawCandidates = [
+				...html.matchAll(/\\"gateSteps\\":(\[[\s\S]*?\])/g),
+				...html.matchAll(/"gateSteps":(\[[\s\S]*?\])/g),
+			];
+			for (const match of rawCandidates) {
+				let raw = match[1];
+				if (!raw) continue;
+				if (raw.includes('\\"')) {
+					raw = raw
+						.replace(/\\"/g, '"')
+						.replace(/\\\\/g, '\\')
+						.replace(/\\n/g, '\n');
+				}
+				try {
+					const parsed = JSON.parse(raw) as GateStep[];
+					if (Array.isArray(parsed) && parsed.length > 0) {
+						steps = parsed;
+						break;
+					}
+				} catch {
+					// try next
+				}
+			}
+
+			return { id, handle, steps };
+		});
+	}
+
+	private async readVerify(page: Page, gateId: string): Promise<VerifyBody> {
+		const result = await page.evaluate(async (id) => {
+			const res = await fetch(
+				`/api/download-gates/${encodeURIComponent(id)}/verify-step`,
+				{ credentials: 'include' },
+			);
+			if (!res.ok) {
+				return { ok: false as const, status: res.status };
+			}
+			return { ok: true as const, body: (await res.json()) as VerifyBody };
+		}, gateId);
+		if (!result.ok) {
+			throw new Error(`MyPressKit verify-step failed (${result.status})`);
+		}
+		return result.body;
+	}
+
+	private async runStep(page: Page, gateId: string, step: GateStep) {
+		if (step.type === 'email-capture') {
+			await this.submitEmail(page, gateId, step.index);
+			return;
+		}
+
+		if (
+			step.type.startsWith('soundcloud-') ||
+			step.type.startsWith('spotify-')
+		) {
+			await this.runOauthStep(page, gateId, step);
+			return;
+		}
+
+		// Generic social / open-link step
+		await page.evaluate(
+			async (id, stepIndex) => {
+				await fetch(
+					`/api/download-gates/${encodeURIComponent(id)}/track-step`,
+					{
+						method: 'POST',
+						headers: { 'Content-Type': 'application/json' },
+						credentials: 'include',
+						body: JSON.stringify({ stepIndex }),
+					},
+				);
+			},
+			gateId,
+			step.index,
+		);
+	}
+
+	private async submitEmail(page: Page, gateId: string, stepIndex: number) {
+		const email = this.config.email?.trim();
+		if (!email) {
+			throw new Error(
+				'This MyPressKit gate requires an email. Set HYPEDDIT_EMAIL in your .env file.',
+			);
+		}
+		await page.evaluate(
+			async (id, index, value) => {
+				const input = document.querySelector(
+					'input[type="email"]',
+				) as HTMLInputElement | null;
+				if (input) {
+					const setter = Object.getOwnPropertyDescriptor(
+						HTMLInputElement.prototype,
+						'value',
+					)?.set;
+					setter?.call(input, value);
+					input.dispatchEvent(new Event('input', { bubbles: true }));
+					input.dispatchEvent(new Event('change', { bubbles: true }));
+				}
+				await fetch(`/api/download-gates/${encodeURIComponent(id)}/email`, {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					credentials: 'include',
+					body: JSON.stringify({ email: value, stepIndex: index }),
+				});
+			},
+			gateId,
+			stepIndex,
+			email,
+		);
+	}
+
+	private async runOauthStep(page: Page, gateId: string, step: GateStep) {
+		if (step.type === 'soundcloud-comment') {
+			const comment = this.config.comment.trim();
+			if (comment.length < 2) {
+				throw new Error(
+					'This MyPressKit gate requires SC_COMMENT (at least 2 characters).',
+				);
+			}
+			await page.evaluate((text) => {
+				const ta = document.querySelector(
+					'textarea',
+				) as HTMLTextAreaElement | null;
+				if (!ta) return;
+				const setter = Object.getOwnPropertyDescriptor(
+					HTMLTextAreaElement.prototype,
+					'value',
+				)?.set;
+				setter?.call(ta, text);
+				ta.dispatchEvent(new Event('input', { bubbles: true }));
+				ta.dispatchEvent(new Event('change', { bubbles: true }));
+			}, comment);
+		}
+
+		const popupPromise = new Promise<Page | null>((resolve) => {
+			const timer = setTimeout(() => resolve(null), 20_000);
+			const onTarget = async (target: { page: () => Promise<Page | null> }) => {
+				const p = await target.page().catch(() => null);
+				if (!p) return;
+				clearTimeout(timer);
+				this.browser.off('targetcreated', onTarget);
+				resolve(p);
+			};
+			this.browser.on('targetcreated', onTarget);
+		});
+
+		const provider = step.type.startsWith('spotify-')
+			? 'spotify'
+			: 'soundcloud';
+		const openMethod = await page.evaluate(
+			(stepIndex, stepType, comment, id, oauthProvider) => {
+				const labels: Record<string, RegExp> = {
+					'soundcloud-follow': /follow on soundcloud/i,
+					'soundcloud-repost': /repost/i,
+					'soundcloud-like': /like track/i,
+					'soundcloud-comment': /comment on track/i,
+				};
+				const re = labels[stepType];
+				const buttons = Array.from(
+					document.querySelectorAll('button'),
+				) as HTMLButtonElement[];
+				const btn = re
+					? buttons.find(
+							(b) => !b.disabled && re.test((b.textContent || '').trim()),
+						)
+					: null;
+				if (btn) {
+					btn.click();
+					return 'ui';
+				}
+				const params = new URLSearchParams({
+					gate: id,
+					step: String(stepIndex),
+					popup: '1',
+				});
+				if (stepType === 'soundcloud-comment') params.set('comment', comment);
+				window.open(
+					`/api/download-gates/oauth/${oauthProvider}/start?${params}`,
+					'mpk-gate-oauth',
+					'width=520,height=720',
+				);
+				return 'direct';
+			},
+			step.index,
+			step.type,
+			this.config.comment.trim(),
+			gateId,
+			provider,
+		);
+		console.log(`MyPressKit OAuth open (${openMethod}) for step ${step.index}`);
+
+		let oauthPage = await popupPromise;
+		if (!oauthPage) oauthPage = await this.findSoundcloudOauthPage();
+		if (oauthPage) {
+			await this.completeSoundcloudOauth(oauthPage);
+		} else {
+			console.log('MyPressKit: no OAuth popup — polling verify-step');
+		}
+	}
+
+	private async waitForStepProgress(
+		page: Page,
+		gateId: string,
+		stepIndex: number,
+		before: VerifyBody,
+	) {
+		const beforeSet = new Set((before.completedStepIndexes ?? []).map(Number));
+		const deadline = Date.now() + 90_000;
+		while (Date.now() < deadline) {
+			const verify = await this.readVerify(page, gateId);
+			if (verify.downloadToken && verify.unlockState?.unlocked) return;
+			const completed = new Set(
+				(verify.completedStepIndexes ?? []).map(Number),
+			);
+			if (completed.has(stepIndex) && !beforeSet.has(stepIndex)) {
+				console.log(`MyPressKit step ${stepIndex} complete`);
+				return;
+			}
+			const remaining = (verify.unlockState?.remaining ?? []).map(Number);
+			if (!remaining.includes(stepIndex)) {
+				console.log(`MyPressKit step ${stepIndex} no longer remaining`);
+				return;
+			}
+			await timeout(1000);
+		}
+		throw new Error(
+			`MyPressKit timed out waiting for step ${stepIndex} to complete.`,
+		);
+	}
+
+	private async findSoundcloudOauthPage(): Promise<Page | null> {
+		for (const candidate of await this.browser.pages()) {
+			if (candidate.isClosed()) continue;
+			if (SC_AUTHORIZE_RE.test(safePageUrl(candidate))) return candidate;
+		}
+		return null;
+	}
+
+	private async completeSoundcloudOauth(startPage: Page) {
+		const hardDeadline = Date.now() + 12 * 60_000;
+		let deadline = Date.now() + 180_000;
+		let lastAllowAt = 0;
+		let sawAuthorize = false;
+		let allowClicks = 0;
+
+		while (Date.now() < deadline) {
+			const oauthPage =
+				(await this.findSoundcloudOauthPage()) ??
+				(SC_AUTHORIZE_RE.test(safePageUrl(startPage)) && !startPage.isClosed()
+					? startPage
+					: null);
+
+			if (oauthPage && !oauthPage.isClosed()) {
+				sawAuthorize = true;
+				const canRetry = Date.now() - lastAllowAt > 3_000;
+				if (lastAllowAt === 0 || canRetry) {
+					const allowed = await this.clickSoundcloudOauthAllow(oauthPage);
+					if (allowed) {
+						deadline = Math.min(
+							hardDeadline,
+							Math.max(deadline, Date.now() + 120_000),
+						);
+						allowClicks += 1;
+						lastAllowAt = Date.now();
+						console.log(
+							`MyPressKit: SoundCloud Allow clicked (${allowClicks})`,
+						);
+						await timeout(1_500);
+						continue;
+					}
+				}
+				await timeout(400);
+				continue;
+			}
+
+			if (sawAuthorize || startPage.isClosed()) {
+				await timeout(800);
+				return;
+			}
+			await timeout(400);
+		}
+
+		throw new Error(
+			'Timed out waiting for SoundCloud OAuth Allow / MyPressKit callback.',
+		);
+	}
+
+	private async clickSoundcloudOauthAllow(oauthPage: Page): Promise<boolean> {
+		await oauthPage.bringToFront().catch(() => {});
+
+		await waitForSoundcloudLogin(oauthPage, {
+			interactive: this.config.browserMode !== 'headless',
+			onWaiting: () => {
+				this.emitProgress(
+					'handling_gates',
+					'Waiting for SoundCloud login in browser…',
+					50,
+					{ currentGate: 'soundcloud', browserActive: true },
+				);
+			},
+		});
+
+		const clicked = await oauthPage
+			.evaluate(() => {
+				const buttons = Array.from(document.querySelectorAll('button'));
+				const allow = buttons.find((b) =>
+					/^(allow|connect|authorize|accept)$/i.test(
+						(b.textContent || '').trim(),
+					),
+				);
+				if (allow) {
+					(allow as HTMLButtonElement).click();
+					return true;
+				}
+				const byId = document.querySelector(
+					'button#submit_approval, button[name="accept"]',
+				) as HTMLButtonElement | null;
+				if (byId) {
+					byId.click();
+					return true;
+				}
+				return false;
+			})
+			.catch(() => false);
+
+		return clicked;
+	}
+
+	private async downloadWithToken(
+		page: Page,
+		gateId: string,
+		token: string,
+		referer: string,
+	): Promise<string> {
+		this.emitProgress('handling_gates', 'Preparing MyPressKit download...', 75);
+		const downloadUrl = `https://www.mypresskit.info/api/download-gates/${encodeURIComponent(gateId)}/download?token=${encodeURIComponent(token)}`;
+		const cookies = await page.cookies('https://www.mypresskit.info');
+		const cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join('; ');
+
+		await mkdir('./downloads', { recursive: true });
+		this.emitProgress('downloading', 'Downloading MyPressKit file...', 0);
+
+		const { response, url: finalUrl } = await safeFetch(downloadUrl, {
+			headers: {
+				Cookie: cookieHeader,
+				Referer: referer,
+				'User-Agent': USER_AGENT,
+				Accept: '*/*',
+			},
+			signal: AbortSignal.timeout(120_000),
+		});
+
+		if (!response.ok || !response.body) {
+			throw new Error(
+				`MyPressKit file download failed (${response.status} ${response.statusText}) from ${finalUrl}`,
+			);
+		}
+
+		const fromHeader = filenameFromContentDisposition(
+			response.headers.get('content-disposition'),
+		);
+		let suggested =
+			sanitizeFilenamePart(basename(fromHeader || '')) ||
+			sanitizeFilenamePart(
+				decodeURIComponent(basename(new URL(finalUrl).pathname)),
+			) ||
+			`mypresskit-${gateId}`;
+		if (!/\.[a-z0-9]{2,5}$/i.test(suggested)) {
+			suggested = `${suggested}.wav`;
+		}
+
+		const target = join('./downloads', suggested);
+		const totalBytes = Number(response.headers.get('content-length')) || 0;
+		const writer = Bun.file(target).writer();
+		const reader = response.body.getReader();
+		let received = 0;
+		let completed = false;
+		const pBar = new SingleBar(
+			{
+				format:
+					'{prefix} {bar} {percentage}% | {current_mb}/{total_mb} MB | ETA: {eta_formatted}',
+				hideCursor: true,
+			},
+			{
+				barCompleteChar: '█',
+				barIncompleteChar: '░',
+				format: Presets.shades_classic.format,
+			},
+		);
+
+		try {
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				received += value.byteLength;
+				if (received > MAX_DOWNLOAD_BYTES) {
+					await reader.cancel();
+					throw new Error(
+						`MyPressKit download too large (${received} bytes; max ${MAX_DOWNLOAD_BYTES})`,
+					);
+				}
+				writer.write(value);
+				if (totalBytes > 0) {
+					if (pBar.isActive) {
+						pBar.update(received, {
+							total_mb: Number((totalBytes / 1024 / 1024).toFixed(2)),
+							current_mb: Number((received / 1024 / 1024).toFixed(2)),
+						});
+					} else {
+						pBar.start(totalBytes, received, { prefix: 'Downloading' });
+					}
+					this.emitProgress(
+						'downloading',
+						`Downloading... ${(received / 1024 / 1024).toFixed(1)} / ${(totalBytes / 1024 / 1024).toFixed(1)} MB`,
+						0,
+						{ downloadBytes: received, totalBytes },
+					);
+				}
+			}
+			await writer.end();
+			completed = true;
+		} finally {
+			pBar.stop();
+			if (!completed) {
+				try {
+					await writer.end();
+				} catch {
+					// ignore
+				}
+				await rm(target, { force: true }).catch(() => {});
+			}
+		}
+
+		console.log('MyPressKit saved:', target);
+		return suggested;
+	}
+}

--- a/src/mypresskit.ts
+++ b/src/mypresskit.ts
@@ -33,10 +33,23 @@ function filenameFromContentDisposition(value: string | null): string | null {
 	if (!value) return null;
 	const star = value.match(/filename\*=(?:UTF-8'')?([^;]+)/i)?.[1];
 	if (star) {
-		return decodeURIComponent(star.replace(/["']/g, ''));
+		const raw = star.replace(/["']/g, '');
+		try {
+			return decodeURIComponent(raw);
+		} catch {
+			return raw;
+		}
 	}
 	const plain = value.match(/filename=["']?([^"';]+)["']?/i)?.[1];
 	return plain ? plain.trim() : null;
+}
+
+function safeDecodeURIComponent(value: string): string {
+	try {
+		return decodeURIComponent(value);
+	} catch {
+		return value;
+	}
 }
 
 function safePageUrl(page: Page): string {
@@ -287,7 +300,7 @@ export class MypresskitDownloader {
 		const result = await page.evaluate(async (id) => {
 			const res = await fetch(
 				`/api/download-gates/${encodeURIComponent(id)}/verify-step`,
-				{ credentials: 'include' },
+				{ credentials: 'include', signal: AbortSignal.timeout(15_000) },
 			);
 			if (!res.ok) {
 				return { ok: false as const, status: res.status };
@@ -306,10 +319,13 @@ export class MypresskitDownloader {
 			return;
 		}
 
-		if (
-			step.type.startsWith('soundcloud-') ||
-			step.type.startsWith('spotify-')
-		) {
+		if (step.type.startsWith('spotify-')) {
+			throw new Error(
+				`MyPressKit Spotify steps are not supported yet (got “${step.type}”).`,
+			);
+		}
+
+		if (step.type.startsWith('soundcloud-')) {
 			await this.runOauthStep(page, gateId, step);
 			return;
 		}
@@ -324,6 +340,7 @@ export class MypresskitDownloader {
 						headers: { 'Content-Type': 'application/json' },
 						credentials: 'include',
 						body: JSON.stringify({ stepIndex }),
+						signal: AbortSignal.timeout(15_000),
 					},
 				);
 			},
@@ -358,6 +375,7 @@ export class MypresskitDownloader {
 					headers: { 'Content-Type': 'application/json' },
 					credentials: 'include',
 					body: JSON.stringify({ email: value, stepIndex: index }),
+					signal: AbortSignal.timeout(15_000),
 				});
 			},
 			gateId,
@@ -390,7 +408,6 @@ export class MypresskitDownloader {
 		}
 
 		const popupPromise = new Promise<Page | null>((resolve) => {
-			const timer = setTimeout(() => resolve(null), 20_000);
 			const onTarget = async (target: { page: () => Promise<Page | null> }) => {
 				const p = await target.page().catch(() => null);
 				if (!p) return;
@@ -398,14 +415,15 @@ export class MypresskitDownloader {
 				this.browser.off('targetcreated', onTarget);
 				resolve(p);
 			};
+			const timer = setTimeout(() => {
+				this.browser.off('targetcreated', onTarget);
+				resolve(null);
+			}, 20_000);
 			this.browser.on('targetcreated', onTarget);
 		});
 
-		const provider = step.type.startsWith('spotify-')
-			? 'spotify'
-			: 'soundcloud';
 		const openMethod = await page.evaluate(
-			(stepIndex, stepType, comment, id, oauthProvider) => {
+			(stepIndex, stepType, comment, id) => {
 				const labels: Record<string, RegExp> = {
 					'soundcloud-follow': /follow on soundcloud/i,
 					'soundcloud-repost': /repost/i,
@@ -432,7 +450,7 @@ export class MypresskitDownloader {
 				});
 				if (stepType === 'soundcloud-comment') params.set('comment', comment);
 				window.open(
-					`/api/download-gates/oauth/${oauthProvider}/start?${params}`,
+					`/api/download-gates/oauth/soundcloud/start?${params}`,
 					'mpk-gate-oauth',
 					'width=520,height=720',
 				);
@@ -442,7 +460,6 @@ export class MypresskitDownloader {
 			step.type,
 			this.config.comment.trim(),
 			gateId,
-			provider,
 		);
 		console.log(`MyPressKit OAuth open (${openMethod}) for step ${step.index}`);
 
@@ -591,7 +608,9 @@ export class MypresskitDownloader {
 	): Promise<string> {
 		this.emitProgress('handling_gates', 'Preparing MyPressKit download...', 75);
 		const downloadUrl = `https://www.mypresskit.info/api/download-gates/${encodeURIComponent(gateId)}/download?token=${encodeURIComponent(token)}`;
-		const cookies = await page.cookies('https://www.mypresskit.info');
+		const cookies = await page
+			.browserContext()
+			.cookies('https://www.mypresskit.info');
 		const cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join('; ');
 
 		await mkdir('./downloads', { recursive: true });
@@ -619,7 +638,7 @@ export class MypresskitDownloader {
 		let suggested =
 			sanitizeFilenamePart(basename(fromHeader || '')) ||
 			sanitizeFilenamePart(
-				decodeURIComponent(basename(new URL(finalUrl).pathname)),
+				safeDecodeURIComponent(basename(new URL(finalUrl).pathname)),
 			) ||
 			`mypresskit-${gateId}`;
 		if (!/\.[a-z0-9]{2,5}$/i.test(suggested)) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,7 @@ import { HypedditDownloader } from './hypeddit';
 import { HypedditHttpDownloader } from './hypedditHttp';
 import { JobQueue } from './jobQueue';
 import { jobStore } from './jobStore';
+import { MypresskitDownloader } from './mypresskit';
 import { PumpyoursoundDownloader } from './pumpyoursound';
 import { isAllowedCorsOrigin } from './serverCors';
 import { SoundcloudClient } from './soundcloud';
@@ -471,6 +472,30 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 			);
 			downloadFilename =
 				await pumpyoursoundDownloader.downloadAudio(downloadSourceUrl);
+			throwIfCancelled();
+		} else if (provider === 'mypresskit') {
+			jobStore.updateProgress(
+				jobId,
+				'initializing_browser',
+				'Launching browser for MyPressKit...',
+				10,
+			);
+			const mypresskitDownloader = new MypresskitDownloader(
+				await prepareBrowserConfig(),
+			);
+			activeDownloaders.set(jobId, mypresskitDownloader);
+			mypresskitDownloader.setProgressCallback(emitProgress);
+			await mypresskitDownloader.initialize();
+			throwIfCancelled();
+			jobStore.updateProgress(
+				jobId,
+				'handling_gates',
+				'Processing MyPressKit gates...',
+				25,
+				{ browserActive: job.browserMode === 'headed' },
+			);
+			downloadFilename =
+				await mypresskitDownloader.downloadAudio(downloadSourceUrl);
 			throwIfCancelled();
 		} else if (provider === 'direct') {
 			jobStore.updateProgress(

--- a/src/soundcloud.ts
+++ b/src/soundcloud.ts
@@ -19,6 +19,7 @@ const GATE_PROVIDER_LABELS: Record<GateProvider, string> = {
 	downloadgater: 'DownloadGater',
 	stillhype: 'StillHype',
 	pumpyoursound: 'PumpYourSound',
+	mypresskit: 'MyPressKit',
 	direct: 'direct download',
 	bandcamp: 'Bandcamp',
 	soundcloud: 'SoundCloud',

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -191,6 +191,28 @@ describe('resolveGateProviderUrl', () => {
 		});
 	});
 
+	test('matches MyPressKit gate URLs and normalizes http to https', () => {
+		expect(
+			resolveGateProviderUrl(
+				'http://www.mypresskit.info/gate/dj-felge-rihanna-umbrella-dj-felge-x-kluge-edit',
+			),
+		).toEqual({
+			url: 'https://www.mypresskit.info/gate/dj-felge-rihanna-umbrella-dj-felge-x-kluge-edit',
+			provider: 'mypresskit',
+		});
+	});
+
+	test('prefers MyPressKit over Bandcamp in the same string', () => {
+		expect(
+			resolveGateProviderUrl(
+				'https://artist.bandcamp.com/track/song and https://www.mypresskit.info/gate/some-track',
+			),
+		).toEqual({
+			url: 'https://www.mypresskit.info/gate/some-track',
+			provider: 'mypresskit',
+		});
+	});
+
 	test('prefers PumpYourSound over Bandcamp in the same string', () => {
 		expect(
 			resolveGateProviderUrl(
@@ -227,6 +249,21 @@ describe('extractGateUrl', () => {
 			url: 'https://pumpyoursound.com/f/pys/aguanile-remix/224680',
 			provider: 'pumpyoursound',
 			type: 'description',
+		});
+	});
+
+	test('prefers MyPressKit purchase_url over Bandcamp description', () => {
+		expect(
+			extractGateUrl({
+				purchase_url:
+					'https://www.mypresskit.info/gate/dj-felge-rihanna-umbrella-dj-felge-x-kluge-edit',
+				description:
+					'Also on Bandcamp: https://artist.bandcamp.com/track/umbrella',
+			} as Parameters<typeof extractGateUrl>[0]),
+		).toEqual({
+			url: 'https://www.mypresskit.info/gate/dj-felge-rihanna-umbrella-dj-felge-x-kluge-edit',
+			provider: 'mypresskit',
+			type: 'purchase_url',
 		});
 	});
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -255,6 +255,7 @@ export type GateProvider =
 	| 'downloadgater'
 	| 'stillhype'
 	| 'pumpyoursound'
+	| 'mypresskit'
 	/** Direct HTTP(S) file URL (Dropbox, Drive, raw audio link, …). */
 	| 'direct'
 	| 'bandcamp'
@@ -277,6 +278,9 @@ const STILLHYPE_URL_RE =
 /** pumpyoursound.com/f/{channel}/{slug}/{id} (channel may be `pys` or the artist). */
 const PUMPYOURSOUND_URL_RE =
 	/https?:\/\/(?:www\.)?pumpyoursound\.com\/f\/[A-Za-z0-9_-]+\/[A-Za-z0-9_-]+\/\d+/i;
+/** mypresskit.info/gate/{handle} */
+const MYPRESSKIT_URL_RE =
+	/https?:\/\/(?:www\.)?mypresskit\.info\/gate\/[A-Za-z0-9_-]+/i;
 /** artist.bandcamp.com/track|album/... (and bare bandcamp.com). */
 const BANDCAMP_URL_RE =
 	/https?:\/\/(?:[\w-]+\.)?bandcamp\.com\/(?:track|album)\/[^\s?#]+/i;
@@ -317,6 +321,10 @@ export function isStillhypeUrl(value: string): boolean {
 
 export function isPumpyoursoundUrl(value: string): boolean {
 	return PUMPYOURSOUND_URL_RE.test(value);
+}
+
+export function isMypresskitUrl(value: string): boolean {
+	return MYPRESSKIT_URL_RE.test(value);
 }
 
 export function isBandcampUrl(value: string): boolean {
@@ -373,7 +381,7 @@ export function validateGateUrl(value: string): true | string {
 	if (/^https?:\/\/\S+/i.test(value.trim())) {
 		return true;
 	}
-	return 'A valid Hypeddit, Droploud, GateRush, DownloadGater, StillHype, PumpYourSound, Bandcamp, direct download, SoundCloud, or resolvable http(s) URL is required';
+	return 'A valid Hypeddit, Droploud, GateRush, DownloadGater, StillHype, PumpYourSound, MyPressKit, Bandcamp, direct download, SoundCloud, or resolvable http(s) URL is required';
 }
 
 function normalizeGateUrl(
@@ -385,6 +393,7 @@ function normalizeGateUrl(
 		provider === 'downloadgater' ||
 		provider === 'stillhype' ||
 		provider === 'pumpyoursound' ||
+		provider === 'mypresskit' ||
 		provider === 'bandcamp' ||
 		provider === 'direct'
 	) {
@@ -440,6 +449,10 @@ function matchTraditionalGateUrl(
 			trimExtractedUrl(pumpyoursoundMatch),
 			'pumpyoursound',
 		);
+	}
+	const mypresskitMatch = value.match(MYPRESSKIT_URL_RE)?.[0];
+	if (mypresskitMatch) {
+		return normalizeGateUrl(trimExtractedUrl(mypresskitMatch), 'mypresskit');
 	}
 	return null;
 }
@@ -616,6 +629,7 @@ export function findKnownGateInHtml(
 				'downloadgater',
 				'stillhype',
 				'pumpyoursound',
+				'mypresskit',
 			].includes(match.provider),
 		);
 		if (traditional) return traditional;
@@ -735,8 +749,8 @@ function collectUnresolvedHttpCandidates(
 
 /**
  * Prefer traditional unlock gates (Hypeddit, Droploud, GateRush, DownloadGater,
- * StillHype, PumpYourSound) from purchase_url or description over Bandcamp /
- * SoundCloud store links, then direct file links (Dropbox, Drive, …).
+ * StillHype, PumpYourSound, MyPressKit) from purchase_url or description over
+ * Bandcamp / SoundCloud store links, then direct file links (Dropbox, Drive, …).
  */
 export function extractGateUrl(track: SoundcloudTrack): GateUrlMatch | null {
 	const { purchase_url, description } = track;

--- a/userscript/sc-gate-dl.test.ts
+++ b/userscript/sc-gate-dl.test.ts
@@ -30,6 +30,14 @@ describe('feed playback origin', () => {
 	});
 });
 
+describe('store link branding', () => {
+	test('recognizes MyPressKit gate URLs', () => {
+		expect(source).toContain("host === 'mypresskit.info'");
+		expect(source).toContain("return 'mypresskit'");
+		expect(source).toContain('https://www.mypresskit.info/favicon.ico');
+	});
+});
+
 describe('Web UI preferences', () => {
 	test('passes the remembered browser mode through the deep link', () => {
 		expect(source).toContain('browserMode: getBrowserMode()');

--- a/userscript/sc-gate-dl.test.ts
+++ b/userscript/sc-gate-dl.test.ts
@@ -6,16 +6,34 @@ type UpdateFeedPlaybackOrigin = (
 	outsidePlaybackSelection: boolean,
 ) => string | null;
 
+type StoreServiceForUrl = (href: string) => string | null;
+
 const source = await Bun.file(
 	new URL('./sc-gate-dl.user.js', import.meta.url),
 ).text();
-const start = source.indexOf('\tfunction updateFeedPlaybackOrigin(');
-const end = source.indexOf('\n\n\tlet lastRecordedPlayingUrl', start);
-if (start < 0 || end < 0) throw new Error('Playback-origin helper not found');
-const helperSource = source.slice(start, end).trim();
-const updateFeedPlaybackOrigin = Function(
-	`"use strict"; ${helperSource}; return updateFeedPlaybackOrigin;`,
-)() as UpdateFeedPlaybackOrigin;
+
+function extractHelper<T>(
+	startMarker: string,
+	endMarker: string,
+	name: string,
+): T {
+	const start = source.indexOf(startMarker);
+	const end = source.indexOf(endMarker, start);
+	if (start < 0 || end < 0) throw new Error(`${name} helper not found`);
+	const helperSource = source.slice(start, end).trim();
+	return Function(`"use strict"; ${helperSource}; return ${name};`)() as T;
+}
+
+const updateFeedPlaybackOrigin = extractHelper<UpdateFeedPlaybackOrigin>(
+	'\tfunction updateFeedPlaybackOrigin(',
+	'\n\n\tlet lastRecordedPlayingUrl',
+	'updateFeedPlaybackOrigin',
+);
+const storeServiceForUrl = extractHelper<StoreServiceForUrl>(
+	'\tfunction storeServiceForUrl(',
+	'\n\n\tfunction decorateStoreLink(',
+	'storeServiceForUrl',
+);
 
 describe('feed playback origin', () => {
 	test('clears feed provenance when another track is selected outside the feed', () => {
@@ -32,9 +50,24 @@ describe('feed playback origin', () => {
 
 describe('store link branding', () => {
 	test('recognizes MyPressKit gate URLs', () => {
-		expect(source).toContain("host === 'mypresskit.info'");
-		expect(source).toContain("return 'mypresskit'");
-		expect(source).toContain('https://www.mypresskit.info/favicon.ico');
+		expect(
+			storeServiceForUrl(
+				'https://www.mypresskit.info/gate/dj-felge-rihanna-umbrella-dj-felge-x-kluge-edit',
+			),
+		).toBe('mypresskit');
+		expect(
+			storeServiceForUrl(
+				'https://mypresskit.info/gate/dj-felge-rihanna-umbrella-dj-felge-x-kluge-edit/',
+			),
+		).toBe('mypresskit');
+	});
+
+	test('rejects non-gate MyPressKit URLs', () => {
+		expect(storeServiceForUrl('https://www.mypresskit.info/')).toBeNull();
+		expect(
+			storeServiceForUrl('https://www.mypresskit.info/marketplace'),
+		).toBeNull();
+		expect(storeServiceForUrl('https://example.com/gate/foo')).toBeNull();
 	});
 });
 

--- a/userscript/sc-gate-dl.user.js
+++ b/userscript/sc-gate-dl.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         sc-gate-dl
 // @namespace    https://github.com/D3SOX/sc-gate-dl
-// @version      1.10.10
+// @version      1.10.11
 // @description  Add sc-gate-dl download controls and remember your position in the SoundCloud feed
 // @author       D3SOX
 // @match        https://soundcloud.com/*
@@ -129,6 +129,9 @@
 		},
 		pumpyoursound: {
 			icon: 'https://pumpyoursound.com/favicon.ico',
+		},
+		mypresskit: {
+			icon: 'https://www.mypresskit.info/favicon.ico',
 		},
 		bandcamp: {
 			icon: 'https://s4.bcbits.com/client-bundle/1/PageLayout_1/favicon-78ff127104384a042453aca8d73be7dc.static/favicon/favicon-32x32.png',
@@ -360,6 +363,12 @@
 				/^\/f\/[A-Za-z0-9_-]+\/[A-Za-z0-9_-]+\/\d+\/?$/i.test(path)
 			) {
 				return 'pumpyoursound';
+			}
+			if (
+				host === 'mypresskit.info' &&
+				/^\/gate\/[A-Za-z0-9_-]+\/?$/i.test(path)
+			) {
+				return 'mypresskit';
 			}
 			if (
 				(host === 'bandcamp.com' || host.endsWith('.bandcamp.com')) &&

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -1163,8 +1163,8 @@ export default function App() {
 					</div>
 					<p className="tagline">
 						Download & tag SoundCloud tracks from Hypeddit, Droploud, GateRush,
-						DownloadGater, StillHype, PumpYourSound, Bandcamp, or a direct
-						download link
+						DownloadGater, StillHype, PumpYourSound, MyPressKit, Bandcamp, or a
+						direct download link
 					</p>
 				</header>
 			)}
@@ -1361,7 +1361,7 @@ export default function App() {
 							<p>
 								{skipAutomaticHypedditFetch
 									? 'Automatic gate lookup is disabled. Enter a gate URL manually, or download the SoundCloud track via yt-dlp.'
-									: 'Gate URL not found in track. Enter a Hypeddit, Droploud, GateRush, DownloadGater, StillHype, PumpYourSound, Bandcamp, or direct download URL, or download via yt-dlp from SoundCloud.'}
+									: 'Gate URL not found in track. Enter a Hypeddit, Droploud, GateRush, DownloadGater, StillHype, PumpYourSound, MyPressKit, Bandcamp, or direct download URL, or download via yt-dlp from SoundCloud.'}
 							</p>
 						</div>
 						<form onSubmit={handleHypedditSubmit}>


### PR DESCRIPTION
SoundCloud tracks that unlock via MyPressKit (`mypresskit.info/gate/...`) were not recognized, so downloads fell through to Bandcamp/SoundCloud yt-dlp instead of the gate file.

Add a MyPressKit provider that prefers these gate URLs over Bandcamp/SoundCloud, completes the verified SoundCloud OAuth steps in the browser, then downloads with the unlock token. Wired through CLI, server, Web UI copy, and URL matching tests.

Made with [Cursor](https://cursor.com) (Composer / Auto agent harness).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for downloading audio from MyPressKit gates.
  * Added handling for email, social, SoundCloud, and OAuth verification steps.
  * Added progress reporting, cancellation support, download limits, and cleanup of incomplete downloads.
  * Added MyPressKit URL detection, validation, and provider recognition.
  * Updated the interface, browser script, and documentation to list MyPressKit as a supported source.

* **Tests**
  * Added coverage for MyPressKit URL detection, normalization, provider selection, and link extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->