### PR TITLE
feat: improve mobile remote browser controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,8 +391,25 @@ tailscale serve status
 
 When Tailscale itself runs in Docker with userspace networking, run those
 commands inside its container, for example `docker exec tailscaled tailscale
-serve ...`. Use Tailscale **Serve**, not **Funnel**: Serve is restricted to the
-tailnet, while Funnel publishes the service to the internet.
+serve ...`. The `127.0.0.1` targets above work only when that container uses
+host networking. For a bridge-mode container, add
+`host.docker.internal:host-gateway` as an extra host and replace each target
+with the container-reachable host name, for example:
+
+```yaml
+extra_hosts:
+  - "host.docker.internal:host-gateway"
+```
+
+```bash
+docker exec tailscaled tailscale serve --bg --http=3000 http://host.docker.internal:3000
+docker exec tailscaled tailscale serve --bg --http=4321 http://host.docker.internal:4321
+docker exec tailscaled tailscale serve --bg --http=6080 http://host.docker.internal:6080
+```
+
+The host services must listen on an interface reachable from the Docker bridge.
+Use Tailscale **Serve**, not **Funnel**: Serve is restricted to the tailnet,
+while Funnel publishes the service to the internet.
 
 Vite rejects unlisted DNS hostnames even when they are private. Add the short
 MagicDNS name and fully qualified tailnet name to the app service as shown

--- a/README.md
+++ b/README.md
@@ -226,9 +226,9 @@ mkdir -p ~/.local/state/sc-gate-dl
 sh -c 'umask 077; touch "$HOME/.local/state/sc-gate-dl/xauthority"; chmod 600 "$HOME/.local/state/sc-gate-dl/xauthority"; xauth -f "$HOME/.local/state/sc-gate-dl/xauthority" add :99 . "$(mcookie)"'
 ```
 
-Add the runtime environment to the project `.env`. Replace `SERVER_ADDRESS`
-with the stable hostname or IP address reachable by the browser that opens the
-Web UI:
+Add the runtime environment to the project `.env`. The `{host}` placeholder
+makes the noVNC URL follow the hostname or IP address used to open the Web UI,
+so the same server works through both a LAN address and Tailscale:
 
 ```dotenv
 DISPLAY=:99
@@ -237,8 +237,11 @@ XDG_SESSION_TYPE=x11
 OZONE_PLATFORM=x11
 SC_GATE_DL_DISABLE_GPU=true
 SC_GATE_DL_DISABLE_DEV_SHM=true
-BROWSER_VIEW_URL="http://SERVER_ADDRESS:6080/vnc.html?autoconnect=true&resize=scale"
+BROWSER_VIEW_URL="http://{host}:6080/vnc.html?autoconnect=true&resize=scale"
 ```
+
+A fixed noVNC hostname or IP address is still supported when the viewer is
+reachable through only one address.
 
 `SC_GATE_DL_DISABLE_DEV_SHM` is mainly useful for containers or constrained
 hosts. It may be omitted when Chromium can use `/dev/shm` normally.
@@ -317,6 +320,8 @@ Environment=DISPLAY=:99
 Environment=XAUTHORITY=/home/YOUR_USER/.local/state/sc-gate-dl/xauthority
 Environment=XDG_SESSION_TYPE=x11
 Environment=OZONE_PLATFORM=x11
+# Comma-separated hostnames used to open the Vite-powered Web UI:
+Environment=__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=SERVER_NAME,SERVER_NAME.TAILNET.ts.net
 ExecStart=/home/YOUR_USER/.bun/bin/bun webui
 Restart=on-failure
 RestartSec=3
@@ -372,6 +377,48 @@ systemctl --user stop sc-gate-dl.target
 systemctl --user start sc-gate-dl.target
 ```
 
+##### Private Tailscale access
+
+Keep the application available on its LAN addresses and add private tailnet
+listeners for the API, Web UI, and noVNC gateway:
+
+```bash
+tailscale serve --bg --http=3000 http://127.0.0.1:3000
+tailscale serve --bg --http=4321 http://127.0.0.1:4321
+tailscale serve --bg --http=6080 http://127.0.0.1:6080
+tailscale serve status
+```
+
+When Tailscale itself runs in Docker with userspace networking, run those
+commands inside its container, for example `docker exec tailscaled tailscale
+serve ...`. Use Tailscale **Serve**, not **Funnel**: Serve is restricted to the
+tailnet, while Funnel publishes the service to the internet.
+
+Vite rejects unlisted DNS hostnames even when they are private. Add the short
+MagicDNS name and fully qualified tailnet name to the app service as shown
+above, or place the same setting in the root `.env`:
+
+```dotenv
+__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=SERVER_NAME,SERVER_NAME.TAILNET.ts.net
+```
+
+Do not use `server.allowedHosts: true`; an explicit allowlist retains Vite's
+DNS-rebinding protection. After changing the environment, reload the systemd
+configuration and restart the app:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user restart sc-gate-app.service
+```
+
+With `BROWSER_VIEW_URL` using `{host}`, both addresses can be used without
+changing the server again:
+
+```text
+http://192.168.1.50:4321
+http://SERVER_NAME:4321
+```
+
 If you intentionally keep a plaintext password file instead of
 `~/.vnc/passwd`, protect it with mode `600` and use x11vnc's `-passwdfile`
 option. Do not pass a plaintext file to `-rfbauth`; that option expects
@@ -412,7 +459,7 @@ http://localhost:4321/?url=https://soundcloud.com/artist/track&outputFormat=mp3-
 
 ### Browser userscript
 
-Adds a download icon next to SoundCloud store/buy links (feed and track pages). Clicking it opens the **exact Web UI** in a floating, movable panel on the right (resizable from all edges) — the page behind stays usable (no dimmed overlay). Choose both output format and browser mode from the panel toolbar, or from Violentmonkey's **Choose output format…** and **Choose browser mode…** menu commands. Both choices are remembered and passed to the Web UI. Auto-close after the **browser file download** (Download MP3/Original) or **Start New Download** is on by default — toggle via **Auto-close after browser download**. Closing the panel (× / Escape) or **Cancel download** in the Web UI stops an in-progress job and exits the browser cleanly.
+Adds a download icon next to SoundCloud store/buy links (feed and track pages). Clicking it opens the **exact Web UI** in a floating, movable panel on the right (resizable from all edges) — the page behind stays usable (no dimmed overlay). Choose both output format and browser mode from the panel toolbar, or from Violentmonkey's **Choose output format…** and **Choose browser mode…** menu commands. Both choices are remembered and passed to the Web UI. Enable **Always open downloads in new tab** from Violentmonkey's userscript menu to bypass the modal for every download; the choice is remembered. Auto-close after the **browser file download** (Download MP3/Original) or **Start New Download** is on by default — toggle via **Auto-close after browser download**. Closing the panel (× / Escape) or **Cancel download** in the Web UI stops an in-progress job and exits the browser cleanly.
 
 **Recommended:** [Violentmonkey](https://violentmonkey.github.io/) (Firefox / Chrome / Edge). Tampermonkey also works.
 

--- a/README.md
+++ b/README.md
@@ -393,6 +393,9 @@ any saved password immediately. Closing and reopening the panel keeps the
 established VNC connection. Use the header controls to zoom, disconnect, or
 maximize/restore the viewer. Double-clicking the header also toggles maximized
 mode, while dragging a maximized header restores the floating window.
+On touchscreens, drag with one finger to move the remote pointer, tap to
+left-click, hold without moving to right-click, and drag with two fingers to
+pan the local view while zoomed in.
 
 VNC authentication does not encrypt the connection. Keep port `6080` on a
 trusted LAN, or put the Web UI, API, and noVNC behind an authenticated HTTPS

--- a/src/deepLink.test.ts
+++ b/src/deepLink.test.ts
@@ -100,6 +100,21 @@ describe('browser-view capability', () => {
 		).toBe('http://192.168.178.57:6080/vnc.html?autoconnect=true');
 	});
 
+	test('uses the Web UI hostname for a host template', () => {
+		const capability = {
+			browserViewUrl: 'http://{host}:6080/vnc.html?autoconnect=true',
+		};
+		expect(parseBrowserViewUrl(capability, '192.168.178.57')).toBe(
+			'http://192.168.178.57:6080/vnc.html?autoconnect=true',
+		);
+		expect(parseBrowserViewUrl(capability, 'homelan')).toBe(
+			'http://homelan:6080/vnc.html?autoconnect=true',
+		);
+		expect(parseBrowserViewUrl(capability, 'fd7a:115c:a1e0::1')).toBe(
+			'http://[fd7a:115c:a1e0::1]:6080/vnc.html?autoconnect=true',
+		);
+	});
+
 	test('rejects invalid and executable URLs', () => {
 		expect(
 			parseBrowserViewUrl({ browserViewUrl: 'javascript:alert(1)' }),

--- a/src/gaterush.test.ts
+++ b/src/gaterush.test.ts
@@ -13,13 +13,16 @@ describe('GaterushDownloader cancellation', () => {
 		});
 		const settled = pending.catch((error: unknown) => error);
 		let browserClosed = false;
+		const events: string[] = [];
 
 		Object.assign(downloader, {
 			cancelPendingDownloadWait: () => {
+				events.push('cancel');
 				rejectPending(new Error('Download was canceled'));
 			},
 			browser: {
 				close: async () => {
+					events.push('close');
 					browserClosed = true;
 				},
 			},
@@ -27,6 +30,7 @@ describe('GaterushDownloader cancellation', () => {
 
 		await downloader.close();
 
+		expect(events).toEqual(['cancel', 'close']);
 		expect(browserClosed).toBeTrue();
 		expect(await settled).toEqual(new Error('Download was canceled'));
 	});

--- a/src/gaterush.test.ts
+++ b/src/gaterush.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test';
+import { GaterushDownloader } from './gaterush';
+
+describe('GaterushDownloader cancellation', () => {
+	test('rejects a pending download wait before closing the browser', async () => {
+		const downloader = new GaterushDownloader({
+			comment: '',
+			browserMode: 'headless',
+		});
+		let rejectPending = (_error: Error) => {};
+		const pending = new Promise<void>((_resolve, reject) => {
+			rejectPending = reject;
+		});
+		const settled = pending.catch((error: unknown) => error);
+		let browserClosed = false;
+
+		Object.assign(downloader, {
+			cancelPendingDownloadWait: () => {
+				rejectPending(new Error('Download was canceled'));
+			},
+			browser: {
+				close: async () => {
+					browserClosed = true;
+				},
+			},
+		});
+
+		await downloader.close();
+
+		expect(browserClosed).toBeTrue();
+		expect(await settled).toEqual(new Error('Download was canceled'));
+	});
+});

--- a/src/gaterush.ts
+++ b/src/gaterush.ts
@@ -15,6 +15,7 @@ export class GaterushDownloader {
 	private downloadFilename: string | null = null;
 	private config: HypedditConfig;
 	private progressCallback: ProgressCallback | null = null;
+	private cancelPendingDownloadWait: (() => void) | null = null;
 
 	constructor(config: HypedditConfig) {
 		this.config = config;
@@ -132,6 +133,8 @@ export class GaterushDownloader {
 	}
 
 	async close() {
+		this.cancelPendingDownloadWait?.();
+		this.cancelPendingDownloadWait = null;
 		await this.browser?.close();
 	}
 
@@ -540,6 +543,10 @@ export class GaterushDownloader {
 			downloadCompleteResolve = resolve;
 			downloadCompleteReject = reject;
 		});
+		const cancelPendingDownloadWait = () => {
+			downloadCompleteReject(new Error('Download was canceled'));
+		};
+		this.cancelPendingDownloadWait = cancelPendingDownloadWait;
 		const downloadTimer = setTimeout(
 			() =>
 				downloadCompleteReject(
@@ -621,6 +628,9 @@ export class GaterushDownloader {
 		try {
 			await Promise.all([clickDownload(), downloadCompletePromise]);
 		} finally {
+			if (this.cancelPendingDownloadWait === cancelPendingDownloadWait) {
+				this.cancelPendingDownloadWait = null;
+			}
 			clearTimeout(downloadTimer);
 			clearTimeout(retryTimer);
 			pBar.stop();

--- a/src/jobStore.test.ts
+++ b/src/jobStore.test.ts
@@ -29,6 +29,27 @@ describe('jobStore Bandcamp track selection', () => {
 		}
 	});
 
+	test('reports cancellation as terminal only after teardown completes', () => {
+		const job = jobStore.create('https://soundcloud.com/a/b', 'mp3-320');
+		const stages: string[] = [];
+		const unsubscribe = jobStore.subscribe(job.id, (progress) => {
+			stages.push(progress.stage);
+		});
+		try {
+			jobStore.requestCancellation(job.id);
+			expect(jobStore.isCancelled(job.id)).toBeTrue();
+			expect(jobStore.get(job.id)?.progress.stage).toBe('cancelling');
+			expect(stages).toEqual(['cancelling']);
+
+			jobStore.cancel(job.id);
+			expect(jobStore.get(job.id)?.progress.stage).toBe('cancelled');
+			expect(stages).toEqual(['cancelling', 'cancelled']);
+		} finally {
+			unsubscribe();
+			jobStore.delete(job.id);
+		}
+	});
+
 	test('delete resolves pending wait with null', async () => {
 		const job = jobStore.create('https://soundcloud.com/a/b', 'mp3');
 		const wait = jobStore.waitForBandcampTrackSelection(job.id);

--- a/src/jobStore.ts
+++ b/src/jobStore.ts
@@ -138,6 +138,25 @@ class JobStore {
 		return this.jobs.get(id)?.cancelled === true;
 	}
 
+	/** Mark an active job for cancellation without reporting terminal completion. */
+	requestCancellation(id: string): Job | undefined {
+		const job = this.jobs.get(id);
+		if (!job) return undefined;
+
+		job.cancelled = true;
+		job.error = null;
+		job.bandcampAlbumTracks = null;
+		job.progress = {
+			stage: 'cancelling',
+			message: 'Cancelling download…',
+			percent: job.progress.percent,
+		};
+		job.updatedAt = new Date();
+		this.resolveBandcampTrackSelection(id, null);
+		this.notifyListeners(id, job.progress);
+		return job;
+	}
+
 	/**
 	 * Mark a job cancelled and notify listeners. Caller closes the browser.
 	 */

--- a/src/server.ts
+++ b/src/server.ts
@@ -633,10 +633,8 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 		jobStore.updateProgress(jobId, 'ready', 'Ready for metadata editing', 100);
 	} catch (error) {
 		if (jobStore.isCancelled(jobId)) {
-			// Progress already set to cancelled by the cancel endpoint (or below).
-			if (jobStore.get(jobId)?.progress.stage !== 'cancelled') {
-				jobStore.cancel(jobId);
-			}
+			// The cancel endpoint publishes the terminal state after this task has
+			// released the serial queue slot.
 			return;
 		}
 		const message =
@@ -1143,7 +1141,7 @@ const server = Bun.serve({
 						return jsonResponse({ success: true, message: 'Cancelled' });
 					}
 
-					jobStore.cancel(jobId, 'Cancelling download…');
+					jobStore.requestCancellation(jobId);
 					// Close CloakBrowser / job profile so Chromium exits cleanly
 					await closeJobDownloader(jobId);
 					await jobQueue.waitForCompletion(jobId);

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,7 @@ export type JobStage =
 	| 'processing_audio'
 	| 'ready'
 	| 'error'
+	| 'cancelling'
 	| 'cancelled';
 
 /** Candidate track on a Bandcamp album when auto title-match fails. */

--- a/userscript/sc-gate-dl.test.ts
+++ b/userscript/sc-gate-dl.test.ts
@@ -93,6 +93,14 @@ describe('Web UI preferences', () => {
 		expect(source).toContain('class="sc-gate-dl-server"');
 	});
 
+	test('offers a remembered always-open-in-tab mode', () => {
+		expect(source).toContain('sc-gate-dl-always-open-tab');
+		expect(source).toContain('Always open downloads in new tab:');
+		expect(source).toContain(
+			"window.open(buildWebuiSrc(trackUrl), '_blank', 'noopener,noreferrer')",
+		);
+	});
+
 	test('passes the remembered browser mode through the deep link', () => {
 		expect(source).toContain('browserMode: getBrowserMode()');
 		expect(source).toContain('class="sc-gate-dl-browser-mode"');

--- a/userscript/sc-gate-dl.user.js
+++ b/userscript/sc-gate-dl.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         sc-gate-dl
 // @namespace    https://github.com/D3SOX/sc-gate-dl
-// @version      1.10.12
+// @version      1.10.13
 // @description  Add sc-gate-dl download controls and remember your position in the SoundCloud feed
 // @author       D3SOX
 // @match        https://soundcloud.com/*
@@ -31,6 +31,7 @@
 	const OUTPUT_FORMAT_KEY = 'sc-gate-dl-output-format';
 	const BROWSER_MODE_KEY = 'sc-gate-dl-browser-mode';
 	const AUTO_CLOSE_KEY = 'sc-gate-dl-auto-close';
+	const ALWAYS_OPEN_TAB_KEY = 'sc-gate-dl-always-open-tab';
 	const FEED_CHECKPOINT_KEY = 'sc-gate-dl-feed-checkpoint';
 	const DEFAULT_WEBUI_BASE = 'http://localhost:4321';
 	const BUTTON_ATTR = 'data-sc-gate-dl-btn';
@@ -171,6 +172,41 @@
 		}
 	}
 
+	function getAlwaysOpenTab() {
+		try {
+			if (typeof GM_getValue === 'function') {
+				const stored = GM_getValue(ALWAYS_OPEN_TAB_KEY, null);
+				if (typeof stored === 'boolean') return stored;
+			}
+		} catch {
+			// ignore
+		}
+		try {
+			const stored = localStorage.getItem(ALWAYS_OPEN_TAB_KEY);
+			if (stored === '1' || stored === 'true') return true;
+			if (stored === '0' || stored === 'false') return false;
+		} catch {
+			// ignore
+		}
+		return false;
+	}
+
+	function setAlwaysOpenTab(value) {
+		const enabled = Boolean(value);
+		try {
+			if (typeof GM_setValue === 'function') {
+				GM_setValue(ALWAYS_OPEN_TAB_KEY, enabled);
+			}
+		} catch {
+			// ignore
+		}
+		try {
+			localStorage.setItem(ALWAYS_OPEN_TAB_KEY, enabled ? '1' : '0');
+		} catch {
+			// ignore
+		}
+	}
+
 	function getOutputFormat() {
 		try {
 			if (typeof GM_getValue === 'function') {
@@ -262,6 +298,7 @@
 	}
 
 	let autoCloseMenuId;
+	let alwaysOpenTabMenuId;
 
 	function refreshAutoCloseMenu() {
 		if (typeof GM_registerMenuCommand !== 'function') return;
@@ -285,6 +322,28 @@
 		);
 	}
 
+	function refreshAlwaysOpenTabMenu() {
+		if (typeof GM_registerMenuCommand !== 'function') return;
+		if (
+			typeof GM_unregisterMenuCommand === 'function' &&
+			alwaysOpenTabMenuId != null
+		) {
+			try {
+				GM_unregisterMenuCommand(alwaysOpenTabMenuId);
+			} catch {
+				// ignore
+			}
+		}
+		const enabled = getAlwaysOpenTab();
+		alwaysOpenTabMenuId = GM_registerMenuCommand(
+			`Always open downloads in new tab: ${enabled ? 'ON' : 'OFF'}`,
+			() => {
+				setAlwaysOpenTab(!getAlwaysOpenTab());
+				refreshAlwaysOpenTabMenu();
+			},
+		);
+	}
+
 	function registerMenuCommands() {
 		if (typeof GM_registerMenuCommand !== 'function') return;
 		GM_registerMenuCommand('Configure server…', () => {
@@ -299,6 +358,7 @@
 		GM_registerMenuCommand('Choose browser mode…', () => {
 			openBrowserModeDialog();
 		});
+		refreshAlwaysOpenTabMenu();
 		refreshAutoCloseMenu();
 	}
 
@@ -2254,6 +2314,10 @@ a[${STORE_SERVICE_ATTR}] > button::after {
 	}
 
 	function requestDownload(trackUrl) {
+		if (getAlwaysOpenTab()) {
+			window.open(buildWebuiSrc(trackUrl), '_blank', 'noopener,noreferrer');
+			return;
+		}
 		if (isPanelBusy()) {
 			enqueueDownload(trackUrl);
 			return;

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -51,6 +51,7 @@ const GATE_PROGRESS_STAGES = new Set([
 	'preparing_logins',
 	'handling_gates',
 	'waiting_bandcamp_track',
+	'cancelling',
 ]);
 
 const ACTIVE_JOB_STAGES = new Set([
@@ -61,6 +62,7 @@ const ACTIVE_JOB_STAGES = new Set([
 	'waiting_bandcamp_track',
 	'downloading',
 	'processing_audio',
+	'cancelling',
 ]);
 
 interface BandcampAlbumTrackChoice {
@@ -703,7 +705,7 @@ export default function App() {
 
 	const cancelDownload = useCallback(async () => {
 		const jobId = job.jobId;
-		if (!jobId) return;
+		if (!jobId || cancelRequestedRef.current) return;
 		cancelRequestedRef.current = true;
 
 		try {
@@ -1046,6 +1048,7 @@ export default function App() {
 	});
 	const isHandlingGate =
 		step === 'gate' && GATE_PROGRESS_STAGES.has(job.progress?.stage ?? '');
+	const isCancelling = job.progress?.stage === 'cancelling';
 	const existingTagRows = (
 		[
 			{ key: 'title', label: 'Title' },
@@ -1327,7 +1330,7 @@ export default function App() {
 									onChange={(e) =>
 										updateOutputFormat(e.target.value as OutputFormat)
 									}
-									disabled={isLoading}
+									disabled={isLoading || isCancelling}
 								>
 									<option value="mp3-320">MP3 320 kbps</option>
 									<option value="flac">FLAC</option>
@@ -1497,7 +1500,7 @@ export default function App() {
 									type="button"
 									className="btn-secondary btn-cancel-download"
 									onClick={() => void cancelDownload()}
-									disabled={isLoading}
+									disabled={isLoading || isCancelling}
 								>
 									Cancel download
 								</button>
@@ -1561,6 +1564,7 @@ export default function App() {
 									type="button"
 									className="btn-secondary btn-cancel-download"
 									onClick={() => void cancelDownload()}
+									disabled={isCancelling}
 								>
 									Cancel download
 								</button>

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -342,7 +342,7 @@ export default function App() {
 				if (response.ok) {
 					const capabilities = await response.json();
 					modes = parseAvailableBrowserModes(capabilities);
-					viewUrl = parseBrowserViewUrl(capabilities);
+					viewUrl = parseBrowserViewUrl(capabilities, window.location.hostname);
 				}
 			} catch {
 				// Keep the portable modes when the API is unavailable.

--- a/webui/src/components/RemoteBrowserPanel.css
+++ b/webui/src/components/RemoteBrowserPanel.css
@@ -269,6 +269,7 @@
 	flex: 1;
 	min-height: 0;
 	overflow: auto;
+	touch-action: none;
 	background: #000;
 	border-radius: 0 0 11px 11px;
 }

--- a/webui/src/components/RemoteBrowserPanel.tsx
+++ b/webui/src/components/RemoteBrowserPanel.tsx
@@ -46,8 +46,8 @@ const MAX_ZOOM = 2;
 const ZOOM_STEP = 0.25;
 const FINE_ZOOM_STEP = 0.05;
 const ZOOM_DRAG_PER_PIXEL = FINE_ZOOM_STEP / 20;
-const TOUCH_ZOOM_HOLD_MS = 450;
-const TOUCH_HOLD_MOVE_TOLERANCE = 8;
+const TOUCH_LONG_PRESS_MS = 550;
+const TOUCH_MOVE_TOLERANCE = 10;
 
 type ZoomAnchor = {
 	x: number;
@@ -623,6 +623,222 @@ export function RemoteBrowserPanel({
 		};
 	}, [updateZoom]);
 
+	useEffect(() => {
+		const screen = screenContainerRef.current;
+		if (!screen) return;
+
+		type TouchSession = {
+			identifier: number;
+			startX: number;
+			startY: number;
+			lastX: number;
+			lastY: number;
+			moved: boolean;
+			longPressed: boolean;
+			multiple: boolean;
+			holdTimer: number;
+		};
+
+		let session: TouchSession | null = null;
+		let panCenter: { x: number; y: number } | null = null;
+
+		const touchByIdentifier = (touches: TouchList, identifier: number) => {
+			for (let index = 0; index < touches.length; index += 1) {
+				const touch = touches.item(index);
+				if (touch?.identifier === identifier) return touch;
+			}
+			return null;
+		};
+
+		const touchCenter = (touches: TouchList) => {
+			if (touches.length < 2) return null;
+			const first = touches.item(0);
+			const second = touches.item(1);
+			if (!first || !second) return null;
+			return {
+				x: (first.clientX + second.clientX) / 2,
+				y: (first.clientY + second.clientY) / 2,
+			};
+		};
+
+		const clearHoldTimer = () => {
+			if (!session?.holdTimer) return;
+			window.clearTimeout(session.holdTimer);
+			session.holdTimer = 0;
+		};
+
+		const dispatchRemoteMouse = (
+			type: 'mousedown' | 'mousemove' | 'mouseup',
+			clientX: number,
+			clientY: number,
+			button = 0,
+			buttons = 0,
+		) => {
+			const canvas = screenRef.current?.querySelector('canvas');
+			if (!canvas) return;
+			remotePointerPositionRef.current = { x: clientX, y: clientY };
+			canvas.dispatchEvent(
+				new MouseEvent(type, {
+					bubbles: true,
+					cancelable: true,
+					view: window,
+					button,
+					buttons,
+					clientX,
+					clientY,
+				}),
+			);
+		};
+
+		const clickRemote = (clientX: number, clientY: number, button: 0 | 2) => {
+			const buttons = button === 2 ? 2 : 1;
+			dispatchRemoteMouse('mousemove', clientX, clientY);
+			dispatchRemoteMouse('mousedown', clientX, clientY, button, buttons);
+			dispatchRemoteMouse('mouseup', clientX, clientY, button);
+		};
+
+		const finishPan = () => {
+			panCenter = null;
+			if (viewportInteractionRef.current === 'pan') {
+				viewportInteractionRef.current = null;
+			}
+			screen.classList.remove('is-panning');
+		};
+
+		const handleTouchStart = (event: TouchEvent) => {
+			event.preventDefault();
+			event.stopImmediatePropagation();
+			suppressRemoteClickRef.current = false;
+
+			if (event.touches.length >= 2) {
+				if (session) session.multiple = true;
+				clearHoldTimer();
+				panCenter = touchCenter(event.touches);
+				if (zoomRef.current > MIN_ZOOM) {
+					viewportInteractionRef.current = 'pan';
+					screen.classList.add('is-panning');
+				}
+				return;
+			}
+
+			const touch = event.touches.item(0);
+			if (!touch) return;
+			session = {
+				identifier: touch.identifier,
+				startX: touch.clientX,
+				startY: touch.clientY,
+				lastX: touch.clientX,
+				lastY: touch.clientY,
+				moved: false,
+				longPressed: false,
+				multiple: false,
+				holdTimer: 0,
+			};
+			session.holdTimer = window.setTimeout(() => {
+				if (!session || session.moved || session.multiple) return;
+				session.longPressed = true;
+				clickRemote(session.lastX, session.lastY, 2);
+			}, TOUCH_LONG_PRESS_MS);
+		};
+
+		const handleTouchMove = (event: TouchEvent) => {
+			event.preventDefault();
+			event.stopImmediatePropagation();
+
+			if (event.touches.length >= 2) {
+				if (session) session.multiple = true;
+				clearHoldTimer();
+				const nextCenter = touchCenter(event.touches);
+				if (zoomRef.current > MIN_ZOOM && panCenter && nextCenter) {
+					screen.scrollLeft -= nextCenter.x - panCenter.x;
+					screen.scrollTop -= nextCenter.y - panCenter.y;
+				}
+				panCenter = nextCenter;
+				return;
+			}
+
+			if (!session || session.multiple) return;
+			const touch = touchByIdentifier(event.touches, session.identifier);
+			if (!touch) return;
+			session.lastX = touch.clientX;
+			session.lastY = touch.clientY;
+			if (
+				Math.hypot(
+					touch.clientX - session.startX,
+					touch.clientY - session.startY,
+				) > TOUCH_MOVE_TOLERANCE
+			) {
+				session.moved = true;
+				clearHoldTimer();
+			}
+			if (session.moved) {
+				dispatchRemoteMouse('mousemove', touch.clientX, touch.clientY);
+			}
+		};
+
+		const handleTouchEnd = (event: TouchEvent) => {
+			event.preventDefault();
+			event.stopImmediatePropagation();
+			if (event.touches.length > 0) {
+				if (event.touches.length < 2) finishPan();
+				return;
+			}
+
+			clearHoldTimer();
+			finishPan();
+			if (
+				session &&
+				!session.moved &&
+				!session.longPressed &&
+				!session.multiple
+			) {
+				const touch = touchByIdentifier(
+					event.changedTouches,
+					session.identifier,
+				);
+				clickRemote(
+					touch?.clientX ?? session.lastX,
+					touch?.clientY ?? session.lastY,
+					0,
+				);
+			}
+			session = null;
+		};
+
+		const handleTouchCancel = (event: TouchEvent) => {
+			event.preventDefault();
+			event.stopImmediatePropagation();
+			clearHoldTimer();
+			finishPan();
+			session = null;
+		};
+
+		screen.addEventListener('touchstart', handleTouchStart, {
+			capture: true,
+			passive: false,
+		});
+		screen.addEventListener('touchmove', handleTouchMove, {
+			capture: true,
+			passive: false,
+		});
+		screen.addEventListener('touchend', handleTouchEnd, {
+			capture: true,
+			passive: false,
+		});
+		screen.addEventListener('touchcancel', handleTouchCancel, {
+			capture: true,
+			passive: false,
+		});
+		return () => {
+			clearHoldTimer();
+			finishPan();
+			screen.removeEventListener('touchstart', handleTouchStart, true);
+			screen.removeEventListener('touchmove', handleTouchMove, true);
+			screen.removeEventListener('touchend', handleTouchEnd, true);
+			screen.removeEventListener('touchcancel', handleTouchCancel, true);
+		};
+	}, []);
+
 	const resetBrowserView = () => {
 		const canvas = screenRef.current?.querySelector('canvas');
 		if (canvas?.width && canvas.height) {
@@ -678,10 +894,7 @@ export function RemoteBrowserPanel({
 		window.addEventListener('pointercancel', handleEnd);
 	};
 
-	const beginViewportZoom = (
-		event: ReactPointerEvent<HTMLDivElement>,
-		delayed = false,
-	) => {
+	const beginViewportZoom = (event: ReactPointerEvent<HTMLDivElement>) => {
 		if (event.button !== 0 || !event.isPrimary) return;
 		const screen = screenContainerRef.current;
 		if (!screen) return;
@@ -693,37 +906,13 @@ export function RemoteBrowserPanel({
 			x: startX - bounds.left - screen.clientLeft,
 			y: startY - bounds.top - screen.clientTop,
 		};
-		let zooming = !delayed;
-		let holdTimer = 0;
-
-		const activate = () => {
-			zooming = true;
-			viewportInteractionRef.current = 'zoom';
-			suppressRemoteClickRef.current = true;
-			screen.classList.add('is-zooming');
-			if (delayed) {
-				window.dispatchEvent(new Event(REMOTE_POINTER_RELEASE_EVENT));
-			}
-		};
-
-		if (delayed) {
-			holdTimer = window.setTimeout(activate, TOUCH_ZOOM_HOLD_MS);
-		} else {
-			event.preventDefault();
-			event.stopPropagation();
-			activate();
-		}
+		event.preventDefault();
+		event.stopPropagation();
+		viewportInteractionRef.current = 'zoom';
+		suppressRemoteClickRef.current = true;
+		screen.classList.add('is-zooming');
 
 		const handleMove = (moveEvent: PointerEvent) => {
-			if (!zooming) {
-				if (
-					Math.hypot(moveEvent.clientX - startX, moveEvent.clientY - startY) >
-					TOUCH_HOLD_MOVE_TOLERANCE
-				) {
-					window.clearTimeout(holdTimer);
-				}
-				return;
-			}
 			moveEvent.preventDefault();
 			moveEvent.stopPropagation();
 			const nextZoom =
@@ -734,7 +923,6 @@ export function RemoteBrowserPanel({
 			updateZoom(nextZoom, anchor);
 		};
 		const handleEnd = () => {
-			window.clearTimeout(holdTimer);
 			if (viewportInteractionRef.current === 'zoom') {
 				viewportInteractionRef.current = null;
 			}
@@ -757,10 +945,6 @@ export function RemoteBrowserPanel({
 		}
 		if (event.altKey) {
 			beginViewportZoom(event);
-			return;
-		}
-		if (event.pointerType === 'touch') {
-			beginViewportZoom(event, true);
 		}
 	};
 
@@ -992,15 +1176,29 @@ export function RemoteBrowserPanel({
 				<div
 					className={`remote-browser-screen${shiftHeld ? ' is-shift-held' : ''}${altHeld ? ' is-alt-held' : ''}`}
 					ref={screenContainerRef}
-					title="Shift-drag to pan. Alt-scroll or Alt-drag vertically to zoom. Long-press and drag vertically on touch."
+					title="Shift-drag to pan. Alt-scroll or Alt-drag vertically to zoom. On touch: drag the pointer, tap to click, hold to right-click, or use two fingers to pan while zoomed."
 					onPointerDownCapture={(event) => {
-						remotePointerPositionRef.current = {
-							x: event.clientX,
-							y: event.clientY,
-						};
 						beginViewportInteraction(event);
+						if (
+							!event.shiftKey &&
+							!event.altKey &&
+							event.pointerType !== 'touch'
+						) {
+							remotePointerPositionRef.current = {
+								x: event.clientX,
+								y: event.clientY,
+							};
+						}
 					}}
 					onPointerMoveCapture={(event) => {
+						if (
+							viewportInteractionRef.current ||
+							event.shiftKey ||
+							event.altKey ||
+							event.pointerType === 'touch'
+						) {
+							return;
+						}
 						remotePointerPositionRef.current = {
 							x: event.clientX,
 							y: event.clientY,

--- a/webui/src/components/RemoteBrowserPanel.tsx
+++ b/webui/src/components/RemoteBrowserPanel.tsx
@@ -9,6 +9,10 @@ import {
 	useState,
 } from 'react';
 import {
+	createMobileRemoteControls,
+	type MobileTouch,
+} from './mobileRemoteControls';
+import {
 	browserPasswordStorageKey,
 	browserRememberStorageKey,
 	browserViewWebSocketUrl,
@@ -627,44 +631,19 @@ export function RemoteBrowserPanel({
 		const screen = screenContainerRef.current;
 		if (!screen) return;
 
-		type TouchSession = {
-			identifier: number;
-			startX: number;
-			startY: number;
-			lastX: number;
-			lastY: number;
-			moved: boolean;
-			longPressed: boolean;
-			multiple: boolean;
-			holdTimer: number;
-		};
-
-		let session: TouchSession | null = null;
-		let panCenter: { x: number; y: number } | null = null;
-
-		const touchByIdentifier = (touches: TouchList, identifier: number) => {
+		const touchesFrom = (touches: TouchList): MobileTouch[] => {
+			const result: MobileTouch[] = [];
 			for (let index = 0; index < touches.length; index += 1) {
 				const touch = touches.item(index);
-				if (touch?.identifier === identifier) return touch;
+				if (touch) {
+					result.push({
+						identifier: touch.identifier,
+						clientX: touch.clientX,
+						clientY: touch.clientY,
+					});
+				}
 			}
-			return null;
-		};
-
-		const touchCenter = (touches: TouchList) => {
-			if (touches.length < 2) return null;
-			const first = touches.item(0);
-			const second = touches.item(1);
-			if (!first || !second) return null;
-			return {
-				x: (first.clientX + second.clientX) / 2,
-				y: (first.clientY + second.clientY) / 2,
-			};
-		};
-
-		const clearHoldTimer = () => {
-			if (!session?.holdTimer) return;
-			window.clearTimeout(session.holdTimer);
-			session.holdTimer = 0;
+			return result;
 		};
 
 		const dispatchRemoteMouse = (
@@ -697,120 +676,62 @@ export function RemoteBrowserPanel({
 			dispatchRemoteMouse('mouseup', clientX, clientY, button);
 		};
 
-		const finishPan = () => {
-			panCenter = null;
-			if (viewportInteractionRef.current === 'pan') {
-				viewportInteractionRef.current = null;
-			}
-			screen.classList.remove('is-panning');
-		};
+		const controls = createMobileRemoteControls({
+			getZoom: () => zoomRef.current,
+			moveTolerance: TOUCH_MOVE_TOLERANCE,
+			longPressMs: TOUCH_LONG_PRESS_MS,
+			schedule: (callback, delay) => {
+				const timer = window.setTimeout(callback, delay);
+				return () => window.clearTimeout(timer);
+			},
+			movePointer: (clientX, clientY) => {
+				dispatchRemoteMouse('mousemove', clientX, clientY);
+			},
+			click: clickRemote,
+			panBy: (deltaX, deltaY) => {
+				screen.scrollLeft -= deltaX;
+				screen.scrollTop -= deltaY;
+			},
+			setPanning: (active) => {
+				if (active) {
+					viewportInteractionRef.current = 'pan';
+					screen.classList.add('is-panning');
+				} else {
+					if (viewportInteractionRef.current === 'pan') {
+						viewportInteractionRef.current = null;
+					}
+					screen.classList.remove('is-panning');
+				}
+			},
+		});
 
 		const handleTouchStart = (event: TouchEvent) => {
 			event.preventDefault();
 			event.stopImmediatePropagation();
 			suppressRemoteClickRef.current = false;
-
-			if (event.touches.length >= 2) {
-				if (session) session.multiple = true;
-				clearHoldTimer();
-				panCenter = touchCenter(event.touches);
-				if (zoomRef.current > MIN_ZOOM) {
-					viewportInteractionRef.current = 'pan';
-					screen.classList.add('is-panning');
-				}
-				return;
-			}
-
-			const touch = event.touches.item(0);
-			if (!touch) return;
-			session = {
-				identifier: touch.identifier,
-				startX: touch.clientX,
-				startY: touch.clientY,
-				lastX: touch.clientX,
-				lastY: touch.clientY,
-				moved: false,
-				longPressed: false,
-				multiple: false,
-				holdTimer: 0,
-			};
-			session.holdTimer = window.setTimeout(() => {
-				if (!session || session.moved || session.multiple) return;
-				session.longPressed = true;
-				clickRemote(session.lastX, session.lastY, 2);
-			}, TOUCH_LONG_PRESS_MS);
+			controls.start(touchesFrom(event.touches));
 		};
 
 		const handleTouchMove = (event: TouchEvent) => {
 			event.preventDefault();
 			event.stopImmediatePropagation();
 
-			if (event.touches.length >= 2) {
-				if (session) session.multiple = true;
-				clearHoldTimer();
-				const nextCenter = touchCenter(event.touches);
-				if (zoomRef.current > MIN_ZOOM && panCenter && nextCenter) {
-					screen.scrollLeft -= nextCenter.x - panCenter.x;
-					screen.scrollTop -= nextCenter.y - panCenter.y;
-				}
-				panCenter = nextCenter;
-				return;
-			}
-
-			if (!session || session.multiple) return;
-			const touch = touchByIdentifier(event.touches, session.identifier);
-			if (!touch) return;
-			session.lastX = touch.clientX;
-			session.lastY = touch.clientY;
-			if (
-				Math.hypot(
-					touch.clientX - session.startX,
-					touch.clientY - session.startY,
-				) > TOUCH_MOVE_TOLERANCE
-			) {
-				session.moved = true;
-				clearHoldTimer();
-			}
-			if (session.moved) {
-				dispatchRemoteMouse('mousemove', touch.clientX, touch.clientY);
-			}
+			controls.move(touchesFrom(event.touches));
 		};
 
 		const handleTouchEnd = (event: TouchEvent) => {
 			event.preventDefault();
 			event.stopImmediatePropagation();
-			if (event.touches.length > 0) {
-				if (event.touches.length < 2) finishPan();
-				return;
-			}
-
-			clearHoldTimer();
-			finishPan();
-			if (
-				session &&
-				!session.moved &&
-				!session.longPressed &&
-				!session.multiple
-			) {
-				const touch = touchByIdentifier(
-					event.changedTouches,
-					session.identifier,
-				);
-				clickRemote(
-					touch?.clientX ?? session.lastX,
-					touch?.clientY ?? session.lastY,
-					0,
-				);
-			}
-			session = null;
+			controls.end(
+				touchesFrom(event.touches),
+				touchesFrom(event.changedTouches),
+			);
 		};
 
 		const handleTouchCancel = (event: TouchEvent) => {
 			event.preventDefault();
 			event.stopImmediatePropagation();
-			clearHoldTimer();
-			finishPan();
-			session = null;
+			controls.cancel();
 		};
 
 		screen.addEventListener('touchstart', handleTouchStart, {
@@ -830,8 +751,7 @@ export function RemoteBrowserPanel({
 			passive: false,
 		});
 		return () => {
-			clearHoldTimer();
-			finishPan();
+			controls.cancel();
 			screen.removeEventListener('touchstart', handleTouchStart, true);
 			screen.removeEventListener('touchmove', handleTouchMove, true);
 			screen.removeEventListener('touchend', handleTouchEnd, true);

--- a/webui/src/components/deepLink.ts
+++ b/webui/src/components/deepLink.ts
@@ -51,13 +51,22 @@ export function parseAvailableBrowserModes(value: unknown): BrowserMode[] {
 	return parsed.length > 0 ? parsed : ['headless', 'headed'];
 }
 
-export function parseBrowserViewUrl(value: unknown): string | null {
+export function parseBrowserViewUrl(
+	value: unknown,
+	currentHostname?: string,
+): string | null {
 	if (!value || typeof value !== 'object') return null;
 	const browserViewUrl = (value as { browserViewUrl?: unknown }).browserViewUrl;
 	if (typeof browserViewUrl !== 'string') return null;
 
 	try {
-		const url = new URL(browserViewUrl);
+		const hostname = currentHostname?.includes(':')
+			? `[${currentHostname.replace(/^\[|\]$/g, '')}]`
+			: currentHostname;
+		const resolvedUrl = hostname
+			? browserViewUrl.replaceAll('{host}', hostname)
+			: browserViewUrl;
+		const url = new URL(resolvedUrl);
 		return url.protocol === 'http:' || url.protocol === 'https:'
 			? url.href
 			: null;

--- a/webui/src/components/mobileRemoteControls.ts
+++ b/webui/src/components/mobileRemoteControls.ts
@@ -1,0 +1,164 @@
+export type MobileTouch = {
+	identifier: number;
+	clientX: number;
+	clientY: number;
+};
+
+type MobileRemoteControlOptions = {
+	getZoom: () => number;
+	moveTolerance: number;
+	longPressMs: number;
+	schedule: (callback: () => void, delay: number) => () => void;
+	movePointer: (clientX: number, clientY: number) => void;
+	click: (clientX: number, clientY: number, button: 0 | 2) => void;
+	panBy: (deltaX: number, deltaY: number) => void;
+	setPanning: (active: boolean) => void;
+};
+
+type TouchSession = {
+	identifier: number;
+	startX: number;
+	startY: number;
+	lastX: number;
+	lastY: number;
+	moved: boolean;
+	longPressed: boolean;
+	multiple: boolean;
+	cancelHold: (() => void) | null;
+};
+
+const centerOfFirstTwoTouches = (touches: readonly MobileTouch[]) => {
+	if (touches.length < 2) return null;
+	return {
+		x: (touches[0].clientX + touches[1].clientX) / 2,
+		y: (touches[0].clientY + touches[1].clientY) / 2,
+	};
+};
+
+export function createMobileRemoteControls({
+	getZoom,
+	moveTolerance,
+	longPressMs,
+	schedule,
+	movePointer,
+	click,
+	panBy,
+	setPanning,
+}: MobileRemoteControlOptions) {
+	let session: TouchSession | null = null;
+	let panCenter: { x: number; y: number } | null = null;
+
+	const cancelHold = () => {
+		session?.cancelHold?.();
+		if (session) session.cancelHold = null;
+	};
+
+	const finishPan = () => {
+		panCenter = null;
+		setPanning(false);
+	};
+
+	const startSingleTouch = (touch: MobileTouch, moved = false) => {
+		session = {
+			identifier: touch.identifier,
+			startX: touch.clientX,
+			startY: touch.clientY,
+			lastX: touch.clientX,
+			lastY: touch.clientY,
+			moved,
+			longPressed: false,
+			multiple: false,
+			cancelHold: null,
+		};
+		if (moved) return;
+		session.cancelHold = schedule(() => {
+			if (!session || session.moved || session.multiple) return;
+			session.longPressed = true;
+			click(session.lastX, session.lastY, 2);
+		}, longPressMs);
+	};
+
+	return {
+		start(touches: readonly MobileTouch[]) {
+			if (touches.length >= 2) {
+				if (session) session.multiple = true;
+				cancelHold();
+				panCenter = centerOfFirstTwoTouches(touches);
+				setPanning(getZoom() > 1);
+				return;
+			}
+			if (touches[0]) startSingleTouch(touches[0]);
+		},
+
+		move(touches: readonly MobileTouch[]) {
+			if (touches.length >= 2) {
+				if (session) session.multiple = true;
+				cancelHold();
+				const nextCenter = centerOfFirstTwoTouches(touches);
+				if (getZoom() > 1 && panCenter && nextCenter) {
+					panBy(nextCenter.x - panCenter.x, nextCenter.y - panCenter.y);
+				}
+				panCenter = nextCenter;
+				return;
+			}
+
+			if (!session || session.multiple) return;
+			const touch = touches.find(
+				(candidate) => candidate.identifier === session?.identifier,
+			);
+			if (!touch) return;
+			session.lastX = touch.clientX;
+			session.lastY = touch.clientY;
+			if (
+				Math.hypot(
+					touch.clientX - session.startX,
+					touch.clientY - session.startY,
+				) > moveTolerance
+			) {
+				session.moved = true;
+				cancelHold();
+			}
+			if (session.moved) movePointer(touch.clientX, touch.clientY);
+		},
+
+		end(
+			touches: readonly MobileTouch[],
+			changedTouches: readonly MobileTouch[],
+		) {
+			if (touches.length > 0) {
+				if (touches.length < 2) {
+					finishPan();
+					if (touches[0]) {
+						startSingleTouch(touches[0], true);
+					}
+				}
+				return;
+			}
+
+			cancelHold();
+			finishPan();
+			if (
+				session &&
+				!session.moved &&
+				!session.longPressed &&
+				!session.multiple
+			) {
+				const touch = changedTouches.find(
+					(candidate) => candidate.identifier === session?.identifier,
+				);
+				click(
+					touch?.clientX ?? session.lastX,
+					touch?.clientY ?? session.lastY,
+					0,
+				);
+			}
+			session = null;
+		},
+
+		cancel() {
+			cancelHold();
+			finishPan();
+			session = null;
+		},
+	};
+}

--- a/webui/src/components/remoteBrowser.test.ts
+++ b/webui/src/components/remoteBrowser.test.ts
@@ -9,6 +9,10 @@ import {
 	shouldBlockRemoteMouseEvent,
 } from './remoteBrowser';
 
+const panelSource = await Bun.file(
+	new URL('./RemoteBrowserPanel.tsx', import.meta.url),
+).text();
+
 describe('browserViewWebSocketUrl', () => {
 	test('converts a noVNC page URL to its WebSocket endpoint', () => {
 		expect(
@@ -44,11 +48,30 @@ describe('browserRememberStorageKey', () => {
 });
 
 describe('remote pointer release', () => {
-	test('lets the internal release reach noVNC during local touch zoom', () => {
+	test('lets the internal release reach noVNC during local viewport gestures', () => {
 		const release = markInternalRemotePointerRelease(new Event('mouseup'));
 		expect(shouldBlockRemoteMouseEvent(release, true, true)).toBeFalse();
 		expect(
 			shouldBlockRemoteMouseEvent(new Event('mouseup'), true, true),
 		).toBeTrue();
+	});
+});
+
+describe('mobile remote controls', () => {
+	test('owns touch events before noVNC and maps the requested gestures', () => {
+		expect(panelSource).toContain("screen.addEventListener('touchstart'");
+		expect(panelSource).toContain("dispatchRemoteMouse('mousemove'");
+		expect(panelSource).toContain(
+			'clickRemote(session.lastX, session.lastY, 2)',
+		);
+		expect(panelSource).toContain(
+			'screen.scrollLeft -= nextCenter.x - panCenter.x',
+		);
+	});
+
+	test('does not reuse the touch pointer while a local viewport gesture runs', () => {
+		expect(panelSource).toContain("event.pointerType === 'touch'");
+		expect(panelSource).toContain('viewportInteractionRef.current ||');
+		expect(panelSource).not.toContain('beginViewportZoom(event, true)');
 	});
 });

--- a/webui/src/components/remoteBrowser.test.ts
+++ b/webui/src/components/remoteBrowser.test.ts
@@ -1,6 +1,7 @@
 /// <reference types="bun" />
 
 import { describe, expect, test } from 'bun:test';
+import { createMobileRemoteControls } from './mobileRemoteControls';
 import {
 	browserPasswordStorageKey,
 	browserRememberStorageKey,
@@ -8,10 +9,6 @@ import {
 	markInternalRemotePointerRelease,
 	shouldBlockRemoteMouseEvent,
 } from './remoteBrowser';
-
-const panelSource = await Bun.file(
-	new URL('./RemoteBrowserPanel.tsx', import.meta.url),
-).text();
 
 describe('browserViewWebSocketUrl', () => {
 	test('converts a noVNC page URL to its WebSocket endpoint', () => {
@@ -58,20 +55,80 @@ describe('remote pointer release', () => {
 });
 
 describe('mobile remote controls', () => {
-	test('owns touch events before noVNC and maps the requested gestures', () => {
-		expect(panelSource).toContain("screen.addEventListener('touchstart'");
-		expect(panelSource).toContain("dispatchRemoteMouse('mousemove'");
-		expect(panelSource).toContain(
-			'clickRemote(session.lastX, session.lastY, 2)',
-		);
-		expect(panelSource).toContain(
-			'screen.scrollLeft -= nextCenter.x - panCenter.x',
-		);
+	const touch = (identifier: number, clientX: number, clientY: number) => ({
+		identifier,
+		clientX,
+		clientY,
 	});
 
-	test('does not reuse the touch pointer while a local viewport gesture runs', () => {
-		expect(panelSource).toContain("event.pointerType === 'touch'");
-		expect(panelSource).toContain('viewportInteractionRef.current ||');
-		expect(panelSource).not.toContain('beginViewportZoom(event, true)');
+	function setup(zoom = 2) {
+		const pointerMoves: Array<[number, number]> = [];
+		const clicks: Array<[number, number, 0 | 2]> = [];
+		const pans: Array<[number, number]> = [];
+		const panning: boolean[] = [];
+		let longPress: (() => void) | null = null;
+		const controls = createMobileRemoteControls({
+			getZoom: () => zoom,
+			moveTolerance: 10,
+			longPressMs: 550,
+			schedule: (callback) => {
+				longPress = callback;
+				return () => {
+					longPress = null;
+				};
+			},
+			movePointer: (x, y) => pointerMoves.push([x, y]),
+			click: (x, y, button) => clicks.push([x, y, button]),
+			panBy: (x, y) => pans.push([x, y]),
+			setPanning: (active) => panning.push(active),
+		});
+		return {
+			controls,
+			pointerMoves,
+			clicks,
+			pans,
+			panning,
+			fireLongPress: () => longPress?.(),
+		};
+	}
+
+	test('moves the pointer with one finger without clicking after a drag', () => {
+		const { controls, pointerMoves, clicks } = setup();
+		controls.start([touch(1, 20, 30)]);
+		controls.move([touch(1, 42, 55)]);
+		controls.end([], [touch(1, 42, 55)]);
+
+		expect(pointerMoves).toEqual([[42, 55]]);
+		expect(clicks).toEqual([]);
+	});
+
+	test('maps a tap to left-click and a stationary hold to right-click', () => {
+		const tap = setup();
+		tap.controls.start([touch(1, 20, 30)]);
+		tap.controls.end([], [touch(1, 20, 30)]);
+		expect(tap.clicks).toEqual([[20, 30, 0]]);
+
+		const hold = setup();
+		hold.controls.start([touch(1, 40, 50)]);
+		hold.fireLongPress();
+		hold.controls.end([], [touch(1, 40, 50)]);
+		expect(hold.clicks).toEqual([[40, 50, 2]]);
+	});
+
+	test('pans with two fingers and resumes pointer movement with the remainder', () => {
+		const { controls, pans, panning, pointerMoves, clicks } = setup();
+		const first = touch(1, 20, 30);
+		const second = touch(2, 60, 70);
+		controls.start([first]);
+		controls.start([first, second]);
+		controls.move([touch(1, 30, 45), touch(2, 70, 85)]);
+		controls.end([touch(1, 30, 45)], [touch(2, 70, 85)]);
+		controls.move([touch(1, 36, 53)]);
+		controls.end([], [touch(1, 36, 53)]);
+
+		expect(pans).toEqual([[10, 15]]);
+		expect(panning).toContain(true);
+		expect(pointerMoves).toEqual([[36, 53]]);
+		expect(clicks).toEqual([]);
 	});
 });


### PR DESCRIPTION
Mobile control of the remote browser was awkward: touch zoom competed with noVNC input, clicks could land away from the tracked cursor, and a zoomed view could not be panned naturally.

This replaces the competing touch-to-zoom path with a coordinated mobile gesture layer. One-finger dragging moves the remote pointer, tapping left-clicks, a stationary long-press right-clicks, and two-finger dragging pans the local viewport while zoomed. Local zoom and pan gestures no longer update or release the remote pointer at unrelated coordinates. The touchscreen controls are also documented in the README.

Validation:
- `bun test` (125 passing)
- `bunx biome check webui/src/components/RemoteBrowserPanel.tsx webui/src/components/RemoteBrowserPanel.css webui/src/components/remoteBrowser.test.ts`
- `bunx tsc --noEmit -p webui/tsconfig.json`
- `git diff --check`

Prepared by OpenAI GPT-5 in the Codex desktop harness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added touchscreen controls for remote browser viewing, including pointer movement, tap-to-click, long-press right-click, and two-finger panning while zoomed.
  * Added dynamic browser-view URLs based on the current host.
  * Added an option to always open downloads in a new browser tab.

* **Bug Fixes**
  * Improved cancellation handling so jobs remain cancellable until cleanup completes.
  * Improved touch and pointer responsiveness during viewport interactions.

* **Documentation**
  * Added guidance for touchscreen controls, dynamic viewer URLs, LAN/Tailscale access, and security configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->