### PR TITLE
feat: add remote browser controls help tip

### DIFF
--- a/webui/src/components/RemoteBrowserPanel.css
+++ b/webui/src/components/RemoteBrowserPanel.css
@@ -145,6 +145,84 @@
 	font-size: 1rem;
 }
 
+.remote-browser-help {
+	position: relative;
+	flex: none;
+}
+
+.remote-browser-help-trigger {
+	display: grid;
+	place-items: center;
+	width: 22px;
+	height: 22px;
+	padding: 0;
+	font: 700 0.8rem/1 inherit;
+	color: var(--text-secondary);
+	background: transparent;
+	border: 1px solid var(--border-strong);
+	border-radius: 999px;
+	cursor: help;
+}
+
+.remote-browser-help-trigger:hover,
+.remote-browser-help.is-open .remote-browser-help-trigger,
+.remote-browser-help:focus-within .remote-browser-help-trigger {
+	color: var(--neon-cyan);
+	border-color: var(--neon-cyan);
+}
+
+.remote-browser-help-panel {
+	position: absolute;
+	top: calc(100% + 8px);
+	left: 0;
+	z-index: 5;
+	width: min(280px, calc(100vw - 32px));
+	padding: var(--space-sm) var(--space-md);
+	color: var(--text-primary);
+	font-size: 0.8rem;
+	line-height: 1.35;
+	text-align: left;
+	pointer-events: none;
+	visibility: hidden;
+	opacity: 0;
+	background: var(--bg-elevated);
+	border: 1px solid var(--border-strong);
+	border-radius: 8px;
+	box-shadow: 0 10px 28px rgb(0 0 0 / 35%);
+	transition:
+		opacity 120ms ease,
+		visibility 120ms ease;
+}
+
+.remote-browser-help:hover .remote-browser-help-panel,
+.remote-browser-help:focus-within .remote-browser-help-panel,
+.remote-browser-help.is-open .remote-browser-help-panel {
+	pointer-events: auto;
+	visibility: visible;
+	opacity: 1;
+}
+
+.remote-browser-help-panel p {
+	margin: 0 0 4px;
+}
+
+.remote-browser-help-panel p + ul {
+	margin-top: 0;
+}
+
+.remote-browser-help-panel ul {
+	margin: 0 0 10px;
+	padding-left: 1.1em;
+}
+
+.remote-browser-help-panel ul:last-child {
+	margin-bottom: 0;
+}
+
+.remote-browser-help-panel li + li {
+	margin-top: 2px;
+}
+
 .remote-browser-toolbar button {
 	padding: var(--space-xs) var(--space-sm);
 	color: var(--text-secondary);
@@ -476,6 +554,11 @@
 
 	.remote-browser-toolbar-heading h2 {
 		display: none;
+	}
+
+	.remote-browser-help-panel {
+		left: auto;
+		right: 0;
 	}
 
 	.remote-browser-zoom button:nth-child(2) {

--- a/webui/src/components/RemoteBrowserPanel.tsx
+++ b/webui/src/components/RemoteBrowserPanel.tsx
@@ -123,13 +123,15 @@ export function RemoteBrowserPanel({
 			}
 		};
 		const onKeyDown = (event: KeyboardEvent) => {
-			if (event.key === 'Escape') setControlsHelpOpen(false);
+			if (event.key !== 'Escape') return;
+			event.stopImmediatePropagation();
+			setControlsHelpOpen(false);
 		};
 		window.addEventListener('pointerdown', closeHelp, true);
-		window.addEventListener('keydown', onKeyDown);
+		window.addEventListener('keydown', onKeyDown, true);
 		return () => {
 			window.removeEventListener('pointerdown', closeHelp, true);
-			window.removeEventListener('keydown', onKeyDown);
+			window.removeEventListener('keydown', onKeyDown, true);
 		};
 	}, [controlsHelpOpen]);
 

--- a/webui/src/components/RemoteBrowserPanel.tsx
+++ b/webui/src/components/RemoteBrowserPanel.tsx
@@ -107,6 +107,35 @@ export function RemoteBrowserPanel({
 	const [remember, setRemember] = useState(true);
 	const [status, setStatus] = useState<ConnectionStatus>('idle');
 	const [error, setError] = useState<string | null>(null);
+	const [controlsHelpOpen, setControlsHelpOpen] = useState(false);
+	const controlsHelpRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (!controlsHelpOpen) return;
+		const closeHelp = (event: Event) => {
+			const root = controlsHelpRef.current;
+			if (
+				root &&
+				event.target instanceof Node &&
+				!root.contains(event.target)
+			) {
+				setControlsHelpOpen(false);
+			}
+		};
+		const onKeyDown = (event: KeyboardEvent) => {
+			if (event.key === 'Escape') setControlsHelpOpen(false);
+		};
+		window.addEventListener('pointerdown', closeHelp, true);
+		window.addEventListener('keydown', onKeyDown);
+		return () => {
+			window.removeEventListener('pointerdown', closeHelp, true);
+			window.removeEventListener('keydown', onKeyDown);
+		};
+	}, [controlsHelpOpen]);
+
+	useEffect(() => {
+		if (!open) setControlsHelpOpen(false);
+	}, [open]);
 
 	const updateGeometry = useCallback((nextGeometry: typeof geometry) => {
 		geometryRef.current = nextGeometry;
@@ -986,6 +1015,50 @@ export function RemoteBrowserPanel({
 				>
 					<div className="remote-browser-toolbar-heading">
 						<h2 id="remote-browser-title">Remote Browser</h2>
+						<div
+							ref={controlsHelpRef}
+							className={`remote-browser-help${controlsHelpOpen ? ' is-open' : ''}`}
+						>
+							<button
+								type="button"
+								className="remote-browser-help-trigger"
+								aria-label="How to control the remote browser"
+								aria-expanded={controlsHelpOpen}
+								aria-controls="remote-browser-controls-help"
+								title="Controls help"
+								onClick={(event) => {
+									event.stopPropagation();
+									setControlsHelpOpen((value) => !value);
+								}}
+								onPointerDown={(event) => event.stopPropagation()}
+							>
+								?
+							</button>
+							<div
+								id="remote-browser-controls-help"
+								className="remote-browser-help-panel"
+								role="tooltip"
+							>
+								<p>
+									<strong>Mouse</strong>
+								</p>
+								<ul>
+									<li>Click or drag to use the remote desktop</li>
+									<li>Shift-drag to pan the view</li>
+									<li>Alt-scroll or Alt-drag vertically to zoom</li>
+								</ul>
+								<p>
+									<strong>Touch</strong>
+								</p>
+								<ul>
+									<li>Drag to move the remote pointer</li>
+									<li>Tap to click at the pointer</li>
+									<li>Hold and release to right-click</li>
+									<li>Hold, then drag vertically to zoom</li>
+									<li>Two fingers to pan while zoomed</li>
+								</ul>
+							</div>
+						</div>
 						<span
 							className={`remote-browser-status is-${status}`}
 							role="status"
@@ -1146,7 +1219,6 @@ export function RemoteBrowserPanel({
 				<div
 					className={`remote-browser-screen${shiftHeld ? ' is-shift-held' : ''}${altHeld ? ' is-alt-held' : ''}`}
 					ref={screenContainerRef}
-					title="Shift-drag to pan. Alt-scroll or Alt-drag vertically to zoom. On touch: drag the pointer, tap to click at its current position, hold and release to right-click, hold then drag vertically to zoom, or use two fingers to pan while zoomed."
 					onPointerDownCapture={(event) => {
 						beginViewportInteraction(event);
 						if (


### PR DESCRIPTION
The remote browser control gestures were only documented in a long native `title` tooltip on the screen, which is easy to miss and awkward on mobile.

Add a small `?` control next to the Remote Browser header title that shows mouse/keyboard/touch shortcuts on hover (desktop) or tap (mobile). Outside tap or Escape closes the pinned tip.

## Test plan
- [ ] Open the remote browser panel and hover the `?` — tip appears with mouse and touch sections
- [ ] Tap/click the `?` on a narrow/touch viewport — tip toggles open and closes on outside tap or Escape
- [ ] Confirm toolbar dragging still works and does not start when pressing `?`
- [ ] Confirm the screen no longer shows the old native title tooltip

Made with Cursor (Composer)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a help control to the remote browser toolbar with mouse and touch interaction instructions.
  * Help information can be opened or dismissed using the button, outside interaction, or the Escape key.
  * Help content automatically resets when the remote browser panel closes.
  * Improved help panel layout for narrow screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->