### PR TITLE
fix: cancel downloads when the userscript panel or tab closes

### DIFF
--- a/src/browserLaunch.test.ts
+++ b/src/browserLaunch.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import {
 	buildXvfbBrowserEnv,
+	CancellableBrowserLaunch,
 	createXvfbManager,
 	getGpuWorkaroundArgs,
 	isXvfbSupported,
@@ -116,5 +117,43 @@ describe('isXvfbSupported', () => {
 		expect(isXvfbSupported('linux')).toBeTrue();
 		expect(isXvfbSupported('darwin')).toBeFalse();
 		expect(isXvfbSupported('win32')).toBeFalse();
+	});
+});
+
+describe('CancellableBrowserLaunch', () => {
+	test('closes a browser that finishes launching after close()', async () => {
+		const events: string[] = [];
+		let resolveLaunch!: (browser: { close: () => Promise<void> }) => void;
+		const launchPromise = new Promise<{ close: () => Promise<void> }>(
+			(resolve) => {
+				resolveLaunch = resolve;
+			},
+		);
+
+		const session = new CancellableBrowserLaunch(
+			() => launchPromise as Promise<never>,
+		);
+		const launching = session.launch();
+		const closing = session.close();
+		let closed = false;
+		resolveLaunch({
+			close: async () => {
+				if (closed) return;
+				closed = true;
+				events.push('close');
+			},
+		});
+
+		await expect(launching).rejects.toThrow('Download cancelled');
+		await closing;
+		expect(events).toEqual(['close']);
+	});
+
+	test('rejects a late launch after close()', async () => {
+		const session = new CancellableBrowserLaunch(async () => {
+			throw new Error('should not launch');
+		});
+		await session.close();
+		await expect(session.launch()).rejects.toThrow('Download cancelled');
 	});
 });

--- a/src/browserLaunch.ts
+++ b/src/browserLaunch.ts
@@ -274,3 +274,62 @@ export async function launchAppBrowser(
 		throw error;
 	}
 }
+
+/**
+ * Tracks an in-flight Chromium launch so cancel can close the browser even when
+ * `close()` races `initialize()` before `this.browser` is assigned.
+ */
+export class CancellableBrowserLaunch {
+	private browser: Browser | undefined;
+	private inflight: Promise<Browser> | null = null;
+	private closed = false;
+
+	constructor(
+		private readonly launchBrowser: (
+			options?: AppBrowserLaunchOptions,
+		) => Promise<Browser> = launchAppBrowser,
+	) {}
+
+	async launch(options: AppBrowserLaunchOptions = {}): Promise<Browser> {
+		if (this.closed) {
+			throw new Error('Download cancelled');
+		}
+		const inflight = this.launchBrowser(options);
+		this.inflight = inflight;
+		try {
+			const browser = await inflight;
+			this.browser = browser;
+			if (this.closed) {
+				this.browser = undefined;
+				await browser.close().catch(() => {});
+				throw new Error('Download cancelled');
+			}
+			return browser;
+		} finally {
+			if (this.inflight === inflight) this.inflight = null;
+		}
+	}
+
+	async launchConfigured(config: HypedditConfig): Promise<Browser> {
+		return this.launch({
+			...browserModeToLaunchOptions(config.browserMode),
+			userDataDir: config.userDataDir ?? './browser-data',
+		});
+	}
+
+	async close(): Promise<void> {
+		this.closed = true;
+		const inflight = this.inflight;
+		if (inflight) {
+			try {
+				const browser = await inflight;
+				await browser.close().catch(() => {});
+			} catch {
+				// Launch failed or already closed after cancel.
+			}
+		}
+		const browser = this.browser;
+		this.browser = undefined;
+		await browser?.close().catch(() => {});
+	}
+}

--- a/src/downloadgater.ts
+++ b/src/downloadgater.ts
@@ -1,6 +1,6 @@
 import { Presets, SingleBar } from 'cli-progress';
 import type { Browser, Page } from 'puppeteer';
-import { launchConfiguredBrowser } from './browserLaunch';
+import { CancellableBrowserLaunch } from './browserLaunch';
 import type { ProgressCallback } from './hypeddit';
 import Selectors from './selectors';
 import { waitForSoundcloudLogin } from './soundcloudLogin';
@@ -9,6 +9,7 @@ import { loadCookies, timeout } from './utils';
 
 export class DownloadgaterDownloader {
 	private browser!: Browser;
+	private readonly browserLaunch = new CancellableBrowserLaunch();
 	private downloadFilename: string | null = null;
 	private config: HypedditConfig;
 	private progressCallback: ProgressCallback | null = null;
@@ -32,7 +33,7 @@ export class DownloadgaterDownloader {
 	}
 
 	async initialize() {
-		this.browser = await launchConfiguredBrowser(this.config);
+		this.browser = await this.browserLaunch.launchConfigured(this.config);
 
 		const browserContext = this.browser.defaultBrowserContext();
 		const soundCloudCookies = await loadCookies('soundcloud-cookies.json');
@@ -170,7 +171,7 @@ export class DownloadgaterDownloader {
 	async close() {
 		this.cancelPendingDownloadWait?.();
 		this.cancelPendingDownloadWait = null;
-		await this.browser?.close();
+		await this.browserLaunch.close();
 	}
 
 	private async clickFreeDownload(page: Page) {

--- a/src/droploud.ts
+++ b/src/droploud.ts
@@ -1,6 +1,6 @@
 import { Presets, SingleBar } from 'cli-progress';
 import type { Browser, Page } from 'puppeteer';
-import { launchConfiguredBrowser } from './browserLaunch';
+import { CancellableBrowserLaunch } from './browserLaunch';
 import type { ProgressCallback } from './hypeddit';
 import Selectors from './selectors';
 import { SoundcloudClient } from './soundcloud';
@@ -19,6 +19,7 @@ type PaneKind =
 
 export class DroploudDownloader {
 	private browser!: Browser;
+	private readonly browserLaunch = new CancellableBrowserLaunch();
 	private downloadFilename: string | null = null;
 	private config: HypedditConfig;
 	private progressCallback: ProgressCallback | null = null;
@@ -42,7 +43,7 @@ export class DroploudDownloader {
 	}
 
 	async initialize() {
-		this.browser = await launchConfiguredBrowser(this.config);
+		this.browser = await this.browserLaunch.launchConfigured(this.config);
 
 		const browserContext = this.browser.defaultBrowserContext();
 		const soundCloudCookies = await loadCookies('soundcloud-cookies.json');
@@ -179,7 +180,7 @@ export class DroploudDownloader {
 	async close() {
 		this.cancelPendingDownloadWait?.();
 		this.cancelPendingDownloadWait = null;
-		await this.browser?.close();
+		await this.browserLaunch.close();
 	}
 
 	private async dismissCookieBanner(page: Page) {

--- a/src/gateCancellation.test.ts
+++ b/src/gateCancellation.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from 'bun:test';
 import { DownloadgaterDownloader } from './downloadgater';
 import { DroploudDownloader } from './droploud';
+import { GaterushDownloader } from './gaterush';
 import { HypedditDownloader } from './hypeddit';
 import { MypresskitDownloader } from './mypresskit';
+import { PumpyoursoundDownloader } from './pumpyoursound';
 import { StillhypeDownloader } from './stillhype';
 import type { HypedditConfig } from './types';
 
@@ -30,7 +32,7 @@ async function expectPendingWaitCancelled(
 			events.push('cancel');
 			rejectPending(new Error('Download was canceled'));
 		},
-		browser: {
+		browserLaunch: {
 			close: async () => {
 				events.push('close');
 			},
@@ -46,6 +48,7 @@ async function expectPendingWaitCancelled(
 describe('browser gate cancellation', () => {
 	for (const [name, create] of [
 		['Droploud', () => new DroploudDownloader(config)],
+		['GateRush', () => new GaterushDownloader(config)],
 		['DownloadGater', () => new DownloadgaterDownloader(config)],
 		['StillHype', () => new StillhypeDownloader(config)],
 		['Hypeddit', () => new HypedditDownloader(config)],
@@ -64,7 +67,7 @@ describe('browser gate cancellation', () => {
 		});
 		Object.assign(downloader, {
 			downloadAbortController,
-			browser: {
+			browserLaunch: {
 				close: async () => {
 					events.push('close');
 				},
@@ -74,5 +77,26 @@ describe('browser gate cancellation', () => {
 		await downloader.close();
 
 		expect(events).toEqual(['abort', 'close']);
+	});
+
+	test('PumpYourSound closes its direct downloader before the browser', async () => {
+		const downloader = new PumpyoursoundDownloader(config);
+		const events: string[] = [];
+		Object.assign(downloader, {
+			directDownloader: {
+				close: async () => {
+					events.push('direct');
+				},
+			},
+			browserLaunch: {
+				close: async () => {
+					events.push('close');
+				},
+			},
+		});
+
+		await downloader.close();
+
+		expect(events).toEqual(['direct', 'close']);
 	});
 });

--- a/src/gaterush.ts
+++ b/src/gaterush.ts
@@ -1,6 +1,6 @@
 import { Presets, SingleBar } from 'cli-progress';
 import type { Browser, Page } from 'puppeteer';
-import { launchConfiguredBrowser } from './browserLaunch';
+import { CancellableBrowserLaunch } from './browserLaunch';
 import type { ProgressCallback } from './hypeddit';
 import Selectors from './selectors';
 import {
@@ -12,6 +12,7 @@ import { loadCookies, timeout } from './utils';
 
 export class GaterushDownloader {
 	private browser!: Browser;
+	private readonly browserLaunch = new CancellableBrowserLaunch();
 	private downloadFilename: string | null = null;
 	private config: HypedditConfig;
 	private progressCallback: ProgressCallback | null = null;
@@ -35,7 +36,7 @@ export class GaterushDownloader {
 	}
 
 	async initialize() {
-		this.browser = await launchConfiguredBrowser(this.config);
+		this.browser = await this.browserLaunch.launchConfigured(this.config);
 
 		const browserContext = this.browser.defaultBrowserContext();
 		const soundCloudCookies = await loadCookies('soundcloud-cookies.json');
@@ -135,7 +136,7 @@ export class GaterushDownloader {
 	async close() {
 		this.cancelPendingDownloadWait?.();
 		this.cancelPendingDownloadWait = null;
-		await this.browser?.close();
+		await this.browserLaunch.close();
 	}
 
 	private async dismissCookieBanner(page: Page) {

--- a/src/hypeddit.ts
+++ b/src/hypeddit.ts
@@ -1,6 +1,9 @@
 import { Presets, SingleBar } from 'cli-progress';
 import type { Browser, Page } from 'puppeteer';
-import { browserModeToLaunchOptions, launchAppBrowser } from './browserLaunch';
+import {
+	browserModeToLaunchOptions,
+	CancellableBrowserLaunch,
+} from './browserLaunch';
 import Selectors from './selectors';
 import { waitForSoundcloudLogin } from './soundcloudLogin';
 import type { HypedditConfig, JobProgress, JobStage } from './types';
@@ -22,6 +25,7 @@ interface GateDefinition {
 
 export class HypedditDownloader {
 	private browser!: Browser; // null-asserted because it is initialized async and every call to it comes logically after the init
+	private readonly browserLaunch = new CancellableBrowserLaunch();
 	private downloadFilename: string | null = null;
 	private config: HypedditConfig;
 	private spotifyCookiesExists = false;
@@ -102,7 +106,7 @@ export class HypedditDownloader {
 	}
 
 	async initialize() {
-		this.browser = await launchAppBrowser({
+		this.browser = await this.browserLaunch.launch({
 			...browserModeToLaunchOptions(this.config.browserMode),
 			userDataDir: this.config.userDataDir ?? './browser-data',
 		});
@@ -354,7 +358,7 @@ export class HypedditDownloader {
 	async close() {
 		this.cancelPendingDownloadWait?.();
 		this.cancelPendingDownloadWait = null;
-		await this.browser?.close();
+		await this.browserLaunch.close();
 	}
 
 	private async handleEmailSlide(page: Page) {

--- a/src/mypresskit.ts
+++ b/src/mypresskit.ts
@@ -2,7 +2,10 @@ import { mkdir, rm } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 import { Presets, SingleBar } from 'cli-progress';
 import type { Browser, Page } from 'puppeteer';
-import { browserModeToLaunchOptions, launchAppBrowser } from './browserLaunch';
+import {
+	browserModeToLaunchOptions,
+	CancellableBrowserLaunch,
+} from './browserLaunch';
 import type { ProgressCallback } from './hypeddit';
 import { safeFetch } from './safeOutboundUrl';
 import Selectors from './selectors';
@@ -63,6 +66,7 @@ function safePageUrl(page: Page): string {
 
 export class MypresskitDownloader {
 	private browser!: Browser;
+	private readonly browserLaunch = new CancellableBrowserLaunch();
 	private config: HypedditConfig;
 	private progressCallback: ProgressCallback | null = null;
 	private readonly downloadAbortController = new AbortController();
@@ -85,7 +89,7 @@ export class MypresskitDownloader {
 	}
 
 	async initialize() {
-		this.browser = await launchAppBrowser({
+		this.browser = await this.browserLaunch.launch({
 			...browserModeToLaunchOptions(this.config.browserMode),
 			userDataDir: this.config.userDataDir ?? './browser-data',
 			// SC OAuth authorize popup shares session cookies more reliably with this.
@@ -225,7 +229,7 @@ export class MypresskitDownloader {
 
 	async close() {
 		this.downloadAbortController.abort();
-		await this.browser?.close();
+		await this.browserLaunch.close();
 	}
 
 	private async dismissCookies(page: Page) {

--- a/src/pumpyoursound.ts
+++ b/src/pumpyoursound.ts
@@ -1,5 +1,8 @@
 import type { Browser, Page } from 'puppeteer';
-import { browserModeToLaunchOptions, launchAppBrowser } from './browserLaunch';
+import {
+	browserModeToLaunchOptions,
+	CancellableBrowserLaunch,
+} from './browserLaunch';
 import { DirectDownloader } from './directDownload';
 import type { ProgressCallback } from './hypeddit';
 import Selectors from './selectors';
@@ -22,6 +25,7 @@ const SC_AUTHORIZE_RE = /secure\.soundcloud\.com\/authorize/i;
  */
 export class PumpyoursoundDownloader {
 	private browser!: Browser;
+	private readonly browserLaunch = new CancellableBrowserLaunch();
 	private directDownloader: DirectDownloader | null = null;
 	private downloadFilename: string | null = null;
 	private config: HypedditConfig;
@@ -45,7 +49,7 @@ export class PumpyoursoundDownloader {
 	}
 
 	async initialize() {
-		this.browser = await launchAppBrowser({
+		this.browser = await this.browserLaunch.launch({
 			...browserModeToLaunchOptions(this.config.browserMode),
 			userDataDir: this.config.userDataDir ?? './browser-data',
 			// SC.connect authorize popup shares session cookies more reliably with this.
@@ -142,7 +146,7 @@ export class PumpyoursoundDownloader {
 
 	async close() {
 		await this.directDownloader?.close();
-		await this.browser?.close();
+		await this.browserLaunch.close();
 	}
 
 	private async dismissOverlays(page: Page) {

--- a/src/stillhype.ts
+++ b/src/stillhype.ts
@@ -2,7 +2,7 @@ import { mkdir, rm } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 import { Presets, SingleBar } from 'cli-progress';
 import type { Browser, HTTPResponse, Page } from 'puppeteer';
-import { launchConfiguredBrowser } from './browserLaunch';
+import { CancellableBrowserLaunch } from './browserLaunch';
 import type { ProgressCallback } from './hypeddit';
 import { safeFetch } from './safeOutboundUrl';
 import Selectors from './selectors';
@@ -49,6 +49,7 @@ function safePageUrl(page: Page): string {
 
 export class StillhypeDownloader {
 	private browser!: Browser;
+	private readonly browserLaunch = new CancellableBrowserLaunch();
 	private downloadFilename: string | null = null;
 	private config: HypedditConfig;
 	private progressCallback: ProgressCallback | null = null;
@@ -73,7 +74,7 @@ export class StillhypeDownloader {
 	}
 
 	async initialize() {
-		this.browser = await launchConfiguredBrowser(this.config);
+		this.browser = await this.browserLaunch.launchConfigured(this.config);
 
 		const browserContext = this.browser.defaultBrowserContext();
 		const soundCloudCookies = await loadCookies('soundcloud-cookies.json');
@@ -290,7 +291,7 @@ export class StillhypeDownloader {
 		this.cancelPendingDownloadWait?.();
 		this.cancelPendingDownloadWait = null;
 		this.downloadAbortController.abort();
-		await this.browser?.close();
+		await this.browserLaunch.close();
 	}
 
 	private async safeEvaluate<T>(

--- a/userscript/sc-gate-dl.test.ts
+++ b/userscript/sc-gate-dl.test.ts
@@ -186,4 +186,19 @@ describe('Web UI preferences', () => {
 			"window.addEventListener('pointerup', releaseRemotePointer, true)",
 		);
 	});
+
+	test('cancels active jobs via GM bridge on panel close and host unload', () => {
+		expect(source).toContain('function requestJobCancel(jobId)');
+		expect(source).toContain('gmXmlHttpRequest({');
+		expect(source).toContain("method: 'POST'");
+		expect(source).toContain(
+			"window.addEventListener('pagehide', cancelJobOnHostUnload)",
+		);
+		expect(source).toContain('await cancellation');
+		expect(source).toContain("iframe.src = 'about:blank'");
+		const cancelIdx = source.indexOf('await cancellation');
+		const blankIdx = source.indexOf("iframe.src = 'about:blank'");
+		expect(cancelIdx).toBeGreaterThan(-1);
+		expect(blankIdx).toBeGreaterThan(cancelIdx);
+	});
 });

--- a/userscript/sc-gate-dl.test.ts
+++ b/userscript/sc-gate-dl.test.ts
@@ -194,6 +194,9 @@ describe('Web UI preferences', () => {
 		expect(source).toContain(
 			"window.addEventListener('pagehide', cancelJobOnHostUnload)",
 		);
+		expect(source).toContain(
+			"window.addEventListener('beforeunload', cancelJobOnHostUnload)",
+		);
 		expect(source).toContain('await cancellation');
 		expect(source).toContain("iframe.src = 'about:blank'");
 		const cancelIdx = source.indexOf('await cancellation');

--- a/userscript/sc-gate-dl.user.js
+++ b/userscript/sc-gate-dl.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         sc-gate-dl
 // @namespace    https://github.com/D3SOX/sc-gate-dl
-// @version      1.11.4
+// @version      1.11.5
 // @description  Add sc-gate-dl download controls and remember your position in the SoundCloud feed
 // @author       D3SOX
 // @match        https://soundcloud.com/*
@@ -1236,16 +1236,20 @@
 	function requestJobCancel(jobId) {
 		const url = `${getApiBase()}/api/job/${encodeURIComponent(jobId)}/cancel`;
 		if (gmXmlHttpRequest) {
-			// Dispatch immediately; do not wait for teardown (browser close can take seconds).
-			gmXmlHttpRequest({
-				method: 'POST',
-				url,
-				anonymous: true,
-				onload: () => {},
-				onerror: () => {},
-				ontimeout: () => {},
-				onabort: () => {},
-			});
+			try {
+				// Dispatch immediately; do not wait for teardown (browser close can take seconds).
+				gmXmlHttpRequest({
+					method: 'POST',
+					url,
+					anonymous: true,
+					onload: () => {},
+					onerror: () => {},
+					ontimeout: () => {},
+					onabort: () => {},
+				});
+			} catch {
+				// Bridge may throw synchronously; panel cleanup must still continue.
+			}
 			return Promise.resolve();
 		}
 		return fetch(url, { method: 'POST', keepalive: true }).catch(() => {});

--- a/userscript/sc-gate-dl.user.js
+++ b/userscript/sc-gate-dl.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         sc-gate-dl
 // @namespace    https://github.com/D3SOX/sc-gate-dl
-// @version      1.11.3
+// @version      1.11.4
 // @description  Add sc-gate-dl download controls and remember your position in the SoundCloud feed
 // @author       D3SOX
 // @match        https://soundcloud.com/*
@@ -1232,6 +1232,25 @@
 			});
 	}
 
+	/** Cancel via GM bridge — page fetch to localhost is blocked by PNA. */
+	function requestJobCancel(jobId) {
+		const url = `${getApiBase()}/api/job/${encodeURIComponent(jobId)}/cancel`;
+		if (gmXmlHttpRequest) {
+			// Dispatch immediately; do not wait for teardown (browser close can take seconds).
+			gmXmlHttpRequest({
+				method: 'POST',
+				url,
+				anonymous: true,
+				onload: () => {},
+				onerror: () => {},
+				ontimeout: () => {},
+				onabort: () => {},
+			});
+			return Promise.resolve();
+		}
+		return fetch(url, { method: 'POST', keepalive: true }).catch(() => {});
+	}
+
 	async function isWebuiReachable(base) {
 		const urls = [`${base}/`, `${apiOriginFromWebui(base)}/api/capabilities`];
 		const seen = new Set();
@@ -2337,30 +2356,35 @@ a[${STORE_SERVICE_ATTR}] > button::after {
 				// ignore
 			}
 		}
-		try {
-			await fetch(
-				`${getApiBase()}/api/job/${encodeURIComponent(jobId)}/cancel`,
-				{
-					method: 'POST',
-				},
-			);
-		} catch {
-			// ignore — panel still closes
-		}
+		await requestJobCancel(jobId);
 		delete panel.dataset.jobId;
 	}
+
+	function cancelJobOnHostUnload() {
+		const panel = document.getElementById(PANEL_ID);
+		const jobId = panel?.dataset.jobId;
+		if (!jobId) return;
+		void requestJobCancel(jobId);
+		delete panel.dataset.jobId;
+	}
+
+	window.addEventListener('pagehide', cancelJobOnHostUnload);
+	window.addEventListener('beforeunload', cancelJobOnHostUnload);
 
 	async function closePanel() {
 		window.clearTimeout(autoCloseTimer);
 		const panel = document.getElementById(PANEL_ID);
 		if (!panel) return;
+		// Cancel via the GM bridge before tearing down the iframe — page fetch to
+		// localhost is blocked by Private Network Access, and blanking the iframe
+		// races the embedded WebUI's own unload cancel.
 		const cancellation = cancelActiveJob(panel);
+		await cancellation;
 		const iframe = panel.querySelector('iframe');
 		if (iframe) iframe.src = 'about:blank';
 		delete panel.dataset.trackUrl;
 		delete panel.dataset.jobId;
 		panel.hidden = true;
-		await cancellation;
 	}
 
 	function applyQueueGeom(el) {

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -455,15 +455,16 @@ export default function App() {
 			if (!jobId || !stage || !ACTIVE_JOB_STAGES.has(stage)) return;
 			cancelRequestedRef.current = true;
 			const url = `${API_BASE}/api/job/${encodeURIComponent(jobId)}/cancel`;
-			try {
-				if (navigator.sendBeacon(url)) return;
-			} catch {
-				// Fall back to a keepalive request below.
-			}
+			// Prefer keepalive fetch: sendBeacon is easy to drop for cross-origin
+			// POSTs, and pagehide is more reliable than beforeunload for iframes/tabs.
 			void fetch(url, { method: 'POST', keepalive: true }).catch(() => {});
 		};
+		window.addEventListener('pagehide', cancelJobOnUnload);
 		window.addEventListener('beforeunload', cancelJobOnUnload);
-		return () => window.removeEventListener('beforeunload', cancelJobOnUnload);
+		return () => {
+			window.removeEventListener('pagehide', cancelJobOnUnload);
+			window.removeEventListener('beforeunload', cancelJobOnUnload);
+		};
 	}, []);
 
 	const showCleanupSoundcloudToast = useCallback(() => {


### PR DESCRIPTION
Closing the userscript panel or SoundCloud tab while Chromium was starting often left the download running. Cancel from the host page used a normal `fetch` to localhost, which Chrome blocks via Private Network Access, and blanking the iframe raced the embedded UI’s unload handler. Separately, `close()` during an in-flight browser launch was a no-op, so the process that finished starting could stay orphaned.

This change routes host cancel through `GM_xmlhttpRequest`, cancels on `pagehide`/`beforeunload` before tearing down the iframe, hardens the WebUI unload path with keepalive `fetch`, and adds `CancellableBrowserLaunch` so cancel waits out launch and closes that browser.

## Test plan
- [ ] Start a gate download, close the userscript panel while status is “Launching browser…”, confirm the job cancels and Chromium exits
- [ ] Start a gate download, close the SoundCloud tab while the browser is up, confirm cancel reaches the API
- [ ] Cancel via the in-UI Cancel button still works as before
- [ ] Update/reinstall userscript 1.11.4 before testing the host-side path
- [ ] `bun test` for cancellation / browser launch / userscript suites

Implemented with Composer in Cursor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation during browser startup to prevent orphaned browser processes.
  * Downloads now shut down more reliably when cancelled or closed.
  * Active downloads are cancelled before page and iframe teardown.
  * Added cancellation handling when leaving or unloading the page.
* **Tests**
  * Expanded coverage for browser-launch cancellation, downloader cleanup, and page-exit cancellation.
* **Updates**
  * Updated the userscript version to 1.11.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->