### PR TITLE
feat: extract audio from ZIP downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Download and tag SoundCloud tracks unlocked via Hypeddit, Droploud, GateRush, Do
 - 🔄 Handles multiple gate types (see [How It Works](#how-it-works))
 - 📝 Fetches metadata from the provided SoundCloud link
 - 🎨 Manual metadata correction before finalizing
-- 🎧 Converts Lossless (WAV/AIFF/FLAC) files to MP3 (320kbps)
+- 🎧 Extracts audio from ZIP downloads, prefers lossless files, and converts them to the selected format
 - 🏷️ Tags MP3 files with metadata and artwork from SoundCloud
 - 🧹 Optional cleanup of the SoundCloud account (unfollow, unlike, delete comments/reposts)
 - 🧩 Userscript (Violentmonkey) that opens the Web UI in a floating panel next to SoundCloud store/buy links
@@ -18,6 +18,7 @@ Download and tag SoundCloud tracks unlocked via Hypeddit, Droploud, GateRush, Do
 
 - [**Bun**](https://bun.sh) - JavaScript runtime and package manager
 - [**ffmpeg**](https://ffmpeg.org) - Must be installed and available in your `PATH`
+- [**unzip**](https://infozip.sourceforge.net/UnZip.html) - Required when a gate provides its audio inside a ZIP archive
 - [**yt-dlp**](https://github.com/yt-dlp/yt-dlp) - Required for Bandcamp purchase/download links and for downloading a SoundCloud track directly when no gate is found. Bandcamp support requires the optional `curl_cffi` backend (`python-curl-cffi` on Arch Linux or `yt-dlp[default,curl-cffi]` with pip) for Chrome impersonation.
 - [**curl-impersonate**](https://github.com/lwthiker/curl-impersonate) (optional but recommended) - Chrome-TLS curl binary (`curl_chrome131`, `curl_chrome116`, or `curl-impersonate` on your `PATH`). Used for SoundCloud engagement writes (repost GraphQL / `me/track_reposts`) that DataDome often blocks when done with Bun's normal TLS. Without it the tool falls back to Bun `fetch`, which may get a 403. Pair with a residential proxy via `SC_API_PROXY`, `CLOAKBROWSER_PROXY`, or `PROXY_URL` when your IP is hard-blocked.
 - **SoundCloud account** - It is recommended to create a throwaway account for this. Even though there were no reports of accounts getting banned I can't guarantee it. Also most gate downloads require reposts/likes/follows which you might not want to do with your main account

--- a/src/archiveAudio.test.ts
+++ b/src/archiveAudio.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { lookpath } from 'find-bin';
+import {
+	hasZipSignature,
+	resolveDownloadedAudio,
+	selectArchiveAudioMember,
+} from './archiveAudio';
+
+describe('ZIP audio resolution', () => {
+	test('recognizes ZIP signatures instead of relying on the extension', () => {
+		expect(
+			hasZipSignature(new Uint8Array([0x50, 0x4b, 0x03, 0x04])),
+		).toBeTrue();
+		expect(
+			hasZipSignature(new Uint8Array([0x50, 0x4b, 0x05, 0x06])),
+		).toBeTrue();
+		expect(
+			hasZipSignature(new Uint8Array([0x49, 0x44, 0x33, 0x04])),
+		).toBeFalse();
+	});
+
+	test('prefers a lossless audio member over lossy alternatives', () => {
+		expect(
+			selectArchiveAudioMember([
+				'cover.jpg',
+				'Track.mp3',
+				'__MACOSX/._Track.flac',
+				'Track.flac',
+			]),
+		).toBe('Track.flac');
+	});
+
+	test('accepts supported lossy audio when no lossless member exists', () => {
+		expect(selectArchiveAudioMember(['notes.txt', 'audio/song.m4a'])).toBe(
+			'audio/song.m4a',
+		);
+	});
+
+	test('returns null when the archive has no supported audio', () => {
+		expect(selectArchiveAudioMember(['cover.png', 'README.txt'])).toBeNull();
+	});
+
+	test('extracts the preferred audio from an extensionless ZIP', async () => {
+		const zipBin = await lookpath('zip');
+		const unzipBin = await lookpath('unzip');
+		if (!zipBin || !unzipBin) return;
+
+		const directory = await mkdtemp(join(tmpdir(), 'sc-gate-dl-archive-test-'));
+		const sourceDirectory = join(directory, 'source');
+		try {
+			await mkdir(sourceDirectory);
+			await Bun.write(join(sourceDirectory, 'song.mp3'), 'lossy');
+			await Bun.write(join(sourceDirectory, 'song.flac'), 'lossless');
+			const archivePath = join(directory, 'download.bin');
+			const zip = Bun.spawnSync(
+				[zipBin, '-q', archivePath, 'song.mp3', 'song.flac'],
+				{ cwd: sourceDirectory },
+			);
+			expect(zip.exitCode).toBe(0);
+
+			const extracted = await resolveDownloadedAudio('download.bin', directory);
+			expect(extracted).toBe('song.flac');
+			expect(await Bun.file(join(directory, extracted)).text()).toBe(
+				'lossless',
+			);
+			expect(await Bun.file(archivePath).exists()).toBeFalse();
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	});
+
+	test('does not overwrite a ZIP named like its audio member', async () => {
+		const zipBin = await lookpath('zip');
+		const unzipBin = await lookpath('unzip');
+		if (!zipBin || !unzipBin) return;
+
+		const directory = await mkdtemp(join(tmpdir(), 'sc-gate-dl-archive-test-'));
+		const sourceDirectory = join(directory, 'source');
+		try {
+			await mkdir(sourceDirectory);
+			await Bun.write(join(sourceDirectory, 'track.flac'), 'lossless');
+			const archivePath = join(directory, 'track.flac');
+			const zip = Bun.spawnSync([zipBin, '-q', archivePath, 'track.flac'], {
+				cwd: sourceDirectory,
+			});
+			expect(zip.exitCode).toBe(0);
+
+			const extracted = await resolveDownloadedAudio('track.flac', directory);
+			expect(extracted).not.toBe('track.flac');
+			expect(await Bun.file(join(directory, extracted)).text()).toBe(
+				'lossless',
+			);
+			expect(await Bun.file(archivePath).exists()).toBeFalse();
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	});
+});

--- a/src/archiveAudio.ts
+++ b/src/archiveAudio.ts
@@ -1,0 +1,207 @@
+import { existsSync } from 'node:fs';
+import { unlink } from 'node:fs/promises';
+import { basename, extname, join } from 'node:path';
+import { lookpath } from 'find-bin';
+import { safeDownloadBasename } from './downloadCleanup';
+import {
+	pickUniqueDownloadFilename,
+	withDownloadRenameLock,
+} from './downloadRename';
+
+const MAX_EXTRACTED_AUDIO_BYTES = 512 * 1024 * 1024;
+const AUDIO_EXTENSION_PRIORITY = [
+	'.flac',
+	'.wav',
+	'.aiff',
+	'.aif',
+	'.ape',
+	'.wv',
+	'.alac',
+	'.mp3',
+	'.m4a',
+	'.aac',
+	'.ogg',
+	'.opus',
+	'.webm',
+] as const;
+
+/** ZIP signatures for regular, empty, and spanned archives. */
+export function hasZipSignature(bytes: Uint8Array): boolean {
+	return (
+		bytes.length >= 4 &&
+		bytes[0] === 0x50 &&
+		bytes[1] === 0x4b &&
+		((bytes[2] === 0x03 && bytes[3] === 0x04) ||
+			(bytes[2] === 0x05 && bytes[3] === 0x06) ||
+			(bytes[2] === 0x07 && bytes[3] === 0x08))
+	);
+}
+
+function audioPriority(member: string): number {
+	const extension = extname(member).toLowerCase();
+	return AUDIO_EXTENSION_PRIORITY.indexOf(
+		extension as (typeof AUDIO_EXTENSION_PRIORITY)[number],
+	);
+}
+
+/** Pick one audio payload, preferring known lossless formats. */
+export function selectArchiveAudioMember(members: string[]): string | null {
+	const candidates = members
+		.filter((member) => {
+			const parts = member.split(/[\\/]/);
+			const memberBase = parts.at(-1) ?? '';
+			return (
+				memberBase.length > 0 &&
+				!member.endsWith('/') &&
+				!parts.includes('__MACOSX') &&
+				!memberBase.startsWith('._')
+			);
+		})
+		.map((member) => ({ member, priority: audioPriority(member) }))
+		.filter((candidate) => candidate.priority >= 0)
+		.sort(
+			(a, b) =>
+				a.priority - b.priority ||
+				a.member.split(/[\\/]/).length - b.member.split(/[\\/]/).length ||
+				a.member.localeCompare(b.member),
+		);
+	return candidates[0]?.member ?? null;
+}
+
+function safeExtractedFilename(member: string): string {
+	const memberBase = basename(member.replace(/\\/g, '/'));
+	const withoutControlCharacters = [...memberBase]
+		.filter((character) => {
+			const code = character.charCodeAt(0);
+			return code > 31 && code !== 127;
+		})
+		.join('');
+	const cleaned = withoutControlCharacters
+		.replace(/[<>:"/\\|?*]/g, '')
+		.replace(/\s+/g, ' ')
+		.trim();
+	return cleaned || `extracted-audio${extname(member)}`;
+}
+
+async function runForText(bin: string, args: string[]): Promise<string> {
+	const process = Bun.spawn([bin, ...args], {
+		stdin: 'ignore',
+		stdout: 'pipe',
+		stderr: 'pipe',
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(process.stdout).text(),
+		new Response(process.stderr).text(),
+		process.exited,
+	]);
+	if (exitCode !== 0) {
+		throw new Error(stderr.trim() || `unzip exited with code ${exitCode}`);
+	}
+	return stdout;
+}
+
+async function allocateExtractedPath(
+	downloadsDir: string,
+	member: string,
+): Promise<string> {
+	return withDownloadRenameLock(async () => {
+		const allocationId = crypto.randomUUID();
+		const outputFilename = pickUniqueDownloadFilename({
+			desiredFilename: safeExtractedFilename(member),
+			// Extraction must never reuse the archive path, even when a ZIP is
+			// misleadingly named with the same extension as its audio member.
+			currentFilename: '',
+			jobId: allocationId,
+			exists: (name) => existsSync(join(downloadsDir, name)),
+			isOwnedByOtherJob: () => false,
+		});
+		const outputPath = join(downloadsDir, outputFilename);
+		await Bun.write(outputPath, new Uint8Array());
+		return outputPath;
+	});
+}
+
+async function extractMember(
+	unzipBin: string,
+	archivePath: string,
+	member: string,
+	outputPath: string,
+): Promise<void> {
+	const process = Bun.spawn([unzipBin, '-p', archivePath, member], {
+		stdin: 'ignore',
+		stdout: 'pipe',
+		stderr: 'pipe',
+	});
+	const stderrPromise = new Response(process.stderr).text();
+	const writer = Bun.file(outputPath).writer();
+	let extractedBytes = 0;
+	try {
+		for await (const chunk of process.stdout) {
+			extractedBytes += chunk.byteLength;
+			if (extractedBytes > MAX_EXTRACTED_AUDIO_BYTES) {
+				process.kill();
+				throw new Error(
+					`Audio file in ZIP is too large (max ${MAX_EXTRACTED_AUDIO_BYTES} bytes)`,
+				);
+			}
+			writer.write(chunk);
+		}
+		await writer.end();
+		const stderr = await stderrPromise;
+		const exitCode = await process.exited;
+		if (exitCode !== 0) {
+			throw new Error(stderr.trim() || `unzip exited with code ${exitCode}`);
+		}
+		if (extractedBytes === 0) {
+			throw new Error('Selected audio file in ZIP is empty');
+		}
+	} catch (error) {
+		process.kill();
+		try {
+			await writer.end();
+		} catch {
+			// Ignore a second close after extraction failure.
+		}
+		await Promise.allSettled([process.exited, stderrPromise]);
+		await unlink(outputPath).catch(() => {});
+		throw error;
+	}
+}
+
+/**
+ * Return the original filename for normal downloads. For a ZIP, extract the
+ * best audio member and remove the archive only after extraction succeeds.
+ */
+export async function resolveDownloadedAudio(
+	filename: string,
+	downloadsDir = './downloads',
+): Promise<string> {
+	const archiveFilename = safeDownloadBasename(filename);
+	if (!archiveFilename) throw new Error('Downloaded filename is unsafe');
+	const archivePath = join(downloadsDir, archiveFilename);
+	const signature = new Uint8Array(
+		await Bun.file(archivePath).slice(0, 4).arrayBuffer(),
+	);
+	if (!hasZipSignature(signature)) return archiveFilename;
+
+	const unzipBin = await lookpath('unzip');
+	if (!unzipBin) {
+		throw new Error(
+			'The downloaded file is a ZIP, but unzip is not installed or not in PATH.',
+		);
+	}
+
+	const listing = await runForText(unzipBin, ['-Z1', archivePath]);
+	const member = selectArchiveAudioMember(listing.split(/\r?\n/));
+	if (!member) {
+		throw new Error(
+			'The downloaded ZIP does not contain a supported audio file',
+		);
+	}
+
+	const outputPath = await allocateExtractedPath(downloadsDir, member);
+	await extractMember(unzipBin, archivePath, member, outputPath);
+	await unlink(archivePath);
+	console.log(`Extracted ${member} from ${archiveFilename}`);
+	return basename(outputPath);
+}

--- a/src/archiveAudio.ts
+++ b/src/archiveAudio.ts
@@ -1,5 +1,4 @@
 import { existsSync } from 'node:fs';
-import { unlink } from 'node:fs/promises';
 import { basename, extname, join } from 'node:path';
 import { lookpath } from 'find-bin';
 import { safeDownloadBasename } from './downloadCleanup';
@@ -163,7 +162,9 @@ async function extractMember(
 			// Ignore a second close after extraction failure.
 		}
 		await Promise.allSettled([process.exited, stderrPromise]);
-		await unlink(outputPath).catch(() => {});
+		await Bun.file(outputPath)
+			.delete()
+			.catch(() => {});
 		throw error;
 	}
 }
@@ -201,7 +202,7 @@ export async function resolveDownloadedAudio(
 
 	const outputPath = await allocateExtractedPath(downloadsDir, member);
 	await extractMember(unzipBin, archivePath, member, outputPath);
-	await unlink(archivePath);
+	await Bun.file(archivePath).delete();
 	console.log(`Extracted ${member} from ${archiveFilename}`);
 	return basename(outputPath);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { confirm, input, select } from '@inquirer/prompts';
+import { resolveDownloadedAudio } from './archiveAudio';
 import { AudioProcessor } from './audioProcessor';
 import { loadConfig, saveConfig } from './config';
 import { DirectDownloader } from './directDownload';
@@ -321,6 +322,7 @@ try {
 	}
 
 	if (downloadFilename) {
+		downloadFilename = await resolveDownloadedAudio(downloadFilename);
 		const artworkUrl = soundcloudClient.getArtworkUrl(track);
 		const artwork = await soundcloudClient.fetchArtwork(artworkUrl);
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import { cp, mkdir, rm } from 'node:fs/promises';
 import { basename, extname, join } from 'node:path';
 import type { SoundcloudTrack } from 'soundcloud.ts';
+import { hasZipSignature, resolveDownloadedAudio } from './archiveAudio';
 import { AudioProcessor } from './audioProcessor';
 import { isXvfbSupported } from './browserLaunch';
 import { attachmentContentDisposition } from './contentDisposition';
@@ -601,6 +602,21 @@ async function runDownloadProcess(jobId: string): Promise<void> {
 		}
 
 		jobStore.update(jobId, { downloadFilename });
+		const downloadedPath = join('./downloads', downloadFilename);
+		const signature = new Uint8Array(
+			await Bun.file(downloadedPath).slice(0, 4).arrayBuffer(),
+		);
+		if (hasZipSignature(signature)) {
+			jobStore.updateProgress(
+				jobId,
+				'processing_audio',
+				'Extracting audio from ZIP...',
+				85,
+			);
+		}
+		downloadFilename = await resolveDownloadedAudio(downloadFilename);
+		jobStore.update(jobId, { downloadFilename });
+		throwIfCancelled();
 		if (job.outputFormat === 'flac') {
 			const sourceIsLossless = await audioProcessor.isLosslessAudio(
 				join('./downloads', downloadFilename),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -859,7 +859,15 @@ export function getDefaultMetadata(track: SoundcloudTrack): Metadata {
 	};
 }
 
-const LOSSLESS_EXTENSIONS = ['.wav', '.aiff', '.aif', '.flac'] as const;
+const LOSSLESS_EXTENSIONS = [
+	'.wav',
+	'.aiff',
+	'.aif',
+	'.flac',
+	'.ape',
+	'.wv',
+	'.alac',
+] as const;
 /** Lossy containers we still re-encode to MP3 (bitrate chosen from the source). */
 const LOSSY_TO_MP3_EXTENSIONS = [
 	'.m4a',


### PR DESCRIPTION
Gate downloads can return ZIP archives containing the actual audio. The existing pipeline treated the archive itself as audio, so metadata editing appeared to work while the final MP3 download still returned the ZIP.

This change detects ZIP content by signature, selects and safely extracts a supported audio member with lossless formats preferred, then feeds that file through the existing original, metadata, and conversion pipeline in both the Web UI server and CLI. Extraction is size-limited, collision-safe, ignores macOS metadata entries, and only removes the archive after success. It also documents the conditional unzip prerequisite and expands recognized lossless formats.

Validation:
- bun test src/archiveAudio.test.ts src/utils.test.ts (45 passed)
- bun run lint
- git diff --check

The full test suite passes 157 tests; one unrelated existing GateRush cancellation test fails in unchanged code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for audio downloads provided as ZIP archives.
  * Automatically extracts the preferred lossless audio file, with fallback to supported lossy formats.
  * Shows extraction progress and safely handles unsupported, empty, or oversized archives.
  * Added support for APE, WV, and ALAC lossless audio formats.
* **Bug Fixes**
  * Prevented archive and extracted audio filenames from overwriting each other.
  * Improved cleanup when extraction fails.
* **Documentation**
  * Documented ZIP audio handling and the required `unzip` prerequisite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->